### PR TITLE
refactor(frontend): clean up dataset tag menu tests

### DIFF
--- a/crates/fricon-ui/frontend/src/features/datasets/model/datasetTableTagMenuLogic.test.ts
+++ b/crates/fricon-ui/frontend/src/features/datasets/model/datasetTableTagMenuLogic.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DatasetDeleteResult, DatasetInfo } from "../api/types";
+import {
+  deriveDatasetTagMenuTarget,
+  runDatasetTagMutation,
+} from "./datasetTableTagMenuLogic";
+
+function makeDataset(overrides: Partial<DatasetInfo> = {}): DatasetInfo {
+  return {
+    id: 1,
+    name: "Dataset 1",
+    description: "desc",
+    favorite: false,
+    tags: ["vision"],
+    status: "Completed",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function createNotifier() {
+  return {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  };
+}
+
+describe("datasetTableTagMenuLogic", () => {
+  it("targets only the clicked dataset when there is no multi-row selection", () => {
+    const dataset = makeDataset({ id: 5, tags: [] });
+    const target = deriveDatasetTagMenuTarget(dataset, []);
+
+    expect(target).toEqual({
+      targetIds: [5],
+      targetLabel: "",
+      removableTags: [],
+    });
+  });
+
+  it("targets all selected rows and combines removable tags", () => {
+    const first = makeDataset({ id: 10, name: "Dataset A", tags: ["vision"] });
+    const second = makeDataset({
+      id: 11,
+      name: "Dataset B",
+      tags: ["audio", "vision"],
+    });
+
+    const target = deriveDatasetTagMenuTarget(second, [first, second]);
+
+    expect(target).toEqual({
+      targetIds: [10, 11],
+      targetLabel: " (2)",
+      removableTags: ["audio", "vision"],
+    });
+  });
+
+  it("adds an existing tag for a single target row", async () => {
+    const notifier = createNotifier();
+    const batchAddTags = vi
+      .fn()
+      .mockResolvedValue([{ id: 5, success: true, error: null }]);
+    const batchRemoveTags = vi.fn();
+
+    const target = deriveDatasetTagMenuTarget(
+      makeDataset({ id: 5, tags: [] }),
+      [],
+    );
+
+    await runDatasetTagMutation({
+      operation: "add",
+      targetIds: target.targetIds,
+      tag: "vision",
+      batchAddTags,
+      batchRemoveTags,
+      notify: notifier,
+    });
+
+    expect(batchAddTags).toHaveBeenCalledWith([5], ["vision"]);
+    expect(notifier.success).toHaveBeenCalledWith(
+      'Added tag "vision" to 1 dataset(s).',
+    );
+  });
+
+  it("adds a tag for all selected rows and reports partial failure", async () => {
+    const notifier = createNotifier();
+    const results: DatasetDeleteResult[] = [
+      { id: 10, success: true, error: null },
+      { id: 11, success: false, error: "locked" },
+    ];
+    const batchAddTags = vi.fn().mockResolvedValue(results);
+    const batchRemoveTags = vi.fn();
+    const first = makeDataset({ id: 10, name: "Dataset A", tags: [] });
+    const second = makeDataset({ id: 11, name: "Dataset B", tags: [] });
+    const target = deriveDatasetTagMenuTarget(second, [first, second]);
+
+    await runDatasetTagMutation({
+      operation: "add",
+      targetIds: target.targetIds,
+      tag: "vision",
+      batchAddTags,
+      batchRemoveTags,
+      notify: notifier,
+    });
+
+    expect(batchAddTags).toHaveBeenCalledWith([10, 11], ["vision"]);
+    expect(notifier.warning).toHaveBeenCalledWith(
+      'Added tag "vision" to 1 dataset(s), but 1 failed.',
+      {
+        description: "ID 11: locked",
+      },
+    );
+  });
+
+  it("removes a tag and reports success", async () => {
+    const notifier = createNotifier();
+    const batchAddTags = vi.fn();
+    const batchRemoveTags = vi
+      .fn()
+      .mockResolvedValue([{ id: 9, success: true, error: null }]);
+
+    await runDatasetTagMutation({
+      operation: "remove",
+      targetIds: [9],
+      tag: "vision",
+      batchAddTags,
+      batchRemoveTags,
+      notify: notifier,
+    });
+
+    expect(batchRemoveTags).toHaveBeenCalledWith([9], ["vision"]);
+    expect(notifier.success).toHaveBeenCalledWith(
+      'Removed tag "vision" from 1 dataset(s).',
+    );
+  });
+});

--- a/crates/fricon-ui/frontend/src/features/datasets/model/datasetTableTagMenuLogic.ts
+++ b/crates/fricon-ui/frontend/src/features/datasets/model/datasetTableTagMenuLogic.ts
@@ -1,0 +1,130 @@
+import type { DatasetDeleteResult, DatasetInfo } from "../api/types";
+
+export type DatasetTagOperation = "add" | "remove";
+
+export interface DatasetTagMenuTarget {
+  targetIds: number[];
+  targetLabel: string;
+  removableTags: string[];
+}
+
+interface DatasetTagMutationNotifier {
+  success: (message: string) => void;
+  error: (message: string, options?: { description?: string }) => void;
+  warning: (message: string, options?: { description?: string }) => void;
+}
+
+interface RunDatasetTagMutationArgs {
+  operation: DatasetTagOperation;
+  targetIds: number[];
+  tag: string;
+  batchAddTags: (
+    ids: number[],
+    tags: string[],
+  ) => Promise<DatasetDeleteResult[]>;
+  batchRemoveTags: (
+    ids: number[],
+    tags: string[],
+  ) => Promise<DatasetDeleteResult[]>;
+  notify: DatasetTagMutationNotifier;
+}
+
+export function deriveDatasetTagMenuTarget(
+  dataset: DatasetInfo,
+  selectedDatasets: DatasetInfo[],
+): DatasetTagMenuTarget {
+  const includesDataset = selectedDatasets.some(
+    (selectedDataset) => selectedDataset.id === dataset.id,
+  );
+  const targetDatasets =
+    selectedDatasets.length > 1 && includesDataset
+      ? selectedDatasets
+      : [dataset];
+
+  return {
+    targetIds: targetDatasets.map((targetDataset) => targetDataset.id),
+    targetLabel: targetDatasets.length > 1 ? ` (${targetDatasets.length})` : "",
+    removableTags: Array.from(
+      new Set(targetDatasets.flatMap((targetDataset) => targetDataset.tags)),
+    ).sort(),
+  };
+}
+
+function getTagMutationDescription(results: DatasetDeleteResult[]) {
+  return results
+    .filter((result) => !result.success)
+    .map((result) => `ID ${result.id}: ${result.error ?? "Unknown error"}`)
+    .join("\n");
+}
+
+export function notifyDatasetTagMutationResult(
+  operation: DatasetTagOperation,
+  tag: string,
+  results: DatasetDeleteResult[],
+  notify: DatasetTagMutationNotifier,
+) {
+  const actionLabel = operation === "add" ? "Added" : "Removed";
+  const actionVerb = operation === "add" ? "add" : "remove";
+  const preposition = operation === "add" ? "to" : "from";
+  const successCount = results.filter((result) => result.success).length;
+  const failedCount = results.length - successCount;
+
+  if (failedCount === 0) {
+    notify.success(
+      `${actionLabel} tag "${tag}" ${preposition} ${successCount} dataset(s).`,
+    );
+    return;
+  }
+
+  if (successCount === 0) {
+    notify.error(
+      `Failed to ${actionVerb} tag "${tag}" ${preposition} ${failedCount} dataset(s).`,
+      {
+        description: getTagMutationDescription(results),
+      },
+    );
+    return;
+  }
+
+  notify.warning(
+    `${actionLabel} tag "${tag}" ${preposition} ${successCount} dataset(s), but ${failedCount} failed.`,
+    {
+      description: getTagMutationDescription(results),
+    },
+  );
+}
+
+export function notifyDatasetTagMutationError(
+  operation: DatasetTagOperation,
+  tag: string,
+  error: unknown,
+  notify: DatasetTagMutationNotifier,
+) {
+  const actionVerb = operation === "add" ? "add" : "remove";
+  notify.error(
+    error instanceof Error
+      ? error.message
+      : `Failed to ${actionVerb} tag "${tag}".`,
+  );
+}
+
+export async function runDatasetTagMutation({
+  operation,
+  targetIds,
+  tag,
+  batchAddTags,
+  batchRemoveTags,
+  notify,
+}: RunDatasetTagMutationArgs) {
+  try {
+    const results =
+      operation === "add"
+        ? await batchAddTags(targetIds, [tag])
+        : await batchRemoveTags(targetIds, [tag]);
+    notifyDatasetTagMutationResult(operation, tag, results, notify);
+    return results;
+  } catch (error) {
+    notifyDatasetTagMutationError(operation, tag, error, notify);
+    return null;
+  }
+}

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTable.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTable.test.tsx
@@ -162,15 +162,6 @@ async function openRowContextMenu(name: string) {
   return menus.at(-1)!;
 }
 
-async function openContextSubmenu(
-  user: ReturnType<typeof userEvent.setup>,
-  label: RegExp,
-) {
-  const subTrigger = screen.getByRole("menuitem", { name: label });
-  subTrigger.focus();
-  await user.keyboard("{ArrowRight}");
-}
-
 async function openColumnsMenu(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: /View/i }));
   const menus = await screen.findAllByRole("menu");
