### PR TITLE
refactor(dataset): clarify create flow and improve write-session safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
 name = "fricon"
 version = "0.1.0-alpha.1"
 dependencies = [
@@ -1455,6 +1467,7 @@ dependencies = [
  "itertools",
  "libsqlite3-sys",
  "memmap2",
+ "mockall",
  "num",
  "prost",
  "prost-types",
@@ -2771,6 +2784,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,6 +3617,32 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -4986,6 +5052,12 @@ dependencies = [
  "mac",
  "utf-8",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 tracing-appender = "0.2.4"
 uuid = "1.19.0"
+mockall = "0.12.1"
 
 [workspace.lints.rust]
 rust-2018-idioms = "warn"

--- a/crates/fricon/Cargo.toml
+++ b/crates/fricon/Cargo.toml
@@ -54,5 +54,8 @@ indexmap = { workspace = true }
 [build-dependencies]
 tonic-prost-build = { workspace = true }
 
+[dev-dependencies]
+mockall = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/fricon/src/dataset_manager/write_registry.rs
+++ b/crates/fricon/src/dataset_manager/write_registry.rs
@@ -16,33 +16,62 @@ pub struct WriteSessionRegistry {
     inner: Arc<RwLock<HashMap<i32, WriteSessionHandle>>>,
 }
 
+pub struct WriteSessionGuard {
+    id: i32,
+    registry: WriteSessionRegistry,
+    session: Option<WriteSession>,
+}
+
+impl WriteSessionGuard {
+    pub fn session_mut(&mut self) -> &mut WriteSession {
+        self.session.as_mut().expect("Write session missing")
+    }
+
+    pub fn write(&mut self, batch: arrow_array::RecordBatch) -> Result<(), Error> {
+        self.session_mut().write(batch)
+    }
+
+    pub fn commit(mut self) -> Result<(), Error> {
+        if let Some(session) = self.session.take() {
+            session.finish()?;
+        }
+        Ok(())
+    }
+
+    pub fn abort(mut self) -> Result<(), Error> {
+        if let Some(session) = self.session.take() {
+            session.abort()?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WriteSessionGuard {
+    fn drop(&mut self) {
+        if let Some(session) = self.session.take() {
+            let _ = session.abort();
+        }
+        self.registry.remove(self.id);
+    }
+}
+
 impl WriteSessionRegistry {
     pub fn new() -> Self {
         Self::default()
     }
-    pub fn with_session<R>(
-        &self,
-        id: i32,
-        path: PathBuf,
-        schema: SchemaRef,
-        f: impl FnOnce(&mut WriteSession) -> Result<R, Error>,
-    ) -> Result<R, Error> {
-        struct Guard(i32, WriteSessionRegistry);
-        impl Drop for Guard {
-            fn drop(&mut self) {
-                self.1.remove(self.0);
-            }
-        }
 
-        let mut session = WriteSession::new(schema, path);
+    pub fn start_session(&self, id: i32, path: PathBuf, schema: SchemaRef) -> WriteSessionGuard {
+        let session = WriteSession::new(schema, path);
         if let Ok(mut m) = self.inner.write() {
             m.insert(id, session.handle());
         }
-        let _guard = Guard(id, self.clone());
-        let result = f(&mut session)?;
-        session.finish()?;
-        Ok(result)
+        WriteSessionGuard {
+            id,
+            registry: self.clone(),
+            session: Some(session),
+        }
     }
+
     pub fn get(&self, id: i32) -> Option<WriteSessionHandle> {
         self.inner.read().ok().and_then(|m| m.get(&id).cloned())
     }

--- a/crates/fricon/src/server.rs
+++ b/crates/fricon/src/server.rs
@@ -1,3 +1,4 @@
+mod create_stream;
 mod dataset;
 mod fricon;
 

--- a/crates/fricon/src/server/create_stream.rs
+++ b/crates/fricon/src/server/create_stream.rs
@@ -1,0 +1,121 @@
+use std::io::{Error as IoError, ErrorKind};
+
+use arrow_array::RecordBatchReader;
+use arrow_ipc::reader::StreamReader;
+use futures::{StreamExt, stream};
+use tokio_util::{
+    io::{StreamReader as TokioStreamReader, SyncIoBridge},
+    sync::CancellationToken,
+};
+use tonic::{Status, Streaming};
+use tracing::{error, warn};
+
+use crate::{
+    dataset_manager::{CreateDatasetRequest, Error},
+    proto::{CreateAbort, CreateMetadata, CreateRequest, create_request::CreateMessage},
+};
+
+pub type BatchReader = Box<dyn RecordBatchReader + Send>;
+pub type CreateBatchReader = Box<dyn FnOnce() -> Result<BatchReader, Error> + Send>;
+
+pub struct CreateStreamParts {
+    pub request: CreateDatasetRequest,
+    pub reader: CreateBatchReader,
+}
+
+pub async fn parse_create_stream(
+    mut stream: Streaming<CreateRequest>,
+    shutdown_token: CancellationToken,
+) -> Result<CreateStreamParts, Status> {
+    let first_message = stream
+        .next()
+        .await
+        .ok_or_else(|| Status::invalid_argument("request stream is empty"))?
+        .map_err(|e| {
+            error!("Failed to read first message: {:?}", e);
+            Status::internal("failed to read first message")
+        })?;
+    let Some(CreateMessage::Metadata(CreateMetadata {
+        name,
+        description,
+        tags,
+    })) = first_message.create_message
+    else {
+        error!("First message must be CreateMetadata");
+        return Err(Status::invalid_argument(
+            "first message must be CreateMetadata",
+        ));
+    };
+
+    let bytes_stream = stream.map(|request| {
+        let request = request.map_err(|e| {
+            error!("Client connection error: {e:?}");
+            IoError::other(e)
+        })?;
+        match request.create_message {
+            Some(CreateMessage::Payload(data)) => Ok(data),
+            Some(CreateMessage::Metadata(_)) => {
+                error!("Unexpected CreateMetadata message after the first message");
+                Err(IoError::new(
+                    ErrorKind::InvalidInput,
+                    "unexpected CreateMetadata message after the first message",
+                ))
+            }
+            Some(CreateMessage::Abort(CreateAbort { reason })) => {
+                warn!("Client aborted the upload: {}", reason);
+                Err(IoError::new(
+                    ErrorKind::UnexpectedEof,
+                    format!("client aborted the upload: {reason}"),
+                ))
+            }
+            None => {
+                error!("Empty CreateRequest message");
+                Err(IoError::new(
+                    ErrorKind::InvalidInput,
+                    "empty CreateRequest message",
+                ))
+            }
+        }
+    });
+
+    let abortable_stream = stream::unfold(
+        (bytes_stream, shutdown_token, false),
+        |(mut stream, token, cancelled)| async move {
+            if cancelled {
+                return None;
+            }
+
+            tokio::select! {
+                item = stream.next() => {
+                    item.map(|item| (item, (stream, token, false)))
+                }
+                () = token.cancelled() => {
+                    Some((
+                        Err(IoError::other(
+                            "Stream aborted because server is shutting down.")),
+                        (stream, token, true),
+                    ))
+                }
+            }
+        },
+    )
+    .boxed();
+
+    let reader: CreateBatchReader = Box::new(move || {
+        let sync_reader = SyncIoBridge::new(TokioStreamReader::new(abortable_stream));
+        StreamReader::try_new(sync_reader, None)
+            .map(|reader| Box::new(reader) as BatchReader)
+            .map_err(|e| Error::BatchStream {
+                message: e.to_string(),
+            })
+    });
+
+    Ok(CreateStreamParts {
+        request: CreateDatasetRequest {
+            name,
+            description,
+            tags,
+        },
+        reader,
+    })
+}


### PR DESCRIPTION
- Make dataset create linear (start session -> write -> commit/abort -> status)
- Preserve aborted dataset data for partial reads
- Add explicit WriteSessionGuard lifecycle + abort semantics
- Extract tonic create-stream adapter with shutdown cancellation
- Reduce read/write contention via snapshot reads from write sessions
- Improve testability with injected deps + mockall-backed unit tests

Tests: cargo test -p fricon