### PR TITLE
feat(charts): use numeric axes for heatmaps

### DIFF
--- a/crates/fricon-ui/frontend/src/features/charts/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.ts
@@ -121,11 +121,6 @@ export type LiveChartAppendOperation =
             shape: "xyz";
             series: import("@/shared/lib/chartTypes").HeatmapSeries;
           };
-    }
-  | {
-      kind: "append_heatmap_categories";
-      xCategories?: number[];
-      yCategories?: number[];
     };
 
 export type LiveChartUpdate =
@@ -200,8 +195,6 @@ export function normalizeChartSnapshot(result: WireChartSnapshot): ChartModel {
         type: "heatmap",
         xName: result.xName,
         yName: result.yName,
-        xCategories: result.xCategories,
-        yCategories: result.yCategories,
         series: result.series.map(normalizeXYZSeries),
       };
     case "xy":
@@ -350,12 +343,6 @@ function normalizeLiveChartAppendOperation(
       return {
         kind: "append_series",
         series: normalizeFlatSeries(operation.series),
-      };
-    case "append_heatmap_categories":
-      return {
-        kind: "append_heatmap_categories",
-        xCategories: operation.x_categories ?? undefined,
-        yCategories: operation.y_categories ?? undefined,
       };
     default:
       return assertNever(

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
@@ -75,20 +75,13 @@ interface HookHarnessProps {
 
 function serializeInteractionState(state: ChartInteractionState | null) {
   if (!state) return null;
-  if ("zoomState" in state) {
-    return {
-      type: state.type,
-      xMin: state.xMin,
-      xMax: state.xMax,
-      yMin: state.yMin,
-      yMax: state.yMax,
-      zoomState: state.zoomState,
-    };
-  }
   return {
     type: state.type,
-    xCategories: state.xCategories,
-    yCategories: state.yCategories,
+    xMin: state.xMin,
+    xMax: state.xMax,
+    yMin: state.yMin,
+    yMax: state.yMax,
+    zoomState: state.zoomState,
   };
 }
 
@@ -179,8 +172,6 @@ function makeHeatmapData(): Extract<ChartOptions, { type: "heatmap" }> {
     type: "heatmap",
     xName: "x",
     yName: "y",
-    xCategories: [0, 1],
-    yCategories: [0, 1],
     series: [
       xyzSeries("z", "z", [
         [0, 0, 1],
@@ -443,7 +434,7 @@ describe("useWebGLChart", () => {
     expect(followed?.xMax).toBeGreaterThan(reset?.xMax ?? 0);
   });
 
-  it("does not expose zoom interactions for heatmaps", () => {
+  it("exposes zoom interactions for heatmaps", () => {
     render(
       <HookHarness
         data={makeHeatmapData()}
@@ -456,13 +447,27 @@ describe("useWebGLChart", () => {
     const snapshotButton = screen.getByRole("button", { name: "Snapshot" });
 
     fireEvent.wheel(svg, { clientX: 170, clientY: 90, deltaY: -240 });
+    fireEvent.click(snapshotButton);
+    const zoomed = readSnapshot();
+    expect(zoomed?.type).toBe("heatmap");
+    expect(zoomed?.zoomState?.scaleX).toBeGreaterThan(1);
+    expect(zoomed?.zoomState?.scaleY).toBeGreaterThan(1);
+
     fireEvent.dblClick(svg, { clientX: 170, clientY: 90 });
     fireEvent.click(snapshotButton);
 
     expect(readSnapshot()).toEqual({
       type: "heatmap",
-      xCategories: [0, 1],
-      yCategories: [0, 1],
+      xMin: -0.5,
+      xMax: 1.5,
+      yMin: -0.5,
+      yMax: 1.5,
+      zoomState: {
+        scaleX: 1,
+        scaleY: 1,
+        translateX: 0,
+        translateY: 0,
+      },
     });
   });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -261,8 +261,7 @@ export function useWebGLChart({
         r.numericLabelFormat,
       );
     } else if (rs.type === "heatmap" && currentData.type === "heatmap") {
-      const layout = deriveHeatmapLayout(currentData.series);
-      const bounds = r.viewBounds ?? layout.bounds;
+      const bounds = r.viewBounds ?? rs.state.bounds;
       const { finalMatrix, zoomedXScale, zoomedYScale, overlayTheme } =
         buildZoomedAxes(canvas, margin, bounds, r.zoomState, r.theme);
 
@@ -280,12 +279,12 @@ export function useWebGLChart({
         {
           showGrid: false,
           xTickValues:
-            layout.centers.xValues.length <= 10
-              ? layout.centers.xValues
+            rs.state.centers.xValues.length <= 10
+              ? rs.state.centers.xValues
               : undefined,
           yTickValues:
-            layout.centers.yValues.length <= 10
-              ? layout.centers.yValues
+            rs.state.centers.yValues.length <= 10
+              ? rs.state.centers.yValues
               : undefined,
         },
       );
@@ -608,17 +607,21 @@ export function useWebGLChart({
       };
     }
     if (currentData.type === "heatmap") {
-      const geometry =
+      const cachedState =
         chartRef.current.renderState?.type === "heatmap"
-          ? chartRef.current.renderState.state.geometry
-          : deriveHeatmapLayout(currentData.series).geometry;
+          ? chartRef.current.renderState.state
+          : null;
+      const layout = cachedState
+        ? null
+        : deriveHeatmapLayout(currentData.series);
       return {
         type: "heatmap" as const,
         ...(chartRef.current.viewBounds ??
-          deriveHeatmapLayout(currentData.series).bounds),
+          cachedState?.bounds ??
+          layout!.bounds),
         margin,
         zoomState: chartRef.current.zoomState,
-        geometry,
+        geometry: cachedState?.geometry ?? layout!.geometry,
       };
     }
 

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useRef, useCallback } from "react";
-import { scaleLinear, scaleBand } from "d3-scale";
+import { scaleLinear } from "d3-scale";
 import { select } from "d3-selection";
 import {
   xyDrawStyleIncludesLine,
@@ -30,7 +30,6 @@ import {
 } from "../rendering/webgl";
 import {
   renderAxes,
-  renderCategoryAxes,
   renderColorScale,
   getOverlayTheme,
 } from "../rendering/d3Overlay";
@@ -69,6 +68,11 @@ import {
   COLOR_RAMP,
   type HeatmapRenderState,
 } from "../rendering/heatmapRenderer";
+import {
+  buildHeatmapGeometry,
+  heatmapDataBounds,
+  type HeatmapGeometry,
+} from "../rendering/heatmapGeometry";
 
 type RenderState =
   | {
@@ -132,9 +136,13 @@ export type ChartInteractionState =
     }
   | {
       type: "heatmap";
-      xCategories: number[];
-      yCategories: number[];
+      xMin: number;
+      xMax: number;
+      yMin: number;
+      yMax: number;
       margin: ChartMargin;
+      zoomState: ZoomState;
+      geometry: HeatmapGeometry;
     };
 
 export function useWebGLChart({
@@ -254,32 +262,22 @@ export function useWebGLChart({
         r.numericLabelFormat,
       );
     } else if (rs.type === "heatmap" && currentData.type === "heatmap") {
-      const numCols = currentData.xCategories.length;
-      const numRows = currentData.yCategories.length;
+      const bounds = r.viewBounds ?? heatmapDataBounds(currentData.series);
+      const { finalMatrix, zoomedXScale, zoomedYScale, overlayTheme } =
+        buildZoomedAxes(canvas, margin, bounds, r.zoomState, r.theme);
 
-      // For heatmap, we render fullscreen in the viewport (no zoom for now)
-      drawHeatmap(gl, rs.state, numCols, numRows);
+      drawHeatmap(gl, rs.state, finalMatrix);
 
-      const overlayTheme = getOverlayTheme(r.theme);
-      const chartW = canvas.clientWidth - margin.left - margin.right;
-      const chartH = canvas.clientHeight - margin.top - margin.bottom;
-      const xScale = scaleBand<string | number>()
-        .domain(currentData.xCategories)
-        .range([0, chartW])
-        .padding(0);
-      const yScale = scaleBand<string | number>()
-        .domain(currentData.yCategories)
-        .range([chartH, 0])
-        .padding(0);
-      renderCategoryAxes(
+      renderAxes(
         svgEl,
-        xScale,
-        yScale,
+        zoomedXScale,
+        zoomedYScale,
         currentData.xName,
         currentData.yName,
         margin,
         overlayTheme,
         r.numericLabelFormat,
+        { showGrid: false },
       );
       renderColorScale(
         svgEl,
@@ -451,8 +449,7 @@ export function useWebGLChart({
     const currentRefs = chartRef.current;
     const svgEl = svgRef.current;
     const canvas = canvasRef.current;
-    if (!svgEl || !canvas || !data || data.type === "heatmap") {
-      // No zoom for heatmap
+    if (!svgEl || !canvas || !data) {
       currentRefs.crosshairController?.destroy();
       currentRefs.crosshairController = null;
       currentRefs.zoomController?.destroy();
@@ -460,7 +457,7 @@ export function useWebGLChart({
       return;
     }
 
-    const margin = DEFAULT_MARGIN;
+    const margin = data.type === "heatmap" ? HEATMAP_MARGIN : DEFAULT_MARGIN;
     const chartW = canvas.clientWidth - margin.left - margin.right;
     const chartH = canvas.clientHeight - margin.top - margin.bottom;
 
@@ -518,9 +515,10 @@ export function useWebGLChart({
     // Crosshair overlay
     const crosshair = attachCrosshair(svgEl, () => {
       const d = currentRefs.data;
-      if (!d || d.type === "heatmap") return null;
+      if (!d) return null;
 
-      const bounds = currentRefs.viewBounds ?? lineDataBounds(d.series);
+      const bounds = currentRefs.viewBounds ?? getNumericBounds(d);
+      if (!bounds) return null;
 
       return {
         margin,
@@ -563,7 +561,10 @@ export function useWebGLChart({
       // Update zoom translate extents so pan/zoom clamps match the new size
       const currentRefs = chartRef.current;
       if (currentRefs.zoomController) {
-        const margin = DEFAULT_MARGIN;
+        const margin =
+          currentRefs.data?.type === "heatmap"
+            ? HEATMAP_MARGIN
+            : DEFAULT_MARGIN;
         const chartW = canvas.clientWidth - margin.left - margin.right;
         const chartH = canvas.clientHeight - margin.top - margin.bottom;
         currentRefs.zoomController.updateExtents(chartW, chartH, margin);
@@ -597,11 +598,17 @@ export function useWebGLChart({
       };
     }
     if (currentData.type === "heatmap") {
+      const geometry =
+        chartRef.current.renderState?.type === "heatmap"
+          ? chartRef.current.renderState.state.geometry
+          : buildHeatmapGeometry(currentData.series);
       return {
         type: "heatmap" as const,
-        xCategories: currentData.xCategories,
-        yCategories: currentData.yCategories,
+        ...(chartRef.current.viewBounds ??
+          heatmapDataBounds(currentData.series)),
         margin,
+        zoomState: chartRef.current.zoomState,
+        geometry,
       };
     }
 
@@ -657,7 +664,7 @@ function resolveNextZoomState({
 }: ResolveNextZoomStateArgs): ZoomState {
   const nextDefaultZoom = getDefaultZoomState();
 
-  if (!data || data.type === "heatmap") {
+  if (!data) {
     return nextDefaultZoom;
   }
 
@@ -673,7 +680,7 @@ function resolveNextViewBounds({
   followsDefaultView,
   previousViewBounds,
 }: ResolveNextViewBoundsArgs): NumericBounds | null {
-  if (!data || data.type === "heatmap") {
+  if (!data) {
     return null;
   }
 
@@ -687,8 +694,10 @@ function resolveNextViewBounds({
 function getNumericBounds(
   data: ChartOptions | undefined,
 ): NumericBounds | null {
-  if (!data || data.type === "heatmap") return null;
-  return lineDataBounds(data.series);
+  if (!data) return null;
+  return data.type === "heatmap"
+    ? heatmapDataBounds(data.series)
+    : lineDataBounds(data.series);
 }
 
 function createRenderStateCache(): RenderStateCache {

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -70,6 +70,7 @@ import {
 } from "../rendering/heatmapRenderer";
 import {
   buildHeatmapGeometry,
+  heatmapAxisCenters,
   heatmapDataBounds,
   type HeatmapGeometry,
 } from "../rendering/heatmapGeometry";
@@ -263,6 +264,7 @@ export function useWebGLChart({
       );
     } else if (rs.type === "heatmap" && currentData.type === "heatmap") {
       const bounds = r.viewBounds ?? heatmapDataBounds(currentData.series);
+      const axisCenters = heatmapAxisCenters(currentData.series);
       const { finalMatrix, zoomedXScale, zoomedYScale, overlayTheme } =
         buildZoomedAxes(canvas, margin, bounds, r.zoomState, r.theme);
 
@@ -277,7 +279,13 @@ export function useWebGLChart({
         margin,
         overlayTheme,
         r.numericLabelFormat,
-        { showGrid: false },
+        {
+          showGrid: false,
+          xTickValues:
+            axisCenters.xValues.length <= 10 ? axisCenters.xValues : undefined,
+          yTickValues:
+            axisCenters.yValues.length <= 10 ? axisCenters.yValues : undefined,
+        },
       );
       renderColorScale(
         svgEl,

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -69,9 +69,7 @@ import {
   type HeatmapRenderState,
 } from "../rendering/heatmapRenderer";
 import {
-  buildHeatmapGeometry,
-  heatmapAxisCenters,
-  heatmapDataBounds,
+  deriveHeatmapLayout,
   type HeatmapGeometry,
 } from "../rendering/heatmapGeometry";
 
@@ -263,8 +261,8 @@ export function useWebGLChart({
         r.numericLabelFormat,
       );
     } else if (rs.type === "heatmap" && currentData.type === "heatmap") {
-      const bounds = r.viewBounds ?? heatmapDataBounds(currentData.series);
-      const axisCenters = heatmapAxisCenters(currentData.series);
+      const layout = deriveHeatmapLayout(currentData.series);
+      const bounds = r.viewBounds ?? layout.bounds;
       const { finalMatrix, zoomedXScale, zoomedYScale, overlayTheme } =
         buildZoomedAxes(canvas, margin, bounds, r.zoomState, r.theme);
 
@@ -282,9 +280,13 @@ export function useWebGLChart({
         {
           showGrid: false,
           xTickValues:
-            axisCenters.xValues.length <= 10 ? axisCenters.xValues : undefined,
+            layout.centers.xValues.length <= 10
+              ? layout.centers.xValues
+              : undefined,
           yTickValues:
-            axisCenters.yValues.length <= 10 ? axisCenters.yValues : undefined,
+            layout.centers.yValues.length <= 10
+              ? layout.centers.yValues
+              : undefined,
         },
       );
       renderColorScale(
@@ -609,11 +611,11 @@ export function useWebGLChart({
       const geometry =
         chartRef.current.renderState?.type === "heatmap"
           ? chartRef.current.renderState.state.geometry
-          : buildHeatmapGeometry(currentData.series);
+          : deriveHeatmapLayout(currentData.series).geometry;
       return {
         type: "heatmap" as const,
         ...(chartRef.current.viewBounds ??
-          heatmapDataBounds(currentData.series)),
+          deriveHeatmapLayout(currentData.series).bounds),
         margin,
         zoomState: chartRef.current.zoomState,
         geometry,
@@ -704,7 +706,7 @@ function getNumericBounds(
 ): NumericBounds | null {
   if (!data) return null;
   return data.type === "heatmap"
-    ? heatmapDataBounds(data.series)
+    ? deriveHeatmapLayout(data.series).bounds
     : lineDataBounds(data.series);
 }
 

--- a/crates/fricon-ui/frontend/src/features/charts/model/liveChartModel.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/liveChartModel.ts
@@ -56,10 +56,6 @@ function appendToChart(
 
   const series = chart.series.map((item) => ({ ...item }));
   for (const operation of update.ops) {
-    if (operation.kind === "append_heatmap_categories") {
-      return null;
-    }
-
     if (operation.kind === "append_points") {
       const target = series.find((item) => item.id === operation.seriesId);
       if (!target) return null;
@@ -83,20 +79,8 @@ function appendToHeatmap(
   update: Extract<LiveChartUpdate, { mode: "append" }>,
 ): ChartModel | null {
   const series = chart.series.map((item) => ({ ...item }));
-  let xCategories = chart.xCategories;
-  let yCategories = chart.yCategories;
 
   for (const operation of update.ops) {
-    if (operation.kind === "append_heatmap_categories") {
-      xCategories = operation.xCategories
-        ? [...xCategories, ...operation.xCategories]
-        : xCategories;
-      yCategories = operation.yCategories
-        ? [...yCategories, ...operation.yCategories]
-        : yCategories;
-      continue;
-    }
-
     if (operation.kind === "append_points") {
       const target = series.find((item) => item.id === operation.seriesId);
       if (!target) return null;
@@ -114,8 +98,6 @@ function appendToHeatmap(
 
   return {
     ...chart,
-    xCategories,
-    yCategories,
     series,
   };
 }

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/d3Overlay.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/d3Overlay.test.ts
@@ -126,6 +126,43 @@ describe("renderColorScale", () => {
     expect(labels).toContain("2k");
   });
 
+  it("renders requested numeric tick values for heatmap center labels", () => {
+    const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    document.body.appendChild(svgEl);
+    Object.defineProperty(svgEl, "clientWidth", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(svgEl, "clientHeight", {
+      configurable: true,
+      value: 220,
+    });
+
+    renderAxes(
+      svgEl,
+      scaleLinear().domain([5, 50]).range([0, 100]),
+      scaleLinear().domain([110, 320]).range([100, 0]),
+      "x",
+      "y",
+      margin,
+      LIGHT_THEME,
+      DEFAULT_NUMERIC_LABEL_FORMAT,
+      {
+        showGrid: false,
+        xTickValues: [7, 19, 46],
+        yTickValues: [120, 185, 310],
+      },
+    );
+
+    const axisLabels = Array.from(
+      svgEl.querySelectorAll(".axes .tick text"),
+    ).map((node) => node.textContent);
+
+    expect(axisLabels).toEqual(
+      expect.arrayContaining(["7", "19", "46", "120", "185", "310"]),
+    );
+  });
+
   it("formats heatmap color scale labels with scientific notation", () => {
     const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     document.body.appendChild(svgEl);

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/d3Overlay.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/d3Overlay.ts
@@ -54,6 +54,8 @@ export function renderAxes(
   options?: {
     gridSvgEl?: SVGSVGElement | null;
     showGrid?: boolean;
+    xTickValues?: number[];
+    yTickValues?: number[];
   },
 ): void {
   const svg = select(svgEl);
@@ -71,6 +73,8 @@ export function renderAxes(
 
   const gridSvgEl = options?.gridSvgEl ?? null;
   const showGrid = options?.showGrid ?? true;
+  const xTickValues = options?.xTickValues;
+  const yTickValues = options?.yTickValues;
   const gridContainer = gridSvgEl ? select(gridSvgEl) : svg;
   clearGridOverlayLayers(gridContainer);
   const gridGroup = showGrid
@@ -84,6 +88,9 @@ export function renderAxes(
   const xAxis = axisBottom(xScale.range([0, chartWidth])).ticks(
     Math.max(2, Math.floor(chartWidth / 80)),
   );
+  if (xTickValues) {
+    xAxis.tickValues(xTickValues);
+  }
   xAxis.tickFormat((value) =>
     formatAxisTickLabel(value as number, numericLabelFormat),
   );
@@ -101,12 +108,16 @@ export function renderAxes(
   gridGroup
     ?.append("g")
     .attr("class", "grid")
-    .call(
-      axisBottom(xScale.range([0, chartWidth]))
+    .call((gridAxisGroup) => {
+      const gridAxis = axisBottom(xScale.range([0, chartWidth]))
         .ticks(Math.max(2, Math.floor(chartWidth / 80)))
         .tickSize(-chartHeight)
-        .tickFormat(() => ""),
-    )
+        .tickFormat(() => "");
+      if (xTickValues) {
+        gridAxis.tickValues(xTickValues);
+      }
+      gridAxisGroup.call(gridAxis);
+    })
     .attr("transform", `translate(0,${chartHeight})`)
     .call((g) => {
       g.selectAll("line")
@@ -119,6 +130,9 @@ export function renderAxes(
   const yAxis = axisLeft(yScale.range([chartHeight, 0])).ticks(
     Math.max(2, Math.floor(chartHeight / 50)),
   );
+  if (yTickValues) {
+    yAxis.tickValues(yTickValues);
+  }
   yAxis.tickFormat((value) =>
     formatAxisTickLabel(value as number, numericLabelFormat),
   );
@@ -135,12 +149,16 @@ export function renderAxes(
   gridGroup
     ?.append("g")
     .attr("class", "grid")
-    .call(
-      axisLeft(yScale.range([chartHeight, 0]))
+    .call((gridAxisGroup) => {
+      const gridAxis = axisLeft(yScale.range([chartHeight, 0]))
         .ticks(Math.max(2, Math.floor(chartHeight / 50)))
         .tickSize(-chartWidth)
-        .tickFormat(() => ""),
-    )
+        .tickFormat(() => "");
+      if (yTickValues) {
+        gridAxis.tickValues(yTickValues);
+      }
+      gridAxisGroup.call(gridAxis);
+    })
     .call((g) => {
       g.selectAll("line")
         .attr("stroke", theme.gridColor)

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/d3Overlay.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/d3Overlay.ts
@@ -51,6 +51,10 @@ export function renderAxes(
   margin: ChartMargin,
   theme: OverlayTheme,
   numericLabelFormat: NumericLabelFormatOptions,
+  options?: {
+    gridSvgEl?: SVGSVGElement | null;
+    showGrid?: boolean;
+  },
 ): void {
   const svg = select(svgEl);
   const width = svgEl.clientWidth;
@@ -58,12 +62,23 @@ export function renderAxes(
   const chartWidth = width - margin.left - margin.right;
   const chartHeight = height - margin.top - margin.bottom;
 
-  clearOverlayLayers(svg);
+  clearForegroundOverlayLayers(svg);
 
   const g = svg
     .append("g")
     .attr("class", "axes")
     .attr("transform", `translate(${margin.left},${margin.top})`);
+
+  const gridSvgEl = options?.gridSvgEl ?? null;
+  const showGrid = options?.showGrid ?? true;
+  const gridContainer = gridSvgEl ? select(gridSvgEl) : svg;
+  clearGridOverlayLayers(gridContainer);
+  const gridGroup = showGrid
+    ? gridContainer
+        .append("g")
+        .attr("class", "grid-layer")
+        .attr("transform", `translate(${margin.left},${margin.top})`)
+    : null;
 
   // X axis
   const xAxis = axisBottom(xScale.range([0, chartWidth])).ticks(
@@ -83,7 +98,8 @@ export function renderAxes(
     });
 
   // X grid lines
-  g.append("g")
+  gridGroup
+    ?.append("g")
     .attr("class", "grid")
     .call(
       axisBottom(xScale.range([0, chartWidth]))
@@ -116,7 +132,8 @@ export function renderAxes(
     });
 
   // Y grid lines
-  g.append("g")
+  gridGroup
+    ?.append("g")
     .attr("class", "grid")
     .call(
       axisLeft(yScale.range([chartHeight, 0]))
@@ -327,5 +344,17 @@ export function renderColorScale(
 function clearOverlayLayers(
   svg: Selection<SVGSVGElement, unknown, null, undefined>,
 ): void {
+  svg.selectAll(".axes, .color-scale, .grid-layer").remove();
+}
+
+function clearForegroundOverlayLayers(
+  svg: Selection<SVGSVGElement, unknown, null, undefined>,
+): void {
   svg.selectAll(".axes, .color-scale").remove();
+}
+
+function clearGridOverlayLayers(
+  svg: Selection<SVGSVGElement, unknown, null, undefined>,
+): void {
+  svg.selectAll(".grid-layer").remove();
 }

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
@@ -90,6 +90,26 @@ export function heatmapDataBounds(series: HeatmapSeries[]) {
   };
 }
 
+export function heatmapAxisCenters(series: HeatmapSeries[]) {
+  const validPoints = series.flatMap((item) =>
+    readSeriesPoints(item).filter(
+      (point) =>
+        Number.isFinite(point.x) &&
+        Number.isFinite(point.y) &&
+        Number.isFinite(point.z),
+    ),
+  );
+
+  return {
+    xValues: Array.from(new Set(validPoints.map((point) => point.x))).sort(
+      (left, right) => left - right,
+    ),
+    yValues: Array.from(new Set(validPoints.map((point) => point.y))).sort(
+      (left, right) => left - right,
+    ),
+  };
+}
+
 interface SeriesPoint {
   x: number;
   y: number;

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
@@ -1,0 +1,158 @@
+import type { HeatmapSeries } from "@/shared/lib/chartTypes";
+
+export interface HeatmapCellGeometry {
+  x: number;
+  y: number;
+  z: number;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+}
+
+export interface HeatmapSeriesGeometry {
+  seriesId: string;
+  cells: HeatmapCellGeometry[];
+}
+
+export interface HeatmapGeometry {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  series: HeatmapSeriesGeometry[];
+}
+
+export const EMPTY_HEATMAP_GEOMETRY: HeatmapGeometry = {
+  xMin: 0,
+  xMax: 1,
+  yMin: 0,
+  yMax: 1,
+  series: [],
+};
+
+export function buildHeatmapGeometry(series: HeatmapSeries[]): HeatmapGeometry {
+  const validPoints = series.flatMap((item) =>
+    readSeriesPoints(item).filter(
+      (point) =>
+        Number.isFinite(point.x) &&
+        Number.isFinite(point.y) &&
+        Number.isFinite(point.z),
+    ),
+  );
+
+  const xBounds = buildAxisBounds(validPoints.map((point) => point.x));
+  const yBounds = buildAxisBounds(validPoints.map((point) => point.y));
+
+  if (xBounds.spanByValue.size === 0 || yBounds.spanByValue.size === 0) {
+    return EMPTY_HEATMAP_GEOMETRY;
+  }
+
+  return {
+    xMin: xBounds.min,
+    xMax: xBounds.max,
+    yMin: yBounds.min,
+    yMax: yBounds.max,
+    series: series.map((item) => ({
+      seriesId: item.id,
+      cells: readSeriesPoints(item)
+        .filter(
+          (point) =>
+            Number.isFinite(point.x) &&
+            Number.isFinite(point.y) &&
+            Number.isFinite(point.z),
+        )
+        .flatMap((point) => {
+          const xSpan = xBounds.spanByValue.get(point.x);
+          const ySpan = yBounds.spanByValue.get(point.y);
+          if (!xSpan || !ySpan) return [];
+          return [
+            {
+              ...point,
+              x0: xSpan[0],
+              x1: xSpan[1],
+              y0: ySpan[0],
+              y1: ySpan[1],
+            },
+          ];
+        }),
+    })),
+  };
+}
+
+export function heatmapDataBounds(series: HeatmapSeries[]) {
+  const geometry = buildHeatmapGeometry(series);
+  return {
+    xMin: geometry.xMin,
+    xMax: geometry.xMax,
+    yMin: geometry.yMin,
+    yMax: geometry.yMax,
+  };
+}
+
+interface SeriesPoint {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface AxisBounds {
+  min: number;
+  max: number;
+  spanByValue: Map<number, [number, number]>;
+}
+
+function readSeriesPoints(series: HeatmapSeries): SeriesPoint[] {
+  const points: SeriesPoint[] = [];
+  for (let i = 0; i < series.pointCount; i++) {
+    const offset = i * 3;
+    points.push({
+      x: series.values[offset] ?? 0,
+      y: series.values[offset + 1] ?? 0,
+      z: series.values[offset + 2] ?? 0,
+    });
+  }
+  return points;
+}
+
+function buildAxisBounds(values: number[]): AxisBounds {
+  const unique = Array.from(new Set(values)).sort(
+    (left, right) => left - right,
+  );
+  if (unique.length === 0) {
+    return {
+      min: 0,
+      max: 1,
+      spanByValue: new Map(),
+    };
+  }
+
+  if (unique.length === 1) {
+    const center = unique[0];
+    return {
+      min: center - 0.5,
+      max: center + 0.5,
+      spanByValue: new Map([[center, [center - 0.5, center + 0.5]]]),
+    };
+  }
+
+  const edges = new Array<number>(unique.length + 1);
+  edges[0] = unique[0] - (unique[1] - unique[0]) / 2;
+  for (let i = 1; i < unique.length; i++) {
+    edges[i] = (unique[i - 1] + unique[i]) / 2;
+  }
+  edges[unique.length] =
+    unique[unique.length - 1] +
+    (unique[unique.length - 1] - unique[unique.length - 2]) / 2;
+
+  const spanByValue = new Map<number, [number, number]>();
+  for (let i = 0; i < unique.length; i++) {
+    spanByValue.set(unique[i], [edges[i], edges[i + 1]]);
+  }
+
+  return {
+    min: edges[0],
+    max: edges[edges.length - 1],
+    spanByValue,
+  };
+}

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
@@ -53,21 +53,18 @@ const EMPTY_HEATMAP_AXIS_CENTERS: HeatmapAxisCenters = {
 };
 
 export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
-  const validPoints = series.flatMap((item) =>
+  const coordinatePoints = series.flatMap((item) =>
     readSeriesPoints(item).filter(
-      (point) =>
-        Number.isFinite(point.x) &&
-        Number.isFinite(point.y) &&
-        Number.isFinite(point.z),
+      (point) => Number.isFinite(point.x) && Number.isFinite(point.y),
     ),
   );
 
-  const xValues = Array.from(new Set(validPoints.map((point) => point.x))).sort(
-    (left, right) => left - right,
-  );
-  const yValues = Array.from(new Set(validPoints.map((point) => point.y))).sort(
-    (left, right) => left - right,
-  );
+  const xValues = Array.from(
+    new Set(coordinatePoints.map((point) => point.x)),
+  ).sort((left, right) => left - right);
+  const yValues = Array.from(
+    new Set(coordinatePoints.map((point) => point.y)),
+  ).sort((left, right) => left - right);
   const xBounds = buildAxisBounds(xValues);
   const yBounds = buildAxisBounds(yValues);
 

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
@@ -23,6 +23,22 @@ export interface HeatmapGeometry {
   series: HeatmapSeriesGeometry[];
 }
 
+export interface HeatmapAxisCenters {
+  xValues: number[];
+  yValues: number[];
+}
+
+export interface HeatmapLayout {
+  geometry: HeatmapGeometry;
+  bounds: {
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+  };
+  centers: HeatmapAxisCenters;
+}
+
 export const EMPTY_HEATMAP_GEOMETRY: HeatmapGeometry = {
   xMin: 0,
   xMax: 1,
@@ -31,7 +47,12 @@ export const EMPTY_HEATMAP_GEOMETRY: HeatmapGeometry = {
   series: [],
 };
 
-export function buildHeatmapGeometry(series: HeatmapSeries[]): HeatmapGeometry {
+const EMPTY_HEATMAP_AXIS_CENTERS: HeatmapAxisCenters = {
+  xValues: [],
+  yValues: [],
+};
+
+export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
   const validPoints = series.flatMap((item) =>
     readSeriesPoints(item).filter(
       (point) =>
@@ -41,14 +62,29 @@ export function buildHeatmapGeometry(series: HeatmapSeries[]): HeatmapGeometry {
     ),
   );
 
-  const xBounds = buildAxisBounds(validPoints.map((point) => point.x));
-  const yBounds = buildAxisBounds(validPoints.map((point) => point.y));
+  const xValues = Array.from(new Set(validPoints.map((point) => point.x))).sort(
+    (left, right) => left - right,
+  );
+  const yValues = Array.from(new Set(validPoints.map((point) => point.y))).sort(
+    (left, right) => left - right,
+  );
+  const xBounds = buildAxisBounds(xValues);
+  const yBounds = buildAxisBounds(yValues);
 
   if (xBounds.spanByValue.size === 0 || yBounds.spanByValue.size === 0) {
-    return EMPTY_HEATMAP_GEOMETRY;
+    return {
+      geometry: EMPTY_HEATMAP_GEOMETRY,
+      bounds: {
+        xMin: EMPTY_HEATMAP_GEOMETRY.xMin,
+        xMax: EMPTY_HEATMAP_GEOMETRY.xMax,
+        yMin: EMPTY_HEATMAP_GEOMETRY.yMin,
+        yMax: EMPTY_HEATMAP_GEOMETRY.yMax,
+      },
+      centers: EMPTY_HEATMAP_AXIS_CENTERS,
+    };
   }
 
-  return {
+  const geometry = {
     xMin: xBounds.min,
     xMax: xBounds.max,
     yMin: yBounds.min,
@@ -78,35 +114,19 @@ export function buildHeatmapGeometry(series: HeatmapSeries[]): HeatmapGeometry {
         }),
     })),
   };
-}
-
-export function heatmapDataBounds(series: HeatmapSeries[]) {
-  const geometry = buildHeatmapGeometry(series);
-  return {
-    xMin: geometry.xMin,
-    xMax: geometry.xMax,
-    yMin: geometry.yMin,
-    yMax: geometry.yMax,
-  };
-}
-
-export function heatmapAxisCenters(series: HeatmapSeries[]) {
-  const validPoints = series.flatMap((item) =>
-    readSeriesPoints(item).filter(
-      (point) =>
-        Number.isFinite(point.x) &&
-        Number.isFinite(point.y) &&
-        Number.isFinite(point.z),
-    ),
-  );
 
   return {
-    xValues: Array.from(new Set(validPoints.map((point) => point.x))).sort(
-      (left, right) => left - right,
-    ),
-    yValues: Array.from(new Set(validPoints.map((point) => point.y))).sort(
-      (left, right) => left - right,
-    ),
+    geometry,
+    bounds: {
+      xMin: geometry.xMin,
+      xMax: geometry.xMax,
+      yMin: geometry.yMin,
+      yMax: geometry.yMax,
+    },
+    centers: {
+      xValues,
+      yValues,
+    },
   };
 }
 

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
@@ -7,7 +7,7 @@
 import type { HeatmapSeries } from "@/shared/lib/chartTypes";
 import { createBuffer, createProgram, hexToRgb } from "./webgl";
 import {
-  buildHeatmapGeometry,
+  deriveHeatmapLayout,
   EMPTY_HEATMAP_GEOMETRY,
   type HeatmapGeometry,
 } from "./heatmapGeometry";
@@ -97,7 +97,7 @@ export function syncHeatmapRenderState(
   state: HeatmapRenderState,
   series: HeatmapSeries[],
 ): void {
-  const geometry = buildHeatmapGeometry(series);
+  const { geometry } = deriveHeatmapLayout(series);
   const { valueMin, valueMax, instanceData } = buildHeatmapInstances(geometry);
   gl.bindBuffer(gl.ARRAY_BUFFER, state.cellBuffer);
   if (

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
@@ -1,11 +1,16 @@
 /**
  * Heatmap renderer — draws a heatmap using instanced quads.
- * Each cell is an instance with position (col, row) and a normalized value
- * that maps to a 5-stop color ramp matching the previous ECharts palette.
+ * Each cell is an instance with numeric bounds and a normalized value that
+ * maps to a 5-stop color ramp matching the previous ECharts palette.
  */
 
 import type { HeatmapSeries } from "@/shared/lib/chartTypes";
 import { createBuffer, createProgram, hexToRgb } from "./webgl";
+import {
+  buildHeatmapGeometry,
+  EMPTY_HEATMAP_GEOMETRY,
+  type HeatmapGeometry,
+} from "./heatmapGeometry";
 import { heatmapFragmentSource, heatmapVertexSource } from "./shaders/heatmap";
 
 export const COLOR_RAMP = [
@@ -23,6 +28,7 @@ export interface HeatmapRenderState {
   instanceCount: number;
   capacity: number;
   instanceData: Float64Array;
+  geometry: HeatmapGeometry;
   vao: WebGLVertexArrayObject;
   valueMin: number;
   valueMax: number;
@@ -58,10 +64,15 @@ export function createHeatmapRenderState(
 
   // Cell buffer (per-instance)
   const cellBuffer = createBuffer(gl, new Float32Array(0), gl.DYNAMIC_DRAW);
-  const aCell = gl.getAttribLocation(program, "a_cell");
-  gl.enableVertexAttribArray(aCell);
-  gl.vertexAttribPointer(aCell, 3, gl.FLOAT, false, 0, 0);
-  gl.vertexAttribDivisor(aCell, 1); // per-instance
+  const aRect = gl.getAttribLocation(program, "a_rect");
+  gl.enableVertexAttribArray(aRect);
+  gl.vertexAttribPointer(aRect, 4, gl.FLOAT, false, 20, 0);
+  gl.vertexAttribDivisor(aRect, 1); // per-instance
+
+  const aValue = gl.getAttribLocation(program, "a_value");
+  gl.enableVertexAttribArray(aValue);
+  gl.vertexAttribPointer(aValue, 1, gl.FLOAT, false, 20, 16);
+  gl.vertexAttribDivisor(aValue, 1); // per-instance
 
   gl.bindVertexArray(null);
 
@@ -72,6 +83,7 @@ export function createHeatmapRenderState(
     instanceCount: 0,
     capacity: 0,
     instanceData: new Float64Array(0),
+    geometry: EMPTY_HEATMAP_GEOMETRY,
     vao,
     valueMin: 0,
     valueMax: 1,
@@ -85,7 +97,8 @@ export function syncHeatmapRenderState(
   state: HeatmapRenderState,
   series: HeatmapSeries[],
 ): void {
-  const { valueMin, valueMax, instanceData } = buildHeatmapInstances(series);
+  const geometry = buildHeatmapGeometry(series);
+  const { valueMin, valueMax, instanceData } = buildHeatmapInstances(geometry);
   gl.bindBuffer(gl.ARRAY_BUFFER, state.cellBuffer);
   if (
     instanceData.length >= state.instanceData.length &&
@@ -117,8 +130,9 @@ export function syncHeatmapRenderState(
     }
     gl.bufferSubData(gl.ARRAY_BUFFER, 0, toFloat32Array(instanceData));
   }
-  state.instanceCount = instanceData.length / 3;
+  state.instanceCount = instanceData.length / 5;
   state.instanceData = instanceData;
+  state.geometry = geometry;
   state.valueMin = valueMin;
   state.valueMax = valueMax;
 }
@@ -126,21 +140,10 @@ export function syncHeatmapRenderState(
 export function drawHeatmap(
   gl: WebGL2RenderingContext,
   state: HeatmapRenderState,
-  numCols: number,
-  numRows: number,
+  matrix: Float32Array,
 ): void {
   const { program, vao, instanceCount, uMatrix, uColorRamp } = state;
   gl.useProgram(program);
-
-  // Build matrix that maps grid coords (0..numCols, 0..numRows) → clip space
-  const sx = numCols > 0 ? 2 / numCols : 1;
-  const sy = numRows > 0 ? 2 / numRows : 1;
-  // prettier-ignore
-  const matrix = new Float32Array([
-    sx, 0,  0,
-    0,  sy, 0,
-    -1, -1, 1,
-  ]);
 
   gl.uniformMatrix3fv(uMatrix, false, matrix);
 
@@ -169,17 +172,16 @@ export function destroyHeatmapRenderState(
   gl.deleteProgram(state.program);
 }
 
-function buildHeatmapInstances(series: HeatmapSeries[]): {
+function buildHeatmapInstances(geometry: HeatmapGeometry): {
   valueMin: number;
   valueMax: number;
   instanceData: Float64Array;
 } {
   let min = Infinity;
   let max = -Infinity;
-  for (const s of series) {
-    for (let i = 0; i < s.values.length; i += 3) {
-      const cellValue = s.values[i + 2];
-      if (cellValue === undefined || !Number.isFinite(cellValue)) continue;
+  for (const item of geometry.series) {
+    for (const cell of item.cells) {
+      const cellValue = cell.z;
       if (cellValue < min) min = cellValue;
       if (cellValue > max) max = cellValue;
     }
@@ -189,11 +191,15 @@ function buildHeatmapInstances(series: HeatmapSeries[]): {
   const range = max !== min ? max - min : 1;
 
   const instances: number[] = [];
-  for (const s of series) {
-    for (let i = 0; i < s.values.length; i += 3) {
-      const value = s.values[i + 2];
-      if (value === undefined || !Number.isFinite(value)) continue;
-      instances.push(s.values[i], s.values[i + 1], (value - min) / range);
+  for (const item of geometry.series) {
+    for (const cell of item.cells) {
+      instances.push(
+        cell.x0,
+        cell.y0,
+        cell.x1,
+        cell.y1,
+        (cell.z - min) / range,
+      );
     }
   }
 

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
@@ -9,6 +9,7 @@ import { createBuffer, createProgram, hexToRgb } from "./webgl";
 import {
   deriveHeatmapLayout,
   EMPTY_HEATMAP_GEOMETRY,
+  type HeatmapAxisCenters,
   type HeatmapGeometry,
 } from "./heatmapGeometry";
 import { heatmapFragmentSource, heatmapVertexSource } from "./shaders/heatmap";
@@ -28,6 +29,13 @@ export interface HeatmapRenderState {
   instanceCount: number;
   capacity: number;
   instanceData: Float64Array;
+  bounds: {
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+  };
+  centers: HeatmapAxisCenters;
   geometry: HeatmapGeometry;
   vao: WebGLVertexArrayObject;
   valueMin: number;
@@ -83,6 +91,16 @@ export function createHeatmapRenderState(
     instanceCount: 0,
     capacity: 0,
     instanceData: new Float64Array(0),
+    bounds: {
+      xMin: EMPTY_HEATMAP_GEOMETRY.xMin,
+      xMax: EMPTY_HEATMAP_GEOMETRY.xMax,
+      yMin: EMPTY_HEATMAP_GEOMETRY.yMin,
+      yMax: EMPTY_HEATMAP_GEOMETRY.yMax,
+    },
+    centers: {
+      xValues: [],
+      yValues: [],
+    },
     geometry: EMPTY_HEATMAP_GEOMETRY,
     vao,
     valueMin: 0,
@@ -97,7 +115,7 @@ export function syncHeatmapRenderState(
   state: HeatmapRenderState,
   series: HeatmapSeries[],
 ): void {
-  const { geometry } = deriveHeatmapLayout(series);
+  const { geometry, bounds, centers } = deriveHeatmapLayout(series);
   const { valueMin, valueMax, instanceData } = buildHeatmapInstances(geometry);
   gl.bindBuffer(gl.ARRAY_BUFFER, state.cellBuffer);
   if (
@@ -132,6 +150,8 @@ export function syncHeatmapRenderState(
   }
   state.instanceCount = instanceData.length / 5;
   state.instanceData = instanceData;
+  state.bounds = bounds;
+  state.centers = centers;
   state.geometry = geometry;
   state.valueMin = valueMin;
   state.valueMax = valueMax;

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./lineRenderer";
 import {
   buildHeatmapGeometry,
+  heatmapAxisCenters,
   heatmapDataBounds,
   EMPTY_HEATMAP_GEOMETRY,
 } from "./heatmapGeometry";
@@ -258,6 +259,22 @@ describe("syncHeatmapRenderState", () => {
           cells: [{ x: 7, y: 11, z: 5, x0: 6.5, x1: 7.5, y0: 10.5, y1: 11.5 }],
         },
       ],
+    });
+  });
+
+  it("returns sorted unique heatmap axis centers", () => {
+    expect(
+      heatmapAxisCenters([
+        xyzSeries("heat", "heat", [
+          [46, 310, 1],
+          [7, 120, 2],
+          [19, 185, 3],
+          [7, 310, 4],
+        ]),
+      ]),
+    ).toEqual({
+      xValues: [7, 19, 46],
+      yValues: [120, 185, 310],
     });
   });
 

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -273,15 +273,30 @@ describe("syncHeatmapRenderState", () => {
     });
   });
 
-  it("returns default bounds when there are no finite heatmap cells", () => {
+  it("preserves heatmap bounds for coordinates whose values are all NaN", () => {
     expect(
       deriveHeatmapLayout([xyzSeries("heat", "heat", [[0, 0, Number.NaN]])])
         .bounds,
     ).toEqual({
-      xMin: EMPTY_HEATMAP_GEOMETRY.xMin,
-      xMax: EMPTY_HEATMAP_GEOMETRY.xMax,
-      yMin: EMPTY_HEATMAP_GEOMETRY.yMin,
-      yMax: EMPTY_HEATMAP_GEOMETRY.yMax,
+      xMin: -0.5,
+      xMax: 0.5,
+      yMin: -0.5,
+      yMax: 0.5,
+    });
+  });
+
+  it("preserves NaN-only rows and columns in axis centers", () => {
+    expect(
+      deriveHeatmapLayout([
+        xyzSeries("heat", "heat", [
+          [0, 0, 1],
+          [1, 0, Number.NaN],
+          [0, 2, 3],
+        ]),
+      ]).centers,
+    ).toEqual({
+      xValues: [0, 1],
+      yValues: [0, 2],
     });
   });
 
@@ -321,7 +336,7 @@ describe("syncHeatmapRenderState", () => {
     expect(state.instanceCount).toBe(2);
     expect(state.geometry).toEqual({
       xMin: -0.5,
-      xMax: 0.5,
+      xMax: 1.5,
       yMin: -0.5,
       yMax: 1.5,
       series: [

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -316,6 +316,16 @@ describe("syncHeatmapRenderState", () => {
       instanceCount: 0,
       capacity: 0,
       instanceData: new Float64Array(0),
+      bounds: {
+        xMin: 0,
+        xMax: 1,
+        yMin: 0,
+        yMax: 1,
+      },
+      centers: {
+        xValues: [],
+        yValues: [],
+      },
       geometry: EMPTY_HEATMAP_GEOMETRY,
       valueMin: 0,
       valueMax: 0,
@@ -348,6 +358,16 @@ describe("syncHeatmapRenderState", () => {
           ],
         },
       ],
+    });
+    expect(state.bounds).toEqual({
+      xMin: -0.5,
+      xMax: 1.5,
+      yMin: -0.5,
+      yMax: 1.5,
+    });
+    expect(state.centers).toEqual({
+      xValues: [0, 1],
+      yValues: [0, 1],
     });
     expect(bufferData).toHaveBeenCalledWith(
       gl.ARRAY_BUFFER,

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -5,12 +5,7 @@ import {
   lineDataBounds,
   type LineRenderState,
 } from "./lineRenderer";
-import {
-  buildHeatmapGeometry,
-  heatmapAxisCenters,
-  heatmapDataBounds,
-  EMPTY_HEATMAP_GEOMETRY,
-} from "./heatmapGeometry";
+import { deriveHeatmapLayout, EMPTY_HEATMAP_GEOMETRY } from "./heatmapGeometry";
 import {
   syncHeatmapRenderState,
   type HeatmapRenderState,
@@ -219,7 +214,7 @@ describe("scatterDataBounds", () => {
 
 describe("syncHeatmapRenderState", () => {
   it("builds midpoint-derived numeric cell geometry", () => {
-    const geometry = buildHeatmapGeometry([
+    const { geometry } = deriveHeatmapLayout([
       xyzSeries("heat", "heat", [
         [10, 5, 1],
         [20, 5, 2],
@@ -247,7 +242,7 @@ describe("syncHeatmapRenderState", () => {
 
   it("uses a default half-step for singleton axes", () => {
     expect(
-      buildHeatmapGeometry([xyzSeries("heat", "heat", [[7, 11, 5]])]),
+      deriveHeatmapLayout([xyzSeries("heat", "heat", [[7, 11, 5]])]).geometry,
     ).toEqual({
       xMin: 6.5,
       xMax: 7.5,
@@ -264,14 +259,14 @@ describe("syncHeatmapRenderState", () => {
 
   it("returns sorted unique heatmap axis centers", () => {
     expect(
-      heatmapAxisCenters([
+      deriveHeatmapLayout([
         xyzSeries("heat", "heat", [
           [46, 310, 1],
           [7, 120, 2],
           [19, 185, 3],
           [7, 310, 4],
         ]),
-      ]),
+      ]).centers,
     ).toEqual({
       xValues: [7, 19, 46],
       yValues: [120, 185, 310],
@@ -280,7 +275,8 @@ describe("syncHeatmapRenderState", () => {
 
   it("returns default bounds when there are no finite heatmap cells", () => {
     expect(
-      heatmapDataBounds([xyzSeries("heat", "heat", [[0, 0, Number.NaN]])]),
+      deriveHeatmapLayout([xyzSeries("heat", "heat", [[0, 0, Number.NaN]])])
+        .bounds,
     ).toEqual({
       xMin: EMPTY_HEATMAP_GEOMETRY.xMin,
       xMax: EMPTY_HEATMAP_GEOMETRY.xMax,

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -6,6 +6,11 @@ import {
   type LineRenderState,
 } from "./lineRenderer";
 import {
+  buildHeatmapGeometry,
+  heatmapDataBounds,
+  EMPTY_HEATMAP_GEOMETRY,
+} from "./heatmapGeometry";
+import {
   syncHeatmapRenderState,
   type HeatmapRenderState,
 } from "./heatmapRenderer";
@@ -212,6 +217,61 @@ describe("scatterDataBounds", () => {
 });
 
 describe("syncHeatmapRenderState", () => {
+  it("builds midpoint-derived numeric cell geometry", () => {
+    const geometry = buildHeatmapGeometry([
+      xyzSeries("heat", "heat", [
+        [10, 5, 1],
+        [20, 5, 2],
+        [40, 9, 3],
+      ]),
+    ]);
+
+    expect(geometry).toEqual({
+      xMin: 5,
+      xMax: 50,
+      yMin: 3,
+      yMax: 11,
+      series: [
+        {
+          seriesId: "heat",
+          cells: [
+            { x: 10, y: 5, z: 1, x0: 5, x1: 15, y0: 3, y1: 7 },
+            { x: 20, y: 5, z: 2, x0: 15, x1: 30, y0: 3, y1: 7 },
+            { x: 40, y: 9, z: 3, x0: 30, x1: 50, y0: 7, y1: 11 },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses a default half-step for singleton axes", () => {
+    expect(
+      buildHeatmapGeometry([xyzSeries("heat", "heat", [[7, 11, 5]])]),
+    ).toEqual({
+      xMin: 6.5,
+      xMax: 7.5,
+      yMin: 10.5,
+      yMax: 11.5,
+      series: [
+        {
+          seriesId: "heat",
+          cells: [{ x: 7, y: 11, z: 5, x0: 6.5, x1: 7.5, y0: 10.5, y1: 11.5 }],
+        },
+      ],
+    });
+  });
+
+  it("returns default bounds when there are no finite heatmap cells", () => {
+    expect(
+      heatmapDataBounds([xyzSeries("heat", "heat", [[0, 0, Number.NaN]])]),
+    ).toEqual({
+      xMin: EMPTY_HEATMAP_GEOMETRY.xMin,
+      xMax: EMPTY_HEATMAP_GEOMETRY.xMax,
+      yMin: EMPTY_HEATMAP_GEOMETRY.yMin,
+      yMax: EMPTY_HEATMAP_GEOMETRY.yMax,
+    });
+  });
+
   it("uses only finite cell values for min/max normalization", () => {
     const bufferData = vi.fn();
     const bufferSubData = vi.fn();
@@ -228,6 +288,7 @@ describe("syncHeatmapRenderState", () => {
       instanceCount: 0,
       capacity: 0,
       instanceData: new Float64Array(0),
+      geometry: EMPTY_HEATMAP_GEOMETRY,
       valueMin: 0,
       valueMax: 0,
     } as unknown as HeatmapRenderState;
@@ -245,15 +306,30 @@ describe("syncHeatmapRenderState", () => {
     expect(state.valueMin).toBe(1);
     expect(state.valueMax).toBe(5);
     expect(state.instanceCount).toBe(2);
+    expect(state.geometry).toEqual({
+      xMin: -0.5,
+      xMax: 0.5,
+      yMin: -0.5,
+      yMax: 1.5,
+      series: [
+        {
+          seriesId: "heat",
+          cells: [
+            { x: 0, y: 0, z: 1, x0: -0.5, x1: 0.5, y0: -0.5, y1: 0.5 },
+            { x: 0, y: 1, z: 5, x0: -0.5, x1: 0.5, y0: 0.5, y1: 1.5 },
+          ],
+        },
+      ],
+    });
     expect(bufferData).toHaveBeenCalledWith(
       gl.ARRAY_BUFFER,
-      new Float32Array(6),
+      new Float32Array(10),
       gl.DYNAMIC_DRAW,
     );
     expect(bufferSubData).toHaveBeenCalledWith(
       gl.ARRAY_BUFFER,
       0,
-      new Float32Array([0, 0, 0, 0, 1, 1]),
+      new Float32Array([-0.5, -0.5, 0.5, 0.5, 0, -0.5, 0.5, 0.5, 1.5, 1]),
     );
   });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/shaders/heatmap.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/shaders/heatmap.ts
@@ -2,8 +2,8 @@
  * GLSL 300 es shaders for heatmap rendering via instanced quads.
  *
  * Each instance is a single heatmap cell. Per-instance attributes provide
- * the cell position (col, row) and the normalized value (0..1) which is
- * mapped to a color ramp in the fragment shader.
+ * the numeric cell bounds and the normalized value (0..1) which is mapped
+ * to a color ramp in the fragment shader.
  */
 
 export const heatmapVertexSource = `#version 300 es
@@ -13,19 +13,21 @@ precision highp float;
 in vec2 a_corner;
 
 // Per-instance
-in vec3 a_cell; // (col, row, normalizedValue)
+in vec4 a_rect; // (x0, y0, x1, y1)
+in float a_value;
 
-uniform mat3 u_matrix; // maps (col, row) grid coords → clip space
-uniform vec2 u_cellSize; // (1.0 / numCols, 1.0 / numRows) in grid-coord units — unused, we just offset by 1
+uniform mat3 u_matrix; // maps data coords → clip space
 
 out float v_value;
 
 void main() {
-  // Cell spans from (col, row) to (col+1, row+1) in grid coordinates
-  vec2 pos = a_cell.xy + a_corner;
+  vec2 pos = vec2(
+    mix(a_rect.x, a_rect.z, a_corner.x),
+    mix(a_rect.y, a_rect.w, a_corner.y)
+  );
   vec3 clip = u_matrix * vec3(pos, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);
-  v_value = a_cell.z;
+  v_value = a_value;
 }
 `;
 

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartFrameHeader.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartFrameHeader.test.tsx
@@ -102,8 +102,6 @@ describe("buildChartFrameHeader", () => {
           type: "heatmap",
           xName: "x",
           yName: "y",
-          xCategories: [0],
-          yCategories: [0],
           series: [],
         },
         derived: {

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartTooltip.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartTooltip.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ChartOptions } from "@/shared/lib/chartTypes";
 import type { ChartInteractionState } from "../hooks/useWebGLChart";
+import { buildHeatmapGeometry } from "../rendering/heatmapGeometry";
 import { DEFAULT_NUMERIC_LABEL_FORMAT } from "../rendering/numericLabelFormat";
 import { getTooltipLines } from "./tooltipLines";
 
@@ -137,16 +138,23 @@ describe("getTooltipLines", () => {
       type: "heatmap",
       xName: "x",
       yName: "y",
-      xCategories: [1, 2],
-      yCategories: [10, 20],
-      series: [xyzSeries("z", "z", [[1, 1, 200]])],
+      series: [xyzSeries("z", "z", [[2, 20, 200]])],
     };
 
     const interactionState: ChartInteractionState = {
       type: "heatmap",
-      xCategories: [1, 2],
-      yCategories: [10, 20],
+      xMin: 1.5,
+      xMax: 2.5,
+      yMin: 19.5,
+      yMax: 20.5,
       margin,
+      zoomState: {
+        scaleX: 1,
+        scaleY: 1,
+        translateX: 0,
+        translateY: 0,
+      },
+      geometry: buildHeatmapGeometry(data.series),
     };
 
     expect(

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartTooltip.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartTooltip.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ChartOptions } from "@/shared/lib/chartTypes";
 import type { ChartInteractionState } from "../hooks/useWebGLChart";
-import { buildHeatmapGeometry } from "../rendering/heatmapGeometry";
+import { deriveHeatmapLayout } from "../rendering/heatmapGeometry";
 import { DEFAULT_NUMERIC_LABEL_FORMAT } from "../rendering/numericLabelFormat";
 import { getTooltipLines } from "./tooltipLines";
 
@@ -154,7 +154,7 @@ describe("getTooltipLines", () => {
         translateX: 0,
         translateY: 0,
       },
-      geometry: buildHeatmapGeometry(data.series),
+      geometry: deriveHeatmapLayout(data.series).geometry,
     };
 
     expect(

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.test.tsx
@@ -309,14 +309,12 @@ describe("ChartViewer", () => {
           type: "heatmap",
           xName: "trace index",
           yName: "idxB",
-          xCategories: [0, 1],
-          yCategories: [10],
           series: [
             {
               id: "trace_signal",
               label: "trace_signal",
               pointCount: 2,
-              values: [0, 0, 1, 1, 0, 2],
+              values: [0, 10, 1, 1, 10, 2],
             },
           ],
         };

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartWrapper.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartWrapper.test.tsx
@@ -155,12 +155,10 @@ describe("ChartWrapper", () => {
       type: "heatmap",
       xName: "x",
       yName: "y",
-      xCategories: [1, 2],
-      yCategories: [10],
       series: [
         xyzSeries("z", "z", [
-          [0, 0, 100],
-          [1, 0, 200],
+          [1, 10, 100],
+          [2, 10, 200],
         ]),
       ],
     };
@@ -240,12 +238,10 @@ describe("ChartWrapper", () => {
       type: "heatmap",
       xName: "x",
       yName: "y",
-      xCategories: [1, 2],
-      yCategories: [10],
       series: [
         xyzSeries("z", "z", [
-          [0, 0, 100],
-          [1, 0, 200],
+          [1, 10, 100],
+          [2, 10, 200],
         ]),
       ],
     };
@@ -260,12 +256,10 @@ describe("ChartWrapper", () => {
       type: "heatmap",
       xName: "x",
       yName: "y",
-      xCategories: [1, 2],
-      yCategories: [10],
       series: [
         xyzSeries("z", "z", [
-          [0, 0, 100],
-          [1, 0, 200],
+          [1, 10, 100],
+          [2, 10, 200],
         ]),
       ],
     };

--- a/crates/fricon-ui/frontend/src/features/charts/ui/tooltipLines.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/tooltipLines.ts
@@ -1,6 +1,5 @@
 import {
   getXYPoint,
-  getXYZPoint,
   type ChartOptions,
   type NumericLabelFormatOptions,
 } from "@/shared/lib/chartTypes";
@@ -52,35 +51,47 @@ export function getTooltipLines(
   }
 
   if (data.type === "heatmap" && interactionState.type === "heatmap") {
-    const col = clampIndex(
-      Math.floor((chartX / chartWidth) * interactionState.xCategories.length),
-      interactionState.xCategories.length,
+    const dataX = invertZoomedLinearRange(
+      chartX,
+      interactionState.zoomState.translateX,
+      interactionState.zoomState.scaleX,
+      interactionState.xMin,
+      interactionState.xMax,
+      0,
+      chartWidth,
     );
-    const row = clampIndex(
-      interactionState.yCategories.length -
-        1 -
-        Math.floor(
-          (chartY / chartHeight) * interactionState.yCategories.length,
-        ),
-      interactionState.yCategories.length,
+    const dataY = invertZoomedLinearRange(
+      chartY,
+      interactionState.zoomState.translateY,
+      interactionState.zoomState.scaleY,
+      interactionState.yMin,
+      interactionState.yMax,
+      chartHeight,
+      0,
     );
-
-    if (col < 0 || row < 0) return [];
-
-    const lines = [
-      `${data.xName}: ${formatNumericLabel(interactionState.xCategories[col], numericLabelFormat)}, ${data.yName}: ${formatNumericLabel(interactionState.yCategories[row], numericLabelFormat)}`,
-    ];
+    const lines: string[] = [];
+    let hoveredCell: { x: number; y: number } | null = null;
 
     for (const series of data.series) {
-      const cellValue = findHeatmapCellValue(series, col, row);
-      if (cellValue !== null) {
-        lines.push(
-          `${series.label}: ${formatNumericLabel(cellValue, numericLabelFormat)}`,
-        );
-      }
+      const cellValue = findHeatmapCellValue(
+        interactionState,
+        series.id,
+        dataX,
+        dataY,
+      );
+      if (!cellValue) continue;
+      hoveredCell ??= { x: cellValue.x, y: cellValue.y };
+      lines.push(
+        `${series.label}: ${formatNumericLabel(cellValue.z, numericLabelFormat)}`,
+      );
     }
 
-    return lines.length > 1 ? lines : [];
+    if (!hoveredCell || lines.length === 0) return [];
+
+    return [
+      `${data.xName}: ${formatNumericLabel(hoveredCell.x, numericLabelFormat)}, ${data.yName}: ${formatNumericLabel(hoveredCell.y, numericLabelFormat)}`,
+      ...lines,
+    ];
   }
 
   return [];
@@ -151,20 +162,25 @@ function findNearestPoint(
 }
 
 function findHeatmapCellValue(
-  series: import("@/shared/lib/chartTypes").HeatmapSeries,
-  col: number,
-  row: number,
+  interactionState: Extract<ChartInteractionState, { type: "heatmap" }>,
+  seriesId: string,
+  dataX: number,
+  dataY: number,
 ) {
-  for (let i = 0; i < series.pointCount; i++) {
-    const point = getXYZPoint(series, i);
-    if (point.x === col && point.y === row) {
-      return point.z;
+  const geometry = interactionState.geometry.series.find(
+    (item) => item.seriesId === seriesId,
+  );
+  if (!geometry) return null;
+
+  for (const cell of geometry.cells) {
+    if (
+      dataX >= cell.x0 &&
+      dataX <= cell.x1 &&
+      dataY >= cell.y0 &&
+      dataY <= cell.y1
+    ) {
+      return cell;
     }
   }
   return null;
-}
-
-function clampIndex(index: number, length: number): number {
-  if (length <= 0) return -1;
-  return Math.min(Math.max(index, 0), length - 1);
 }

--- a/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
@@ -212,12 +212,10 @@ export type HeatmapChartDataOptions = {
 export type HeatmapChartSnapshot = {
 	xName: string,
 	yName: string,
-	xCategories: number[],
-	yCategories: number[],
 	series: FlatXYZSeries[],
 };
 
-export type LiveChartAppendOperation = { kind: "append_points"; series_id: string; values: number[]; point_count: number } | { kind: "append_series"; series: FlatSeries } | { kind: "append_heatmap_categories"; x_categories: number[] | null; y_categories: number[] | null };
+export type LiveChartAppendOperation = { kind: "append_points"; series_id: string; values: number[]; point_count: number } | { kind: "append_series"; series: FlatSeries };
 
 export type LiveChartDataOptions = { view: "xy" } & (LiveXYOptions) | { view: "heatmap" } & (LiveHeatmapOptions);
 

--- a/crates/fricon-ui/frontend/src/shared/lib/chartTypes.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/chartTypes.ts
@@ -40,8 +40,6 @@ export interface HeatmapChartModel {
   type: "heatmap";
   xName: string;
   yName: string;
-  xCategories: number[];
-  yCategories: number[];
   series: HeatmapSeries[];
 }
 

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -476,21 +476,8 @@ fn diff_heatmap(
     if previous.series.len() > current.series.len() {
         return None;
     }
-    if !current.x_categories.starts_with(&previous.x_categories)
-        || !current.y_categories.starts_with(&previous.y_categories)
-    {
-        return None;
-    }
 
     let mut ops = Vec::new();
-    let appended_x = current.x_categories[previous.x_categories.len()..].to_vec();
-    let appended_y = current.y_categories[previous.y_categories.len()..].to_vec();
-    if !appended_x.is_empty() || !appended_y.is_empty() {
-        ops.push(LiveChartAppendOperation::AppendHeatmapCategories {
-            x_categories: (!appended_x.is_empty()).then_some(appended_x),
-            y_categories: (!appended_y.is_empty()).then_some(appended_y),
-        });
-    }
 
     for (previous_series, current_series) in previous.series.iter().zip(&current.series) {
         if previous_series.id != current_series.id || previous_series.label != current_series.label
@@ -642,19 +629,15 @@ mod tests {
     }
 
     #[test]
-    fn diff_heatmap_emits_category_and_point_appends() {
+    fn diff_heatmap_emits_point_appends() {
         let previous = HeatmapChartSnapshot {
             x_name: "x".to_string(),
             y_name: "y".to_string(),
-            x_categories: vec![0.0],
-            y_categories: vec![0.0],
             series: vec![xyz_series("heat", "heat", &[0.0, 0.0, 1.0])],
         };
         let current = HeatmapChartSnapshot {
             x_name: "x".to_string(),
             y_name: "y".to_string(),
-            x_categories: vec![0.0, 1.0],
-            y_categories: vec![0.0, 2.0],
             series: vec![xyz_series("heat", "heat", &[0.0, 0.0, 1.0, 1.0, 2.0, 5.0])],
         };
 
@@ -662,17 +645,11 @@ mod tests {
 
         assert_eq!(
             ops,
-            vec![
-                LiveChartAppendOperation::AppendHeatmapCategories {
-                    x_categories: Some(vec![1.0]),
-                    y_categories: Some(vec![2.0]),
-                },
-                LiveChartAppendOperation::AppendPoints {
-                    series_id: "heat".to_string(),
-                    values: vec![1.0, 2.0, 5.0],
-                    point_count: 1,
-                },
-            ]
+            vec![LiveChartAppendOperation::AppendPoints {
+                series_id: "heat".to_string(),
+                values: vec![1.0, 2.0, 5.0],
+                point_count: 1,
+            },]
         );
     }
 
@@ -808,8 +785,6 @@ mod tests {
 
         assert_eq!(snapshot.x_name, "x");
         assert_eq!(snapshot.y_name, "y");
-        assert_eq!(snapshot.x_categories, vec![0.0, 1.0]);
-        assert_eq!(snapshot.y_categories, vec![0.0, 1.0, 2.0]);
         assert_eq!(snapshot.series.len(), 1);
         assert_eq!(snapshot.series[0].point_count, 6);
 
@@ -836,8 +811,6 @@ mod tests {
 
         assert_eq!(snapshot.x_name, "trace - X");
         assert_eq!(snapshot.y_name, "row");
-        assert_eq!(snapshot.x_categories, vec![0.0, 1.0]);
-        assert_eq!(snapshot.y_categories, vec![0.0, 1.0]);
         assert_eq!(snapshot.series.len(), 1);
         assert_eq!(snapshot.series[0].point_count, 4);
 

--- a/crates/fricon-ui/src/features/charts/transform/heatmap.rs
+++ b/crates/fricon-ui/src/features/charts/transform/heatmap.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use anyhow::{Context, Result};
 use arrow_array::RecordBatch;
 use fricon::{DatasetArray, DatasetDataType, DatasetSchema};
@@ -37,7 +35,7 @@ pub(crate) fn build_heatmap_series(
         .complex_view_single
         .unwrap_or(ComplexViewOption::Mag);
 
-    let mut series = if is_trace {
+    let series = if is_trace {
         process_trace_heatmap(
             batch,
             quantity_name,
@@ -62,63 +60,11 @@ pub(crate) fn build_heatmap_series(
         )?
     };
 
-    let (x_categories, y_categories) = normalize_heatmap_series(&mut series);
-
     Ok(ChartSnapshot::Heatmap(HeatmapChartSnapshot {
         x_name,
         y_name: y_column.clone(),
-        x_categories,
-        y_categories,
         series,
     }))
-}
-
-pub(crate) fn normalize_heatmap_series(series: &mut [FlatXYZSeries]) -> (Vec<f64>, Vec<f64>) {
-    fn f64_key(value: f64) -> u64 {
-        if value == 0.0 { 0_u64 } else { value.to_bits() }
-    }
-
-    let mut x_categories: Vec<f64> = Vec::new();
-    let mut y_categories: Vec<f64> = Vec::new();
-    let mut x_index_by_value: HashMap<u64, usize> = HashMap::new();
-    let mut y_index_by_value: HashMap<u64, usize> = HashMap::new();
-
-    for item in series.iter_mut() {
-        for point in item.values.chunks_exact_mut(3) {
-            let x_value = point[0];
-            let y_value = point[1];
-
-            let x_index = if let Some(index) = x_index_by_value.get(&f64_key(x_value)) {
-                *index
-            } else {
-                let index = x_categories.len();
-                x_categories.push(x_value);
-                x_index_by_value.insert(f64_key(x_value), index);
-                index
-            };
-
-            let y_index = if let Some(index) = y_index_by_value.get(&f64_key(y_value)) {
-                *index
-            } else {
-                let index = y_categories.len();
-                y_categories.push(y_value);
-                y_index_by_value.insert(f64_key(y_value), index);
-                index
-            };
-
-            #[expect(
-                clippy::cast_precision_loss,
-                reason = "Heatmap category indices are bounded by dataset size and safe for \
-                          plotting"
-            )]
-            {
-                point[0] = x_index as f64;
-                point[1] = y_index as f64;
-            }
-        }
-    }
-
-    (x_categories, y_categories)
 }
 
 fn process_trace_heatmap(
@@ -304,11 +250,9 @@ mod tests {
 
         let res = heatmap_snapshot(build_heatmap_series(&batch, &schema, &options).unwrap());
         assert_eq!(res.series.len(), 1);
-        assert_eq!(res.x_categories, vec![1.0, 2.0]);
-        assert_eq!(res.y_categories, vec![10.0]);
         assert_eq!(
             xyz_points(&res.series[0]),
-            vec![vec![0.0, 0.0, 100.0], vec![1.0, 0.0, 200.0]]
+            vec![vec![1.0, 10.0, 100.0], vec![2.0, 10.0, 200.0]]
         );
     }
 
@@ -330,14 +274,12 @@ mod tests {
         };
 
         let res = heatmap_snapshot(build_heatmap_series(&batch, &schema, &options).unwrap());
-        assert_eq!(res.x_categories, vec![1.0, 2.0]);
-        assert_eq!(res.y_categories, vec![1.0, 2.0]);
         assert_eq!(
             xyz_points(&res.series[0]),
             vec![
-                vec![0.0, 0.0, 10.0],
-                vec![1.0, 0.0, 20.0],
-                vec![0.0, 1.0, 30.0]
+                vec![1.0, 1.0, 10.0],
+                vec![2.0, 1.0, 20.0],
+                vec![1.0, 2.0, 30.0]
             ]
         );
     }
@@ -360,14 +302,12 @@ mod tests {
         };
 
         let res = heatmap_snapshot(build_heatmap_series(&batch, &schema, &options).unwrap());
-        assert_eq!(res.x_categories, vec![10.0, 20.0, 40.0]);
-        assert_eq!(res.y_categories, vec![5.0, 9.0]);
         assert_eq!(
             xyz_points(&res.series[0]),
             vec![
-                vec![0.0, 0.0, 1.0],
-                vec![1.0, 0.0, 2.0],
-                vec![2.0, 1.0, 3.0]
+                vec![10.0, 5.0, 1.0],
+                vec![20.0, 5.0, 2.0],
+                vec![40.0, 9.0, 3.0]
             ]
         );
     }
@@ -404,14 +344,12 @@ mod tests {
         };
 
         let res = heatmap_snapshot(build_heatmap_series(&batch, &schema, &options).unwrap());
-        assert_eq!(res.x_categories, vec![0.0, 1.0, 2.0]);
-        assert_eq!(res.y_categories, vec![100.0]);
         assert_eq!(
             xyz_points(&res.series[0]),
             vec![
-                vec![0.0, 0.0, 1.0],
-                vec![1.0, 0.0, 2.0],
-                vec![2.0, 0.0, 3.0]
+                vec![0.0, 100.0, 1.0],
+                vec![1.0, 100.0, 2.0],
+                vec![2.0, 100.0, 3.0]
             ]
         );
     }

--- a/crates/fricon-ui/src/features/charts/transform/live_heatmap.rs
+++ b/crates/fricon-ui/src/features/charts/transform/live_heatmap.rs
@@ -103,8 +103,6 @@ fn build_trace_live_heatmap(
         return Ok(ChartSnapshot::Heatmap(HeatmapChartSnapshot {
             x_name: format!("{quantity_name} - X"),
             y_name,
-            x_categories: vec![],
-            y_categories: vec![],
             series: vec![],
         }));
     }
@@ -181,14 +179,11 @@ fn build_trace_live_heatmap(
         quantity_name.clone()
     };
 
-    let mut series = vec![FlatXYZSeries::new(name.clone(), name, values, point_count)];
-    let (x_categories, y_categories) = super::heatmap::normalize_heatmap_series(&mut series);
+    let series = vec![FlatXYZSeries::new(name.clone(), name, values, point_count)];
 
     Ok(ChartSnapshot::Heatmap(HeatmapChartSnapshot {
         x_name: format!("{quantity_name} - X"),
         y_name,
-        x_categories,
-        y_categories,
         series,
     }))
 }
@@ -370,8 +365,6 @@ mod tests {
 
         assert_eq!(res.x_name, "x");
         assert_eq!(res.y_name, "y");
-        assert_eq!(res.x_categories, vec![0.0, 1.0]);
-        assert_eq!(res.y_categories, vec![0.0, 1.0, 2.0]);
         assert_eq!(res.series.len(), 1);
         assert_eq!(res.series[0].point_count, 6);
         assert_eq!(
@@ -415,8 +408,6 @@ mod tests {
         );
 
         assert_eq!(res.y_name, "idx");
-        assert_eq!(res.x_categories, Vec::<f64>::new());
-        assert_eq!(res.y_categories, Vec::<f64>::new());
         assert!(res.series.is_empty());
     }
 
@@ -433,8 +424,6 @@ mod tests {
             heatmap_snapshot(build_live_heatmap_series(&batch, &schema, None, &options).unwrap());
 
         assert_eq!(res.y_name, "row");
-        assert_eq!(res.x_categories, vec![0.0, 1.0]);
-        assert_eq!(res.y_categories, vec![0.0]);
         assert_eq!(
             xyz_points(&res.series[0]),
             vec![vec![0.0, 0.0, 1.0], vec![1.0, 0.0, 2.0]]
@@ -465,8 +454,6 @@ mod tests {
 
         assert_eq!(res.x_name, "trace - X");
         assert_eq!(res.y_name, "row");
-        assert_eq!(res.x_categories, vec![0.0, 1.0]);
-        assert_eq!(res.y_categories, vec![0.0, 1.0]);
         assert_eq!(res.series.len(), 1);
         assert_eq!(res.series[0].point_count, 4);
         assert_eq!(

--- a/crates/fricon-ui/src/features/charts/types.rs
+++ b/crates/fricon-ui/src/features/charts/types.rs
@@ -158,8 +158,6 @@ pub(crate) struct XYChartSnapshot {
 pub(crate) struct HeatmapChartSnapshot {
     pub(crate) x_name: String,
     pub(crate) y_name: String,
-    pub(crate) x_categories: Vec<f64>,
-    pub(crate) y_categories: Vec<f64>,
     pub(crate) series: Vec<FlatXYZSeries>,
 }
 
@@ -179,10 +177,6 @@ pub(crate) enum FlatSeries {
 
 #[derive(Serialize, Clone, Debug, PartialEq, specta::Type)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-#[expect(
-    clippy::enum_variant_names,
-    reason = "Wire format uses append-prefixed operation names"
-)]
 pub(crate) enum LiveChartAppendOperation {
     AppendPoints {
         series_id: String,
@@ -191,10 +185,6 @@ pub(crate) enum LiveChartAppendOperation {
     },
     AppendSeries {
         series: FlatSeries,
-    },
-    AppendHeatmapCategories {
-        x_categories: Option<Vec<f64>>,
-        y_categories: Option<Vec<f64>>,
     },
 }
 

--- a/examples/dataset/create_feature_test_cases.py
+++ b/examples/dataset/create_feature_test_cases.py
@@ -7,6 +7,7 @@ The dataset names use `testcase_dataset_XX_<purpose>` so each case is obvious:
 - testcase_dataset_04_trace_signal_for_line_and_trace_xy
 - testcase_dataset_05_heatmap_grid_for_xy_heatmap
 - testcase_dataset_06_column_name_variants_for_field_rendering
+- testcase_dataset_07_heatmap_irregular_scan_for_axis_edge_bug
 
 Run:
     uv run python examples/dataset/create_feature_test_cases.py
@@ -184,6 +185,41 @@ def case_06_column_name_variants(manager: DatasetManager) -> None:
             )
 
 
+def case_07_heatmap_irregular_scan(manager: DatasetManager) -> None:
+    with manager.create(
+        "testcase_dataset_07_heatmap_irregular_scan_for_axis_edge_bug",
+        description=(
+            "Irregular scan spacing to expose heatmap axes rendered from cell "
+            "edges instead of coordinate centers"
+        ),
+        tags=["testcase", "heatmap", "irregular-axis", "bug-demo"],
+    ) as writer:
+        idx_scan_x_irregular = [7.0, 19.0, 46.0]
+        idx_scan_y_irregular = [120.0, 185.0, 310.0]
+
+        for idx_wafer in range(1, 3):
+            for x_pos in idx_scan_x_irregular:
+                for y_pos in idx_scan_y_irregular:
+                    center_distance = math.sqrt(
+                        ((x_pos - 26.0) / 14.0) ** 2 + ((y_pos - 215.0) / 75.0) ** 2
+                    )
+                    scalar_regular_sheet_resistance_ohm_sq = (
+                        92.0
+                        + idx_wafer * 1.7
+                        + x_pos * 0.08
+                        - y_pos * 0.015
+                        - center_distance * 4.5
+                    )
+                    writer.write(
+                        idx_wafer=idx_wafer,
+                        idx_scan_x_irregular_mm=x_pos,
+                        idx_scan_y_irregular_mm=y_pos,
+                        scalar_regular_sheet_resistance_ohm_sq=(
+                            scalar_regular_sheet_resistance_ohm_sq
+                        ),
+                    )
+
+
 def main() -> None:
     default_workspace = _load_workspace_from_env() or ".dev/ws"
     parser = argparse.ArgumentParser(description=__doc__)
@@ -204,6 +240,7 @@ def main() -> None:
     case_04_trace_signal(manager)
     case_05_heatmap_grid(manager)
     case_06_column_name_variants(manager)
+    case_07_heatmap_irregular_scan(manager)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch heatmaps from category-index axes to numeric-coordinate geometry and rendering
- add sparse center-tick handling for irregular heatmaps and preserve NaN-only coordinates in layout derivation
- add an irregular heatmap dataset fixture to demonstrate the axis behavior

## Testing
- pnpm run check
- pnpm run test --run src/features/charts/rendering/rendererBounds.test.ts src/features/charts/rendering/d3Overlay.test.ts src/features/charts/hooks/useWebGLChart.test.tsx src/features/charts/ui/ChartTooltip.test.tsx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