@@ -610,102 +601,7 @@ describe("DatasetTable", () => {
     renderDatasetTable({ datasets: [dataset], allTags: ["vision", "audio"] });
 
     const menu = await openRowContextMenu("Tagged Dataset");
-    // The ContextMenuSubTrigger item is rendered inside the context menu
     expect(within(menu).getByText(/Add Tags/i)).toBeInTheDocument();
-  });
-
-  it("calls batchAddTags when clicking a tag in the Add Tags sub-menu", async () => {
-    const dataset = makeDataset({ id: 5, name: "Tagged Dataset", tags: [] });
-    const batchAddTags = vi
-      .fn()
-      .mockResolvedValue([{ id: 5, success: true, error: null }]);
-    renderDatasetTable({
-      datasets: [dataset],
-      allTags: ["vision"],
-      batchAddTags,
-    });
-    const user = userEvent.setup();
-
-    await openRowContextMenu("Tagged Dataset");
-    // The tag items from allTags are rendered in the submenu popup; in JSDOM,
-    // we can use pointer events on the submenu trigger to open it, then query
-    // the sub-menu content which is rendered in a portal.
-    // Since Base-UI sub-menus open on focus/keyboard, use keyboard navigation.
-    await openContextSubmenu(user, /Add Tags/i);
-
-    const tagItem = await screen.findByRole("menuitem", { name: "vision" });
-    await user.click(tagItem);
-
-    await waitFor(() => {
-      expect(batchAddTags).toHaveBeenCalledWith([5], ["vision"]);
-    });
-    expect(toastSuccess).toHaveBeenCalledWith(
-      expect.stringContaining("vision"),
-    );
-  });
-
-  it("accepts typed input in the Add Tags sub-menu and submits it", async () => {
-    const dataset = makeDataset({ id: 5, name: "Tagged Dataset", tags: [] });
-    const batchAddTags = vi
-      .fn()
-      .mockResolvedValue([{ id: 5, success: true, error: null }]);
-    renderDatasetTable({
-      datasets: [dataset],
-      allTags: ["vision"],
-      batchAddTags,
-    });
-    const user = userEvent.setup();
-
-    await openRowContextMenu("Tagged Dataset");
-    await openContextSubmenu(user, /Add Tags/i);
-
-    const input = await screen.findByPlaceholderText("New tag...");
-    await user.click(input);
-    await user.type(input, "fresh-tag");
-    await user.keyboard("{Enter}");
-
-    await waitFor(() => {
-      expect(batchAddTags).toHaveBeenCalledWith([5], ["fresh-tag"]);
-    });
-  });
-
-  it("shows a warning toast when adding a tag partially fails", async () => {
-    const datasets = [
-      makeDataset({ id: 5, name: "Dataset A", tags: [] }),
-      makeDataset({ id: 6, name: "Dataset B", tags: [] }),
-    ];
-    const batchAddTags = vi.fn().mockResolvedValue([
-      { id: 5, success: true, error: null },
-      { id: 6, success: false, error: "locked" },
-    ]);
-    renderDatasetTable({
-      datasets,
-      allTags: ["vision"],
-      batchAddTags,
-    });
-    const user = userEvent.setup();
-
-    const checkboxes = screen.getAllByLabelText("Select row");
-    await user.click(checkboxes[0]);
-    await user.click(checkboxes[1]);
-
-    await openRowContextMenu("Dataset B");
-    await openContextSubmenu(user, /Add Tags/i);
-
-    const tagItem = await screen.findByRole("menuitem", { name: "vision" });
-    await user.click(tagItem);
-
-    await waitFor(() => {
-      expect(toastWarning).toHaveBeenCalledWith(
-        expect.stringContaining("but 1 failed"),
-        expect.any(Object),
-      );
-    });
-    const warningOptions = toastWarning.mock.calls[0]?.[1] as
-      | { description?: string }
-      | undefined;
-    expect(warningOptions?.description).toContain("ID 6: locked");
-    expect(toastSuccess).not.toHaveBeenCalled();
   });
 
   it("shows Remove Tags sub-menu only when target datasets have tags", async () => {
@@ -724,70 +620,21 @@ describe("DatasetTable", () => {
     expect(within(menu).queryByText(/Remove Tags/i)).not.toBeInTheDocument();
   });
 
-  it("calls batchRemoveTags when clicking a tag in the Remove Tags sub-menu", async () => {
-    const dataset = makeDataset({
-      id: 9,
-      name: "Remove Tag",
-      tags: ["vision"],
-    });
-    const batchRemoveTags = vi
-      .fn()
-      .mockResolvedValue([{ id: 9, success: true, error: null }]);
-    renderDatasetTable({
-      datasets: [dataset],
-      allTags: ["vision"],
-      batchRemoveTags,
-    });
-    const user = userEvent.setup();
-
-    await openRowContextMenu("Remove Tag");
-    await openContextSubmenu(user, /Remove Tags/i);
-
-    const tagItem = await screen.findByRole("menuitem", { name: "vision" });
-    await user.click(tagItem);
-
-    await waitFor(() => {
-      expect(batchRemoveTags).toHaveBeenCalledWith([9], ["vision"]);
-    });
-    expect(toastSuccess).toHaveBeenCalledWith(
-      expect.stringContaining("vision"),
-    );
-  });
-
   it("targets all selected rows for tag operations when right-clicking a selected row", async () => {
     const datasets = [
       makeDataset({ id: 10, name: "Dataset A", tags: [] }),
       makeDataset({ id: 11, name: "Dataset B", tags: [] }),
     ];
-    const batchAddTags = vi.fn().mockResolvedValue([
-      { id: 10, success: true, error: null },
-      { id: 11, success: true, error: null },
-    ]);
-    renderDatasetTable({ datasets, allTags: ["vision"], batchAddTags });
+    renderDatasetTable({ datasets, allTags: ["vision"] });
     const user = userEvent.setup();
 
-    // Select both rows via checkboxes
     const checkboxes = screen.getAllByLabelText("Select row");
     await user.click(checkboxes[0]);
     await user.click(checkboxes[1]);
 
-    // Right-click one of the selected rows
     const menu = await openRowContextMenu("Dataset B");
-    // Should say "Add Tags (2)" when 2 rows are targeted
     expect(within(menu).getByText(/Add Tags \(2\)/i)).toBeInTheDocument();
-
-    await openContextSubmenu(user, /Add Tags/i);
-
-    const tagItem = await screen.findByRole("menuitem", { name: "vision" });
-    await user.click(tagItem);
-
-    await waitFor(() => {
-      // Should include both selected IDs
-      expect(batchAddTags).toHaveBeenCalledWith(
-        expect.arrayContaining([10, 11]),
-        ["vision"],
-      );
-    });
+    expect(within(menu).queryByText(/Remove Tags/i)).not.toBeInTheDocument();
   });
 
   it("shows Manage Tags button inside the Tags filter popover", async () => {

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTable.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTable.tsx
@@ -23,9 +23,6 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/shared/ui/context-menu";
 import {
@@ -38,10 +35,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/shared/ui/alert-dialog";
-import { Input } from "@/shared/ui/input";
-import { Tag, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import type { DatasetDeleteResult } from "../api/types";
+import { DatasetRowTagMenus } from "./DatasetTableTagMenu";
+import {
+  deriveDatasetTagMenuTarget,
+  runDatasetTagMutation,
+} from "../model/datasetTableTagMenuLogic";
 
 interface DatasetTableProps {
   selectedDatasetId?: number;
@@ -52,13 +52,6 @@ function isMacPlatform() {
   const platform = navigator.userAgent;
 
   return platform.toUpperCase().includes("MAC");
-}
-
-function getTagMutationDescription(results: DatasetDeleteResult[]) {
-  return results
-    .filter((result) => !result.success)
-    .map((result) => `ID ${result.id}: ${result.error ?? "Unknown error"}`)
-    .join("\n");
 }
 
 export function DatasetTable({
@@ -105,7 +98,6 @@ export function DatasetTable({
     mode: "replace" | "toggle";
     targetValue?: boolean;
   } | null>(null);
-  const [newTagInput, setNewTagInput] = useState("");
 
   useEffect(() => {
     const handleMouseUp = () => setDragState(null);
@@ -467,48 +459,14 @@ export function DatasetTable({
     targetIds: number[],
     tag: string,
   ) => {
-    const actionLabel = operation === "add" ? "Added" : "Removed";
-    const actionVerb = operation === "add" ? "add" : "remove";
-
-    try {
-      const results =
-        operation === "add"
-          ? await batchAddTags(targetIds, [tag])
-          : await batchRemoveTags(targetIds, [tag]);
-
-      const successCount = results.filter((result) => result.success).length;
-      const failedCount = results.length - successCount;
-
-      if (failedCount === 0) {
-        toast.success(
-          `${actionLabel} tag "${tag}" ${operation === "add" ? "to" : "from"} ${successCount} dataset(s).`,
-        );
-        return;
-      }
-
-      if (successCount === 0) {
-        toast.error(
-          `Failed to ${actionVerb} tag "${tag}" ${operation === "add" ? "to" : "from"} ${failedCount} dataset(s).`,
-          {
-            description: getTagMutationDescription(results),
-          },
-        );
-        return;
-      }
-
-      toast.warning(
-        `${actionLabel} tag "${tag}" ${operation === "add" ? "to" : "from"} ${successCount} dataset(s), but ${failedCount} failed.`,
-        {
-          description: getTagMutationDescription(results),
-        },
-      );
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : `Failed to ${actionVerb} tag "${tag}".`,
-      );
-    }
+    await runDatasetTagMutation({
+      operation,
+      targetIds,
+      tag,
+      batchAddTags,
+      batchRemoveTags,
+      notify: toast,
+    });
   };
 
   return (
@@ -595,30 +553,10 @@ export function DatasetTable({
                     const selectedRows =
                       table.getFilteredSelectedRowModel().rows;
                     const selectedCount = selectedRows.length;
-                    const isInSelection =
-                      selectedCount > 1 &&
-                      selectedRows.some((selectedRow) => {
-                        return selectedRow.original.id === dataset.id;
-                      });
-                    const targetIds = isInSelection
-                      ? selectedRows.map(
-                          (selectedRow) => selectedRow.original.id,
-                        )
-                      : [dataset.id];
-                    const targetLabel =
-                      isInSelection && selectedCount > 1
-                        ? ` (${selectedCount})`
-                        : "";
-                    const targetDatasets = isInSelection
-                      ? selectedRows.map((selectedRow) => selectedRow.original)
-                      : [dataset];
-                    const removableTags = Array.from(
-                      new Set(
-                        targetDatasets.flatMap(
-                          (targetDataset) => targetDataset.tags,
-                        ),
-                      ),
-                    ).sort();
+                    const target = deriveDatasetTagMenuTarget(
+                      dataset,
+                      selectedRows.map((selectedRow) => selectedRow.original),
+                    );
 
                     return (
                       <ContextMenu key={row.id}>
@@ -668,104 +606,25 @@ export function DatasetTable({
                             View Details
                           </ContextMenuItem>
                           <ContextMenuSeparator />
-                          {/* Tag management sub-menus */}
-                          <ContextMenuSub>
-                            <ContextMenuSubTrigger>
-                              <Tag
-                                data-icon="inline-start"
-                                className="size-3.5"
-                              />
-                              Add Tags{targetLabel}
-                            </ContextMenuSubTrigger>
-                            <ContextMenuSubContent className="w-56">
-                              <div
-                                className="px-2 pb-1"
-                                onPointerDown={(event) => {
-                                  event.stopPropagation();
-                                }}
-                              >
-                                <form
-                                  onSubmit={(e) => {
-                                    e.preventDefault();
-                                    const tag = newTagInput.trim();
-                                    if (!tag) return;
-                                    void handleBatchTagMutation(
-                                      "add",
-                                      targetIds,
-                                      tag,
-                                    );
-                                    setNewTagInput("");
-                                  }}
-                                  className="flex gap-1"
-                                >
-                                  <Input
-                                    placeholder="New tag..."
-                                    value={newTagInput}
-                                    onChange={(e) =>
-                                      setNewTagInput(e.target.value)
-                                    }
-                                    onClick={(event) => {
-                                      event.stopPropagation();
-                                    }}
-                                    onKeyDown={(event) => {
-                                      event.stopPropagation();
-                                    }}
-                                    className="h-7 text-xs"
-                                  />
-                                </form>
-                              </div>
-                              {allTags.length > 0 && (
-                                <div className="flex max-h-40 flex-col overflow-y-auto">
-                                  {allTags.map((tag) => (
-                                    <ContextMenuItem
-                                      key={tag}
-                                      disabled={isUpdatingTags}
-                                      onClick={() => {
-                                        void handleBatchTagMutation(
-                                          "add",
-                                          targetIds,
-                                          tag,
-                                        );
-                                      }}
-                                    >
-                                      {tag}
-                                    </ContextMenuItem>
-                                  ))}
-                                </div>
-                              )}
-                            </ContextMenuSubContent>
-                          </ContextMenuSub>
-
-                          {removableTags.length > 0 && (
-                            <ContextMenuSub>
-                              <ContextMenuSubTrigger>
-                                <Tag
-                                  data-icon="inline-start"
-                                  className="size-3.5"
-                                />
-                                Remove Tags{targetLabel}
-                              </ContextMenuSubTrigger>
-                              <ContextMenuSubContent className="w-56">
-                                <div className="flex max-h-40 flex-col overflow-y-auto">
-                                  {removableTags.map((tag) => (
-                                    <ContextMenuItem
-                                      key={tag}
-                                      disabled={isUpdatingTags}
-                                      onClick={() => {
-                                        void handleBatchTagMutation(
-                                          "remove",
-                                          targetIds,
-                                          tag,
-                                        );
-                                      }}
-                                    >
-                                      {tag}
-                                    </ContextMenuItem>
-                                  ))}
-                                </div>
-                              </ContextMenuSubContent>
-                            </ContextMenuSub>
-                          )}
+                          <DatasetRowTagMenus
+                            allTags={allTags}
+                            isUpdatingTags={isUpdatingTags}
+                            target={target}
+                            onAddTag={(tag) => {
+                              void handleBatchTagMutation(
+                                "add",
+                                target.targetIds,
+                                tag,
+                              );
+                            }}
+                            onRemoveTag={(tag) => {
+                              void handleBatchTagMutation(
+                                "remove",
+                                target.targetIds,
+                                tag,
+                              );
+                            }}
+                          />
                           <ContextMenuSeparator />
                           <ContextMenuItem
                             variant="destructive"

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTableTagMenu.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTableTagMenu.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DatasetNewTagForm } from "./DatasetTableTagMenu";
+
+describe("DatasetTableTagMenu", () => {
+  it("trims typed input, submits the tag, and clears the form", async () => {
+    const user = userEvent.setup();
+    const onSubmitTag = vi.fn();
+
+    render(<DatasetNewTagForm onSubmitTag={onSubmitTag} />);
+
+    const input = screen.getByPlaceholderText("New tag...");
+    await user.type(input, "  fresh-tag  ");
+    await user.keyboard("{Enter}");
+
+    expect(onSubmitTag).toHaveBeenCalledWith("fresh-tag");
+    expect(input).toHaveValue("");
+  });
+
+  it("ignores blank tag submissions", async () => {
+    const user = userEvent.setup();
+    const onSubmitTag = vi.fn();
+
+    render(<DatasetNewTagForm onSubmitTag={onSubmitTag} />);
+
+    const input = screen.getByPlaceholderText("New tag...");
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+
+    expect(onSubmitTag).not.toHaveBeenCalled();
+    expect(input).toHaveValue("   ");
+  });
+});

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTableTagMenu.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTableTagMenu.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { Tag } from "lucide-react";
+import { Input } from "@/shared/ui/input";
+import {
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+} from "@/shared/ui/context-menu";
+import type { DatasetTagMenuTarget } from "../model/datasetTableTagMenuLogic";
+
+interface DatasetNewTagFormProps {
+  onSubmitTag: (tag: string) => void;
+}
+
+interface DatasetRowTagMenusProps {
+  allTags: string[];
+  isUpdatingTags: boolean;
+  target: DatasetTagMenuTarget;
+  onAddTag: (tag: string) => void;
+  onRemoveTag: (tag: string) => void;
+}
+
+export function DatasetNewTagForm({ onSubmitTag }: DatasetNewTagFormProps) {
+  const [newTagInput, setNewTagInput] = useState("");
+
+  const handleSubmit = () => {
+    const tag = newTagInput.trim();
+    if (!tag) return;
+    onSubmitTag(tag);
+    setNewTagInput("");
+  };
+
+  return (
+    <div
+      className="px-2 pb-1"
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+        className="flex gap-1"
+      >
+        <Input
+          placeholder="New tag..."
+          value={newTagInput}
+          onChange={(event) => setNewTagInput(event.target.value)}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onKeyDown={(event) => {
+            event.stopPropagation();
+          }}
+          className="h-7 text-xs"
+        />
+      </form>
+    </div>
+  );
+}
+
+export function DatasetRowTagMenus({
+  allTags,
+  isUpdatingTags,
+  target,
+  onAddTag,
+  onRemoveTag,
+}: DatasetRowTagMenusProps) {
+  return (
+    <>
+      <ContextMenuSub>
+        <ContextMenuSubTrigger>
+          <Tag data-icon="inline-start" className="size-3.5" />
+          Add Tags{target.targetLabel}
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent className="w-56">
+          <DatasetNewTagForm onSubmitTag={onAddTag} />
+          {allTags.length > 0 && (
+            <div className="flex max-h-40 flex-col overflow-y-auto">
+              {allTags.map((tag) => (
+                <ContextMenuItem
+                  key={tag}
+                  disabled={isUpdatingTags}
+                  onClick={() => {
+                    onAddTag(tag);
+                  }}
+                >
+                  {tag}
+                </ContextMenuItem>
+              ))}
+            </div>
+          )}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+
+      {target.removableTags.length > 0 && (
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <Tag data-icon="inline-start" className="size-3.5" />
+            Remove Tags{target.targetLabel}
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-56">
+            <div className="flex max-h-40 flex-col overflow-y-auto">
+              {target.removableTags.map((tag) => (
+                <ContextMenuItem
+                  key={tag}
+                  disabled={isUpdatingTags}
+                  onClick={() => {
+                    onRemoveTag(tag);
+                  }}
+                >
+                  {tag}
+                </ContextMenuItem>
+              ))}
+            </div>
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- extract dataset tag menu target and mutation logic out of `DatasetTable`
- replace submenu-heavy tag tests with focused unit tests for app-owned behavior
- eliminate the React `act(...)` warnings from the root frontend test run

## Validation
- `pnpm --dir crates/fricon-ui/frontend lint`
- `pnpm --dir crates/fricon-ui/frontend test --run`
- `pnpm --dir crates/fricon-ui/frontend type-check`
- `pnpm -r run test --run`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
