### PR TITLE
refactor(ui): simplify dataset table React Compiler integration

### DIFF
--- a/crates/fricon-ui/frontend/src/components/use-dataset-table-data.test.ts
+++ b/crates/fricon-ui/frontend/src/components/use-dataset-table-data.test.ts
@@ -221,6 +221,52 @@ describe("useDatasetTableData", () => {
     });
   });
 
+  it("does not reset visibleCount on the initial debounce window", async () => {
+    listDatasetsMock
+      .mockResolvedValueOnce([
+        makeDataset({ id: 1 }),
+        makeDataset({ id: 2 }),
+        makeDataset({ id: 3 }),
+      ])
+      .mockResolvedValueOnce([
+        makeDataset({ id: 1 }),
+        makeDataset({ id: 2 }),
+        makeDataset({ id: 3 }),
+        makeDataset({ id: 4 }),
+      ]);
+
+    const { result } = renderHook(() => useDatasetTableData(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.loadNextPage();
+    });
+
+    await waitFor(() => {
+      expect(listDatasetsMock).toHaveBeenNthCalledWith(2, {
+        search: "",
+        tags: [],
+        favoriteOnly: false,
+        statuses: [],
+        sortBy: "id",
+        sortDir: "desc",
+        limit: 6,
+        offset: 0,
+      });
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 350));
+    });
+
+    expect(listDatasetsMock).toHaveBeenCalledTimes(2);
+  });
+
   it("resets the query limit when debounced filters change", async () => {
     listDatasetsMock
       .mockResolvedValueOnce([

--- a/crates/fricon-ui/frontend/src/components/use-dataset-table-data.ts
+++ b/crates/fricon-ui/frontend/src/components/use-dataset-table-data.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import {
   keepPreviousData,
   useMutation,
@@ -66,6 +66,31 @@ function buildDatasetListOptions(
   };
 }
 
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function areSortingStatesEqual(a: SortingState, b: SortingState): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((entry, index) => {
+    const other = b[index];
+    return entry.id === other?.id && entry.desc === other?.desc;
+  });
+}
+
+function areDatasetQueryParamsEqual(
+  a: DatasetQueryParams,
+  b: DatasetQueryParams,
+): boolean {
+  return (
+    a.search === b.search &&
+    a.favoriteOnly === b.favoriteOnly &&
+    areStringArraysEqual(a.tags, b.tags) &&
+    areStringArraysEqual(a.statuses, b.statuses) &&
+    areSortingStatesEqual(a.sorting, b.sorting)
+  );
+}
+
 interface UseDatasetTableDataResult {
   datasets: DatasetInfo[];
   searchQuery: string;
@@ -131,17 +156,28 @@ function useDatasetTableFilters(): DatasetTableFiltersResult {
       statuses: selectedStatuses,
       sorting: sortingState,
     }));
+  const latestDebouncedQueryParamsRef = useRef(debouncedQueryParams);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      setDebouncedQueryParams({
+      const nextDebouncedQueryParams = {
         search: searchQuery,
         tags: selectedTags,
         favoriteOnly,
         statuses: selectedStatuses,
         sorting: sortingState,
-      });
-      setVisibleCount(DATASET_PAGE_SIZE);
+      };
+      const didQueryParamsChange = !areDatasetQueryParamsEqual(
+        latestDebouncedQueryParamsRef.current,
+        nextDebouncedQueryParams,
+      );
+
+      setDebouncedQueryParams(nextDebouncedQueryParams);
+      latestDebouncedQueryParamsRef.current = nextDebouncedQueryParams;
+
+      if (didQueryParamsChange) {
+        setVisibleCount(DATASET_PAGE_SIZE);
+      }
     }, 300);
     return () => {
       window.clearTimeout(timer);


### PR DESCRIPTION
## Summary
- simplify dataset table query state around React Compiler-friendly patterns
- rely on compiler-generated memoization instead of manual useMemo/useCallback in the hook
- reset dataset table pagination when debounced filters change and cover it with a regression test

## Validation
- pnpm run format:check
- pnpm run type-check
- pnpm run lint
- pnpm run test --run

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
