### PR TITLE
fix: stabilize live mode interactions

### DIFF
--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
@@ -387,6 +387,68 @@ describe("useWebGLChart", () => {
     );
   });
 
+  it("cancels an active drag when the interaction key changes", () => {
+    const { rerender } = render(
+      <HookHarness
+        data={makeLineData([
+          [0, 0],
+          [10, 10],
+        ])}
+        interactionKey="live-line-a"
+        liveMode
+      />,
+    );
+
+    const svg = screen.getByTestId("chart-svg");
+    const snapshotButton = screen.getByRole("button", { name: "Snapshot" });
+
+    fireEvent.pointerDown(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 120,
+      clientY: 80,
+    });
+    fireEvent.pointerMove(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 150,
+      clientY: 100,
+    });
+
+    rerender(
+      <HookHarness
+        data={makeLineData([
+          [0, 0],
+          [20, 20],
+        ])}
+        interactionKey="live-line-b"
+        liveMode
+      />,
+    );
+
+    fireEvent.pointerMove(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 180,
+      clientY: 130,
+    });
+    fireEvent.pointerUp(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 180,
+      clientY: 130,
+    });
+    fireEvent.click(snapshotButton);
+    const afterSwitch = readSnapshot();
+
+    expect(afterSwitch?.zoomState?.scaleX).toBeCloseTo(1);
+    expect(afterSwitch?.zoomState?.scaleY).toBeCloseTo(1);
+    expect(afterSwitch?.zoomState?.translateX).toBeCloseTo(0);
+    expect(afterSwitch?.zoomState?.translateY).toBeCloseTo(0);
+    expect(afterSwitch?.xMax).toBeGreaterThan(10);
+    expect(afterSwitch?.yMax).toBeGreaterThan(10);
+  });
+
   it("uses the shared trend series label for the y axis when available", () => {
     expect(
       resolveXYYAxisLabel({

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
@@ -5,6 +5,10 @@ import type { ChartOptions } from "@/shared/lib/chartTypes";
 import { resolveXYYAxisLabel } from "../model/seriesLabeling";
 import { useWebGLChart, type ChartInteractionState } from "./useWebGLChart";
 
+vi.mock("../rendering/crosshairOverlay", () => ({
+  attachCrosshair: () => ({ destroy: noop }),
+}));
+
 const noop = () => undefined;
 
 const glStub = {

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.test.tsx
@@ -133,6 +133,18 @@ function HookHarness({
         toJSON: () => undefined,
       }),
     });
+    Object.defineProperty(svg, "setPointerCapture", {
+      configurable: true,
+      value: () => undefined,
+    });
+    Object.defineProperty(svg, "releasePointerCapture", {
+      configurable: true,
+      value: () => undefined,
+    });
+    Object.defineProperty(svg, "hasPointerCapture", {
+      configurable: true,
+      value: () => true,
+    });
   }, [canvasRef, svgRef]);
 
   return (
@@ -305,6 +317,70 @@ describe("useWebGLChart", () => {
     expect(autoFollow?.zoomState?.translateY).toBeCloseTo(0);
     expect(autoFollow?.xMax).toBeGreaterThan(reset?.xMax ?? 0);
     expect(autoFollow?.yMax).toBeGreaterThan(reset?.yMax ?? 0);
+  });
+
+  it("keeps a live pan gesture active while data updates", () => {
+    const { rerender } = render(
+      <HookHarness
+        data={makeLineData([
+          [0, 0],
+          [10, 10],
+        ])}
+        interactionKey="live-line"
+        liveMode
+      />,
+    );
+
+    const svg = screen.getByTestId("chart-svg");
+    const snapshotButton = screen.getByRole("button", { name: "Snapshot" });
+
+    fireEvent.pointerDown(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 120,
+      clientY: 80,
+    });
+    fireEvent.pointerMove(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 150,
+      clientY: 100,
+    });
+    fireEvent.click(snapshotButton);
+    const beforeUpdate = readSnapshot();
+
+    rerender(
+      <HookHarness
+        data={makeLineData([
+          [0, 0],
+          [20, 20],
+        ])}
+        interactionKey="live-line"
+        liveMode
+      />,
+    );
+
+    fireEvent.pointerMove(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 180,
+      clientY: 130,
+    });
+    fireEvent.pointerUp(svg, {
+      button: 0,
+      pointerId: 1,
+      clientX: 180,
+      clientY: 130,
+    });
+    fireEvent.click(snapshotButton);
+    const afterUpdate = readSnapshot();
+
+    expect(afterUpdate?.zoomState?.translateX).toBeGreaterThan(
+      beforeUpdate?.zoomState?.translateX ?? 0,
+    );
+    expect(afterUpdate?.zoomState?.translateY).toBeGreaterThan(
+      beforeUpdate?.zoomState?.translateY ?? 0,
+    );
   });
 
   it("uses the shared trend series label for the y axis when available", () => {

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -153,6 +153,7 @@ export function useWebGLChart({
 }: UseWebGLChartOptions): UseWebGLChartReturn {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const chartType = data?.type;
   const chartRef = useRef<WebGLChartRefs>({
     gl: null,
     renderStateCache: createRenderStateCache(),
@@ -454,11 +455,13 @@ export function useWebGLChart({
   }, [liveMode, scheduleRender]);
 
   // Zoom controller, crosshair, and brush overlay
+  // Keep the controller stable across live data refreshes so active drags are not interrupted.
   useEffect(() => {
     const currentRefs = chartRef.current;
     const svgEl = svgRef.current;
     const canvas = canvasRef.current;
-    if (!svgEl || !canvas || !data) {
+    const currentData = currentRefs.data;
+    if (!svgEl || !canvas || !currentData) {
       currentRefs.crosshairController?.destroy();
       currentRefs.crosshairController = null;
       currentRefs.zoomController?.destroy();
@@ -466,7 +469,8 @@ export function useWebGLChart({
       return;
     }
 
-    const margin = data.type === "heatmap" ? HEATMAP_MARGIN : DEFAULT_MARGIN;
+    const margin =
+      currentData.type === "heatmap" ? HEATMAP_MARGIN : DEFAULT_MARGIN;
     const chartW = canvas.clientWidth - margin.left - margin.right;
     const chartH = canvas.clientHeight - margin.top - margin.bottom;
 
@@ -546,7 +550,7 @@ export function useWebGLChart({
       currentRefs.zoomController = null;
       brushGroup.remove();
     };
-  }, [data, liveMode, scheduleRender]);
+  }, [chartType, scheduleRender]);
 
   // Resize observer — use devicePixelContentBoxSize when available for accurate DPR sizing
   useEffect(() => {

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -455,7 +455,8 @@ export function useWebGLChart({
   }, [liveMode, scheduleRender]);
 
   // Zoom controller, crosshair, and brush overlay
-  // Keep the controller stable across live data refreshes so active drags are not interrupted.
+  // Keep the controller stable across live data refreshes so active drags are not interrupted,
+  // but reset controller-local gesture state when the interaction identity changes.
   useEffect(() => {
     const currentRefs = chartRef.current;
     const svgEl = svgRef.current;
@@ -550,7 +551,7 @@ export function useWebGLChart({
       currentRefs.zoomController = null;
       brushGroup.remove();
     };
-  }, [chartType, scheduleRender]);
+  }, [chartType, interactionKey, scheduleRender]);
 
   // Resize observer — use devicePixelContentBoxSize when available for accurate DPR sizing
   useEffect(() => {


### PR DESCRIPTION
Enhance the live mode experience by ensuring that chart interactions remain stable during data updates. This change prevents interruptions in user interactions, such as panning and zooming, while new data is being rendered.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
