### PR TITLE
feat(ui): bring up running GUI for opened workspace

### DIFF
--- a/crates/fricon-ui/src/desktop_runtime/event_forwarder.rs
+++ b/crates/fricon-ui/src/desktop_runtime/event_forwarder.rs
@@ -7,6 +7,7 @@ use tracing::{error, warn};
 use crate::{
     api::datasets::{DatasetCreated, DatasetInfo, DatasetUpdated},
     application::session::WorkspaceSession,
+    desktop_runtime::runtime::show_main_window,
 };
 
 pub(crate) fn start_event_forwarder(session: &WorkspaceSession, app_handle: tauri::AppHandle) {
@@ -86,6 +87,9 @@ pub(crate) fn start_event_forwarder(session: &WorkspaceSession, app_handle: taur
                             "Failed to emit DatasetUpdated event"
                         );
                     }
+                }
+                AppEvent::ShowUiRequest => {
+                    show_main_window(&app_handle);
                 }
             }
         }

--- a/crates/fricon-ui/src/desktop_runtime/runtime.rs
+++ b/crates/fricon-ui/src/desktop_runtime/runtime.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result, bail};
+use fricon::ExistingUiProbeResult;
 use rfd::{MessageButtons, MessageDialog, MessageLevel};
 use tauri::{
     Manager, RunEvent, WindowEvent, async_runtime,
@@ -28,13 +29,18 @@ use crate::{
 pub(crate) fn run_with_context_terminal_mode(context: &LaunchContext) -> Result<()> {
     let workspace_path =
         resolve_workspace_path(context)?.ok_or(WorkspaceLaunchError::WorkspacePathMissing)?;
-    let (_log_session, app_state) = build_workspace_runtime(workspace_path)?;
-    run_with_app_state(app_state)
+    match prepare_workspace_runtime(&workspace_path)? {
+        WorkspaceLaunchOutcome::Delegated => Ok(()),
+        WorkspaceLaunchOutcome::Start {
+            log_session: _log_session,
+            app_state,
+        } => run_with_app_state(app_state),
+    }
 }
 
 pub(crate) fn run_with_context_dialog_mode(context: &LaunchContext) -> Result<()> {
     let mut next_workspace = resolve_workspace_path(context)?;
-    let (_log_session, app_state) = loop {
+    loop {
         let workspace_path = match next_workspace.take() {
             Some(path) => path,
             None => match select_workspace_path(&context.launch_source)? {
@@ -43,8 +49,12 @@ pub(crate) fn run_with_context_dialog_mode(context: &LaunchContext) -> Result<()
             },
         };
 
-        match build_workspace_runtime(workspace_path) {
-            Ok(run_inputs) => break run_inputs,
+        match prepare_workspace_runtime(&workspace_path) {
+            Ok(WorkspaceLaunchOutcome::Delegated) => return Ok(()),
+            Ok(WorkspaceLaunchOutcome::Start {
+                log_session: _log_session,
+                app_state,
+            }) => return run_with_app_state(app_state),
             Err(err) => {
                 MessageDialog::new()
                     .set_level(MessageLevel::Error)
@@ -54,15 +64,69 @@ pub(crate) fn run_with_context_dialog_mode(context: &LaunchContext) -> Result<()
                     .show();
             }
         }
-    };
-
-    run_with_app_state(app_state)
+    }
 }
 
-fn build_workspace_runtime(workspace_path: PathBuf) -> Result<(WorkspaceLogSession, AppState)> {
-    let log_session = attach_workspace_file_logging(&workspace_path)
-        .context("Failed to initialize workspace logging")?;
-    let app_state = AppState::new(workspace_path).context("Failed to open workspace")?;
+#[derive(Debug)]
+enum WorkspaceLaunchOutcome<LogSession = WorkspaceLogSession, State = AppState> {
+    Delegated,
+    Start {
+        log_session: LogSession,
+        app_state: State,
+    },
+}
+
+fn prepare_workspace_runtime(workspace_path: &Path) -> Result<WorkspaceLaunchOutcome> {
+    let probe_result =
+        tauri::async_runtime::block_on(fricon::Client::probe_existing_ui(workspace_path))?;
+    prepare_workspace_runtime_from_probe(probe_result, || {
+        build_new_workspace_runtime(workspace_path)
+    })
+}
+
+fn prepare_workspace_runtime_from_probe<LogSession, State, BuildRuntime>(
+    probe_result: ExistingUiProbeResult,
+    build_runtime: BuildRuntime,
+) -> Result<WorkspaceLaunchOutcome<LogSession, State>>
+where
+    BuildRuntime: FnOnce() -> Result<(LogSession, State)>,
+{
+    match probe_result {
+        ExistingUiProbeResult::UiShown => Ok(WorkspaceLaunchOutcome::Delegated),
+        ExistingUiProbeResult::UiUnavailable => {
+            bail!("workspace is already served by another process without a desktop UI attached")
+        }
+        ExistingUiProbeResult::NotRunning => {
+            let (log_session, app_state) = build_runtime()?;
+            Ok(WorkspaceLaunchOutcome::Start {
+                log_session,
+                app_state,
+            })
+        }
+    }
+}
+
+fn build_new_workspace_runtime(workspace_path: &Path) -> Result<(WorkspaceLogSession, AppState)> {
+    build_new_workspace_runtime_with(
+        workspace_path,
+        |path| {
+            attach_workspace_file_logging(path).context("Failed to initialize workspace logging")
+        },
+        |path| AppState::new(path).context("Failed to open workspace"),
+    )
+}
+
+fn build_new_workspace_runtime_with<LogSession, State, AttachLogging, BuildState>(
+    workspace_path: &Path,
+    attach_logging: AttachLogging,
+    build_state: BuildState,
+) -> Result<(LogSession, State)>
+where
+    AttachLogging: FnOnce(&Path) -> Result<LogSession>,
+    BuildState: FnOnce(PathBuf) -> Result<State>,
+{
+    let log_session = attach_logging(workspace_path)?;
+    let app_state = build_state(workspace_path.to_path_buf())?;
     Ok((log_session, app_state))
 }
 
@@ -121,7 +185,7 @@ fn run_with_app_state(app_state: AppState) -> Result<()> {
     Ok(())
 }
 
-fn show_main_window(app: &tauri::AppHandle) {
+pub(crate) fn show_main_window(app: &tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("main") {
         let _ = w.unminimize();
         let _ = w.show();
@@ -171,4 +235,77 @@ fn install_ctrl_c_handler(app: &mut tauri::App) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use super::*;
+
+    #[test]
+    fn prepare_workspace_runtime_from_probe_delegates_without_building() {
+        let built = AtomicBool::new(false);
+
+        let outcome = prepare_workspace_runtime_from_probe(ExistingUiProbeResult::UiShown, || {
+            built.store(true, Ordering::SeqCst);
+            Ok::<_, anyhow::Error>(("log", "state"))
+        })
+        .expect("delegation should succeed");
+
+        assert!(matches!(outcome, WorkspaceLaunchOutcome::Delegated));
+        assert!(!built.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn prepare_workspace_runtime_from_probe_errors_for_non_ui_server() {
+        let built = AtomicBool::new(false);
+
+        let error =
+            prepare_workspace_runtime_from_probe(ExistingUiProbeResult::UiUnavailable, || {
+                built.store(true, Ordering::SeqCst);
+                Ok::<_, anyhow::Error>(("log", "state"))
+            })
+            .expect_err("non-UI server should block desktop startup");
+
+        assert!(error.to_string().contains("without a desktop UI attached"));
+        assert!(!built.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn build_new_workspace_runtime_with_attaches_logging_before_app_state() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let workspace_path = Path::new("/tmp/fricon-workspace");
+
+        let (log_session, app_state) = build_new_workspace_runtime_with(
+            workspace_path,
+            {
+                let order = Arc::clone(&order);
+                move |path| {
+                    order.lock().expect("order lock").push("attach_logging");
+                    assert_eq!(path, workspace_path);
+                    Ok::<_, anyhow::Error>("log")
+                }
+            },
+            {
+                let order = Arc::clone(&order);
+                move |path| {
+                    order.lock().expect("order lock").push("build_state");
+                    assert_eq!(path, workspace_path.to_path_buf());
+                    Ok::<_, anyhow::Error>("state")
+                }
+            },
+        )
+        .expect("runtime should build");
+
+        assert_eq!(log_session, "log");
+        assert_eq!(app_state, "state");
+        assert_eq!(
+            *order.lock().expect("order lock"),
+            vec!["attach_logging", "build_state"]
+        );
+    }
 }

--- a/crates/fricon/proto/fricon/v1alpha/fricon.proto
+++ b/crates/fricon/proto/fricon/v1alpha/fricon.proto
@@ -7,6 +7,11 @@ service FriconService {
    * Get the version of the Fricon service.
    */
   rpc Version(VersionRequest) returns (VersionResponse) {}
+
+  /*
+   * Tell the UI to bring its window to the front.
+   */
+  rpc ShowUi(ShowUiRequest) returns (ShowUiResponse) {}
 }
 
 message VersionRequest {}
@@ -14,3 +19,7 @@ message VersionRequest {}
 message VersionResponse {
   string version = 1;
 }
+
+message ShowUiRequest {}
+
+message ShowUiResponse {}

--- a/crates/fricon/src/app.rs
+++ b/crates/fricon/src/app.rs
@@ -27,6 +27,8 @@ use crate::{
 pub enum AppError {
     #[error("AppState has been dropped")]
     StateDropped,
+    #[error("App event was not delivered to any subscribers")]
+    EventUndelivered,
 }
 
 pub struct AppState {
@@ -116,6 +118,13 @@ impl AppHandle {
 
     pub fn subscribe_to_events(&self) -> Result<broadcast::Receiver<AppEvent>, AppError> {
         Ok(self.state()?.event_sender.subscribe())
+    }
+
+    pub fn send_event(&self, event: AppEvent) -> Result<usize, AppError> {
+        self.state()?
+            .event_sender
+            .send(event)
+            .map_err(|_| AppError::EventUndelivered)
     }
 
     #[must_use]

--- a/crates/fricon/src/app/server.rs
+++ b/crates/fricon/src/app/server.rs
@@ -32,11 +32,14 @@ pub(crate) fn start(
     let listener = ipc::listen(ipc_file, runtime)?;
 
     info!("Starting gRPC server");
+    let app_for_fricon = app.clone();
     task_tracker.spawn_on(
         async move {
             let result = Server::builder()
                 .add_service(service)
-                .add_service(FriconServiceServer::new(Fricon))
+                .add_service(FriconServiceServer::new(Fricon {
+                    app: app_for_fricon,
+                }))
                 .serve_with_incoming_shutdown(listener, async {
                     cancellation_token.cancelled().await;
                     info!("Received shutdown signal");

--- a/crates/fricon/src/client.rs
+++ b/crates/fricon/src/client.rs
@@ -15,7 +15,7 @@ use futures::prelude::*;
 use hyper_util::rt::TokioIo;
 use semver::Version;
 use tokio::{sync::mpsc, task::JoinHandle};
-use tonic::{Request, transport::Channel};
+use tonic::{Code, Request, transport::Channel};
 use tower::service_fn;
 use tracing::{debug, error, info, instrument, warn};
 use uuid::Uuid;
@@ -32,11 +32,18 @@ use crate::{
         create_request::CreateMessage, dataset_service_client::DatasetServiceClient,
         fricon_service_client::FriconServiceClient, get_request::IdEnum,
     },
-    transport::ipc,
+    transport::{ipc, ipc::error::ConnectError},
     workspace::{WorkspacePaths, WorkspaceRoot},
 };
 
 const MAX_PAYLOAD_CHUNK_SIZE: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistingUiProbeResult {
+    NotRunning,
+    UiShown,
+    UiUnavailable,
+}
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -45,6 +52,21 @@ pub struct Client {
 }
 
 impl Client {
+    #[instrument(skip(path), fields(workspace.path = ?path.as_ref()))]
+    pub async fn probe_existing_ui(path: impl AsRef<Path>) -> Result<ExistingUiProbeResult> {
+        match Self::connect(path).await {
+            Ok(client) => match client.show_ui().await {
+                Ok(()) => Ok(ExistingUiProbeResult::UiShown),
+                Err(err) if show_ui_requires_desktop_ui(&err) => {
+                    Ok(ExistingUiProbeResult::UiUnavailable)
+                }
+                Err(err) => Err(err.context("Failed to delegate launch to existing workspace UI")),
+            },
+            Err(err) if connect_target_missing(&err) => Ok(ExistingUiProbeResult::NotRunning),
+            Err(err) => Err(err.context("Failed to connect to existing workspace server")),
+        }
+    }
+
     #[instrument(skip(path), fields(workspace.path = ?path.as_ref()))]
     pub async fn connect(path: impl AsRef<Path>) -> Result<Self> {
         let path = fs::canonicalize(path)?;
@@ -116,9 +138,33 @@ impl Client {
         })
     }
 
+    pub async fn show_ui(&self) -> Result<()> {
+        let request = crate::proto::ShowUiRequest {};
+        let mut client = FriconServiceClient::new(self.channel.clone());
+        client.show_ui(request).await?;
+        Ok(())
+    }
+
     fn dataset_service(&self) -> DatasetServiceClient<Channel> {
         DatasetServiceClient::new(self.channel.clone())
     }
+}
+
+fn connect_target_missing(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<ConnectError>()
+            .is_some_and(|connect_error| matches!(connect_error, ConnectError::NotFound(_)))
+            || cause.to_string().contains("Connect target not found")
+    })
+}
+
+fn show_ui_requires_desktop_ui(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<tonic::Status>()
+            .is_some_and(|status| status.code() == Code::FailedPrecondition)
+    })
 }
 
 #[derive(Debug)]

--- a/crates/fricon/src/dataset/events.rs
+++ b/crates/fricon/src/dataset/events.rs
@@ -23,6 +23,7 @@ pub enum AppEvent {
         status: DatasetStatus,
         created_at: DateTime<Utc>,
     },
+    ShowUiRequest,
 }
 
 #[must_use]

--- a/crates/fricon/src/lib.rs
+++ b/crates/fricon/src/lib.rs
@@ -17,7 +17,7 @@ pub mod workspace;
 
 pub use self::{
     app::{AppEvent, AppHandle, AppManager},
-    client::{Client, Dataset, DatasetWriter},
+    client::{Client, Dataset, DatasetWriter, ExistingUiProbeResult},
     dataset::{
         CreateDatasetRequest, DatasetArray, DatasetCatalogService, DatasetDataType, DatasetId,
         DatasetIngestService, DatasetListQuery, DatasetMetadata, DatasetReadService, DatasetReader,

--- a/crates/fricon/src/transport/grpc/fricon_service.rs
+++ b/crates/fricon/src/transport/grpc/fricon_service.rs
@@ -1,11 +1,18 @@
-use tonic::{Request, Response, Result};
+use tonic::{Request, Response, Result, Status};
+use tracing::warn;
 
 use crate::{
     VERSION,
-    proto::{VersionRequest, VersionResponse, fricon_service_server::FriconService},
+    app::{AppError, AppEvent, AppHandle},
+    proto::{
+        ShowUiRequest, ShowUiResponse, VersionRequest, VersionResponse,
+        fricon_service_server::FriconService,
+    },
 };
 
-pub(crate) struct Fricon;
+pub(crate) struct Fricon {
+    pub(crate) app: AppHandle,
+}
 
 #[tonic::async_trait]
 impl FriconService for Fricon {
@@ -15,5 +22,23 @@ impl FriconService for Fricon {
     ) -> Result<Response<VersionResponse>> {
         let version = VERSION.into();
         Ok(Response::new(VersionResponse { version }))
+    }
+
+    async fn show_ui(&self, _request: Request<ShowUiRequest>) -> Result<Response<ShowUiResponse>> {
+        self.app
+            .send_event(AppEvent::ShowUiRequest)
+            .map_err(|err| match err {
+                AppError::EventUndelivered => {
+                    warn!("ShowUiRequest received but no desktop UI subscriber is attached");
+                    Status::failed_precondition(
+                        "desktop UI is not attached to this workspace server",
+                    )
+                }
+                AppError::StateDropped => {
+                    warn!("ShowUiRequest received while workspace server is shutting down");
+                    Status::unavailable("workspace server is shutting down")
+                }
+            })?;
+        Ok(Response::new(ShowUiResponse {}))
     }
 }

--- a/crates/fricon/tests/integration_test.rs
+++ b/crates/fricon/tests/integration_test.rs
@@ -3,13 +3,15 @@ use std::sync::Arc;
 
 use arrow_array::{Array, Float64Array, RecordBatch};
 use fricon::{
-    AppManager, Client, DatasetId, DatasetListQuery, DatasetRow, DatasetScalar, DatasetStatus,
-    FixedStepTrace, ScalarArray, VariableStepTrace, WorkspaceRoot,
+    AppEvent, AppManager, Client, DatasetId, DatasetListQuery, DatasetRow, DatasetScalar,
+    DatasetStatus, ExistingUiProbeResult, FixedStepTrace, ScalarArray, VariableStepTrace,
+    WorkspaceRoot,
 };
 use indexmap::IndexMap;
 use num::complex::Complex64;
 use tempfile::TempDir;
 use tokio::time::{Duration, Instant};
+use tonic::Code;
 
 fn create_test_rows() -> Vec<DatasetRow> {
     vec![
@@ -379,5 +381,68 @@ async fn test_dataset_create_without_finish_is_aborted() -> anyhow::Result<()> {
     app_manager.shutdown().await;
     temp_dir.close()?;
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_probe_existing_ui_reports_not_running_without_server() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let workspace_path = temp_dir.path();
+    WorkspaceRoot::create_new(workspace_path)?;
+
+    let probe_result = Client::probe_existing_ui(workspace_path).await?;
+
+    assert_eq!(probe_result, ExistingUiProbeResult::NotRunning);
+
+    temp_dir.close()?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_show_ui_requires_attached_ui_subscriber() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let workspace_path = temp_dir.path();
+    WorkspaceRoot::create_new(workspace_path)?;
+
+    let app_manager =
+        AppManager::new_with_path(workspace_path)?.start(&tokio::runtime::Handle::current())?;
+    let client = Client::connect(workspace_path).await?;
+
+    assert_eq!(
+        Client::probe_existing_ui(workspace_path).await?,
+        ExistingUiProbeResult::UiUnavailable
+    );
+
+    let error = client
+        .show_ui()
+        .await
+        .expect_err("show_ui should fail when no UI subscriber is attached");
+    let status = error
+        .downcast_ref::<tonic::Status>()
+        .expect("show_ui should return tonic::Status");
+    assert_eq!(status.code(), Code::FailedPrecondition);
+
+    app_manager.shutdown().await;
+    temp_dir.close()?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_probe_existing_ui_delegates_when_subscriber_is_attached() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let workspace_path = temp_dir.path();
+    WorkspaceRoot::create_new(workspace_path)?;
+
+    let app_manager =
+        AppManager::new_with_path(workspace_path)?.start(&tokio::runtime::Handle::current())?;
+    let mut event_rx = app_manager.handle().subscribe_to_events()?;
+
+    let probe_result = Client::probe_existing_ui(workspace_path).await?;
+
+    assert_eq!(probe_result, ExistingUiProbeResult::UiShown);
+    assert!(matches!(event_rx.recv().await?, AppEvent::ShowUiRequest));
+
+    app_manager.shutdown().await;
+    temp_dir.close()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a `ShowUi` gRPC endpoint so an existing workspace server can tell the desktop UI to bring its window to the front
- wire `ShowUiRequest` through the app event bus and desktop event forwarder to focus the main Tauri window
- probe for an existing workspace UI before starting a new desktop runtime, and delegate to it when available
- restore workspace log attachment to happen before `AppState::new` when launching a fresh runtime
- fail startup clearly when the workspace is already served by a non-UI process

## Testing
- `cargo check -p fricon -p fricon-ui`
- `cargo test -p fricon-ui --lib desktop_runtime::runtime::tests`
- `cargo nextest run -p fricon --test integration_test test_probe_existing_ui_reports_not_running_without_server test_show_ui_requires_attached_ui_subscriber test_probe_existing_ui_delegates_when_subscriber_is_attached`

Closes #67.

## Follow-ups
- #232 Refactor workspace UI probe to use typed errors
- #233 Add regression coverage for unexpected `show_ui` failures
- #234 Document the workspace single-instance startup invariant
- #235 Extract workspace server probe coordination if startup logic grows
