### PR TITLE
refactor(fricon-ui): simplify desktop runtime startup

### DIFF
--- a/crates/fricon-ui/src/desktop_runtime/runtime.rs
+++ b/crates/fricon-ui/src/desktop_runtime/runtime.rs
@@ -75,6 +75,10 @@ enum WorkspaceLaunchOutcome {
     },
 }
 
+// Single-instance invariant: probe *before* starting a new server, because
+// `AppState::new` binds the IPC listener and replaces any existing socket file.
+// If we bound first, we would silently take over a workspace already served by
+// another process.
 fn prepare_workspace_runtime(workspace_path: &Path) -> Result<WorkspaceLaunchOutcome> {
     let probe_result =
         tauri::async_runtime::block_on(fricon::Client::probe_existing_ui(workspace_path))?;


### PR DESCRIPTION
## Summary
- Inline `prepare_workspace_runtime_from_probe`, `build_new_workspace_runtime`, and `build_new_workspace_runtime_with` — these existed solely for test injection of trivially correct logic
- Remove 3 associated unit tests (net -115 lines)
- Document the single-instance probe-before-bind invariant on `prepare_workspace_runtime`

Closes #234
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
