### PR TITLE
fix: make uv sdist builds self-contained

### DIFF
--- a/crates/fricon-ui/build.rs
+++ b/crates/fricon-ui/build.rs
@@ -5,6 +5,16 @@ use tauri_utils::{
     platform::Target,
 };
 
+fn run_checked(command: &mut Command, description: &str) {
+    let status = command.status().unwrap_or_else(|error| {
+        panic!("Failed to run {description}: {error}");
+    });
+    assert!(
+        status.success(),
+        "{description} failed with status {status}"
+    );
+}
+
 /// Find the pnpm executable by trying multiple possible names in order
 fn find_pnpm_executable() -> &'static str {
     if cfg!(windows) {
@@ -66,16 +76,15 @@ fn main() {
             );
         }
         let pnpm = find_pnpm_executable();
-        Command::new(pnpm)
-            .current_dir(frontend_root)
-            .arg("install")
-            .status()
-            .expect("Failed to run pnpm install");
-        Command::new(pnpm)
+        let mut pnpm_install = Command::new(pnpm);
+        pnpm_install.current_dir(frontend_root).arg("install");
+        run_checked(&mut pnpm_install, "pnpm install");
+
+        let mut pnpm_build = Command::new(pnpm);
+        pnpm_build
             .current_dir(frontend_root)
             .arg("run")
-            .arg("build")
-            .status()
-            .expect("Failed to run pnpm build");
+            .arg("build");
+        run_checked(&mut pnpm_build, "pnpm run build");
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ include = [
   { format = "sdist", path = "package.json" },
   { format = "sdist", path = "pnpm-workspace.yaml" },
   { format = "sdist", path = "pnpm-lock.yaml" },
+  { format = "sdist", path = "tsconfig.node.json" },
+  { format = "sdist", path = "eslint.config.ts" },
 ]
 manifest-path = "crates/fricon-py/Cargo.toml"
 module-name = "fricon._core"


### PR DESCRIPTION
## Summary
- include the root frontend config files required by the unpacked sdist build
- make the Tauri frontend build steps fail immediately when pnpm returns a non-zero status
- verify the fix with the full strict preflight and a successful uv build from source distribution

## Testing
- cargo +nightly fmt --all --check
- cargo check
- cargo build --workspace --locked
- cargo clippy --all-targets --all-features
- cargo test --workspace
- cargo deny --workspace --all-features check
- uv run ruff format --check
- uv run maturin develop
- uv run ruff check
- uv run pytest
- uv run basedpyright
- uv run stubtest fricon._core
- pnpm run check
- pnpm run format:check
- pnpm run test --run
- pnpm run build
- uv build

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
