### PR TITLE
refactor(ui): remove unused dataset update callback props

### DIFF
--- a/crates/fricon-ui/frontend/src/app/ui/DatasetInspector.tsx
+++ b/crates/fricon-ui/frontend/src/app/ui/DatasetInspector.tsx
@@ -8,13 +8,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 
 interface DatasetInspectorProps {
   datasetId?: number;
-  onDatasetUpdated?: () => void;
 }
 
-export function DatasetInspector({
-  datasetId,
-  onDatasetUpdated,
-}: DatasetInspectorProps) {
+export function DatasetInspector({ datasetId }: DatasetInspectorProps) {
   if (!datasetId) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
@@ -29,22 +25,15 @@ export function DatasetInspector({
     );
   }
 
-  return (
-    <SelectedDatasetInspector
-      datasetId={datasetId}
-      onDatasetUpdated={onDatasetUpdated}
-    />
-  );
+  return <SelectedDatasetInspector datasetId={datasetId} />;
 }
 
 interface SelectedDatasetInspectorProps {
   datasetId: number;
-  onDatasetUpdated?: () => void;
 }
 
 function SelectedDatasetInspector({
   datasetId,
-  onDatasetUpdated,
 }: SelectedDatasetInspectorProps) {
   const detailQuery = useDatasetDetailQuery(datasetId);
   const detail = detailQuery.data ?? null;
@@ -77,7 +66,6 @@ function SelectedDatasetInspector({
             detail={detail}
             isLoading={detailQuery.isLoading}
             loadErrorMessage={loadErrorMessage}
-            onDatasetUpdated={onDatasetUpdated}
           />
         </TabsContent>
       </Tabs>

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.tsx
@@ -39,7 +39,6 @@ interface DatasetPropertiesPanelProps {
   detail: DatasetDetail | null;
   isLoading: boolean;
   loadErrorMessage: string | null;
-  onDatasetUpdated?: () => void;
 }
 
 export function DatasetPropertiesPanel({
@@ -47,7 +46,6 @@ export function DatasetPropertiesPanel({
   detail,
   isLoading,
   loadErrorMessage,
-  onDatasetUpdated,
 }: DatasetPropertiesPanelProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-1">
@@ -60,7 +58,6 @@ export function DatasetPropertiesPanel({
           key={buildDatasetDetailEditorKey(datasetId, detail)}
           datasetId={datasetId}
           detail={detail}
-          onDatasetUpdated={onDatasetUpdated}
         />
       ) : null}
 
@@ -76,7 +73,6 @@ export function DatasetPropertiesPanel({
 interface DatasetDetailEditorProps {
   datasetId: number;
   detail: DatasetDetail;
-  onDatasetUpdated?: () => void;
 }
 
 interface DatasetDetailEditorDraft {
@@ -87,11 +83,7 @@ interface DatasetDetailEditorDraft {
   normalizedTags: string[];
 }
 
-function DatasetDetailEditor({
-  datasetId,
-  detail,
-  onDatasetUpdated,
-}: DatasetDetailEditorProps) {
+function DatasetDetailEditor({ datasetId, detail }: DatasetDetailEditorProps) {
   const queryClient = useQueryClient();
   const initialDraft = createDatasetDetailEditorDraft(detail);
   const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(null);
@@ -139,8 +131,6 @@ function DatasetDetailEditor({
       );
       return;
     }
-
-    onDatasetUpdated?.();
   };
 
   return (


### PR DESCRIPTION
## Summary
- remove the unused `onDatasetUpdated` prop chain from `DatasetInspector` and `DatasetPropertiesPanel`
- keep the active dataset event API untouched
- trim the post-save no-op callback from the dataset detail editor

## Validation
- `pnpm run format:check`
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run test --run`
- `pnpm run build`
- `git diff --exit-code crates/fricon-ui/frontend/src/routeTree.gen.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
