### PR TITLE
feat(fricon-ui): prefer trailing index columns for chart defaults

### DIFF
--- a/crates/fricon-ui/frontend/src/components/chart-viewer.test.tsx
+++ b/crates/fricon-ui/frontend/src/components/chart-viewer.test.tsx
@@ -147,6 +147,112 @@ describe("ChartViewer", () => {
     clearMocks();
   });
 
+  it("uses trailing Y default for trace heatmap without X axis", async () => {
+    const chartPayloads: Record<string, unknown>[] = [];
+    mockIPC((cmd, payload) => {
+      if (cmd === "dataset_detail") {
+        return {
+          id: 1,
+          name: "Dataset 1",
+          description: "Test dataset",
+          favorite: false,
+          tags: [],
+          status: "Completed",
+          createdAt: new Date().toISOString(),
+          columns: [
+            { name: "idxA", isComplex: false, isTrace: false, isIndex: true },
+            { name: "idxB", isComplex: false, isTrace: false, isIndex: true },
+            {
+              name: "trace_signal",
+              isComplex: false,
+              isTrace: true,
+              isIndex: false,
+            },
+          ],
+        };
+      }
+      if (cmd === "get_filter_table_data") {
+        return {
+          fields: ["idxA", "idxB"],
+          rows: [
+            { index: 1, displayValues: ["1", "10"], valueIndices: [1, 1] },
+          ],
+          columnUniqueValues: {
+            idxA: [{ index: 1, displayValue: "1" }],
+            idxB: [{ index: 1, displayValue: "10" }],
+          },
+        };
+      }
+      if (cmd === "dataset_chart_data") {
+        if (payload && typeof payload === "object") {
+          chartPayloads.push(payload as Record<string, unknown>);
+        }
+        return {
+          type: "heatmap",
+          xName: "trace index",
+          yName: "idxB",
+          xCategories: [0, 1],
+          yCategories: [10],
+          series: [
+            {
+              name: "trace_signal",
+              data: [
+                [0, 0, 1],
+                [1, 0, 2],
+              ],
+            },
+          ],
+        };
+      }
+      if (cmd === "get_dataset_write_status") {
+        return { rowCount: 0, isComplete: true };
+      }
+      return null;
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          refetchOnWindowFocus: false,
+        },
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChartViewer datasetId={1} />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByTestId("chart");
+
+    const chartTypeLabel = await screen.findByText("Chart Type");
+    const chartTypeTrigger = chartTypeLabel
+      .closest("div")
+      ?.querySelector('[data-slot="select-trigger"]');
+    if (!(chartTypeTrigger instanceof HTMLElement)) {
+      throw new Error("Chart type trigger not found");
+    }
+    await user.click(chartTypeTrigger);
+    await user.click(await screen.findByText("heatmap"));
+
+    await waitFor(() => {
+      const lastPayload = chartPayloads.at(-1);
+      const options = lastPayload?.options as {
+        chartType: string;
+        xColumn?: string | null;
+        yColumn?: string;
+      };
+      expect(options.chartType).toBe("heatmap");
+      expect(options.xColumn).toBeNull();
+      expect(options.yColumn).toBe("idxB");
+    });
+
+    clearMocks();
+  });
+
   it("fetches chart data once per meaningful change", async () => {
     let chartCallCount = 0;
     mockIPC((cmd) => {
@@ -349,7 +455,13 @@ describe("ChartViewer", () => {
     }
     await user.click(excludeTrigger);
     const idxBChoices = await screen.findAllByText("idxB");
-    await user.click(idxBChoices[idxBChoices.length - 1]);
+    const idxBOption = idxBChoices.find((choice) =>
+      choice.closest('[role="option"]'),
+    );
+    if (!(idxBOption instanceof HTMLElement)) {
+      throw new Error("idxB option not found");
+    }
+    await user.click(idxBOption);
 
     await waitFor(() => {
       const lastPayload = chartPayloads.at(-1);

--- a/crates/fricon-ui/frontend/src/components/chart-viewer.tsx
+++ b/crates/fricon-ui/frontend/src/components/chart-viewer.tsx
@@ -98,6 +98,10 @@ export function ChartViewer({ datasetId }: ChartViewerProps) {
     ? []
     : columns.filter((column) => column.isIndex);
   const yColumnOptions = columns.filter((column) => column.isIndex);
+  const defaultYColumnIndex =
+    xColumnOptions.length > 0
+      ? yColumnOptions.length - 2
+      : yColumnOptions.length - 1;
   const effectiveXColumnName = pickSelection(
     xColumnOptions,
     xColumnName,
@@ -106,7 +110,7 @@ export function ChartViewer({ datasetId }: ChartViewerProps) {
   const effectiveYColumnName = pickSelection(
     yColumnOptions,
     yColumnName,
-    yColumnOptions.length - 2,
+    defaultYColumnIndex,
   );
   const xColumn = columns.find(
     (column) => column.name === effectiveXColumnName,


### PR DESCRIPTION
## Summary
- default chart index-column selection now prefers trailing index columns (most frequent)
- for heatmap, keep `y` default as the next trailing index to avoid duplicating `x`
- scatter index exclusion default now also prefers trailing index columns
- updated chart viewer test expectation for the new default behavior

## Testing
- pnpm --filter fricon-ui run test --run src/components/chart-viewer.test.tsx
