### PR TITLE
feat(charts): support jagged heatmap x grids

### DIFF
--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useWebGLChart.ts
@@ -70,6 +70,7 @@ import {
 } from "../rendering/heatmapRenderer";
 import {
   deriveHeatmapLayout,
+  getHeatmapXTickValues,
   type HeatmapGeometry,
 } from "../rendering/heatmapGeometry";
 
@@ -279,10 +280,10 @@ export function useWebGLChart({
         r.numericLabelFormat,
         {
           showGrid: false,
-          xTickValues:
-            rs.state.centers.xValues.length <= 10
-              ? rs.state.centers.xValues
-              : undefined,
+          xTickValues: getHeatmapXTickValues(
+            rs.state.centers,
+            rs.state.xTopology,
+          ),
           yTickValues:
             rs.state.centers.yValues.length <= 10
               ? rs.state.centers.yValues

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
@@ -1,5 +1,8 @@
 import type { HeatmapSeries } from "@/shared/lib/chartTypes";
 
+const MIN_COMPARISON_TOLERANCE = 1e-15;
+const COMPARISON_TOLERANCE_RATIO = 1e-12;
+
 export interface HeatmapCellGeometry {
   x: number;
   y: number;
@@ -28,6 +31,11 @@ export interface HeatmapAxisCenters {
   yValues: number[];
 }
 
+export type HeatmapXAxisTopology =
+  | "shared_uniform"
+  | "row_local_uniform"
+  | "jagged";
+
 export interface HeatmapLayout {
   geometry: HeatmapGeometry;
   bounds: {
@@ -37,6 +45,7 @@ export interface HeatmapLayout {
     yMax: number;
   };
   centers: HeatmapAxisCenters;
+  xTopology: HeatmapXAxisTopology;
 }
 
 export const EMPTY_HEATMAP_GEOMETRY: HeatmapGeometry = {
@@ -65,10 +74,10 @@ export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
   const yValues = Array.from(
     new Set(coordinatePoints.map((point) => point.y)),
   ).sort((left, right) => left - right);
-  const xBounds = buildAxisBounds(xValues);
   const yBounds = buildAxisBounds(yValues);
+  const rowSpans = buildRowSpansByY(yValues, coordinatePoints, xValues);
 
-  if (xBounds.spanByValue.size === 0 || yBounds.spanByValue.size === 0) {
+  if (rowSpans.byY.size === 0 || yBounds.spanByValue.size === 0) {
     return {
       geometry: EMPTY_HEATMAP_GEOMETRY,
       bounds: {
@@ -78,12 +87,13 @@ export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
         yMax: EMPTY_HEATMAP_GEOMETRY.yMax,
       },
       centers: EMPTY_HEATMAP_AXIS_CENTERS,
+      xTopology: "shared_uniform",
     };
   }
 
   const geometry = {
-    xMin: xBounds.min,
-    xMax: xBounds.max,
+    xMin: rowSpans.min,
+    xMax: rowSpans.max,
     yMin: yBounds.min,
     yMax: yBounds.max,
     series: series.map((item) => ({
@@ -96,7 +106,7 @@ export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
             Number.isFinite(point.z),
         )
         .flatMap((point) => {
-          const xSpan = xBounds.spanByValue.get(point.x);
+          const xSpan = rowSpans.byY.get(point.y)?.spanByValue.get(point.x);
           const ySpan = yBounds.spanByValue.get(point.y);
           if (!xSpan || !ySpan) return [];
           return [
@@ -121,10 +131,25 @@ export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
       yMax: geometry.yMax,
     },
     centers: {
-      xValues,
+      xValues:
+        rowSpans.xTopology === "shared_uniform"
+          ? rowSpans.sharedCenters
+          : EMPTY_HEATMAP_AXIS_CENTERS.xValues,
       yValues,
     },
+    xTopology: rowSpans.xTopology,
   };
+}
+
+export function getHeatmapXTickValues(
+  centers: HeatmapAxisCenters,
+  xTopology: HeatmapXAxisTopology,
+  maxExplicitTicks = 10,
+) {
+  return xTopology === "shared_uniform" &&
+    centers.xValues.length <= maxExplicitTicks
+    ? centers.xValues
+    : undefined;
 }
 
 interface SeriesPoint {
@@ -139,6 +164,14 @@ interface AxisBounds {
   spanByValue: Map<number, [number, number]>;
 }
 
+interface RowSpanState {
+  byY: Map<number, AxisBounds>;
+  min: number;
+  max: number;
+  sharedCenters: number[];
+  xTopology: HeatmapXAxisTopology;
+}
+
 function readSeriesPoints(series: HeatmapSeries): SeriesPoint[] {
   const points: SeriesPoint[] = [];
   for (let i = 0; i < series.pointCount; i++) {
@@ -150,6 +183,165 @@ function readSeriesPoints(series: HeatmapSeries): SeriesPoint[] {
     });
   }
   return points;
+}
+
+function buildRowSpansByY(
+  yValues: number[],
+  coordinatePoints: SeriesPoint[],
+  globalXValues: number[],
+): RowSpanState {
+  const xTolerance = deriveXTolerance(globalXValues);
+  const xValuesByY = new Map<number, number[]>();
+  for (const point of coordinatePoints) {
+    const values = xValuesByY.get(point.y);
+    if (values) {
+      values.push(point.x);
+    } else {
+      xValuesByY.set(point.y, [point.x]);
+    }
+  }
+
+  const byY = new Map<number, AxisBounds>();
+  const rowCenters: number[][] = [];
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const y of yValues) {
+    const rowXValues = xValuesByY.get(y);
+    if (!rowXValues || rowXValues.length === 0) continue;
+
+    const uniqueRowXValues = Array.from(new Set(rowXValues)).sort(
+      (left, right) => left - right,
+    );
+    const bounds = buildRowAxisBounds(
+      uniqueRowXValues,
+      globalXValues,
+      xTolerance,
+    );
+    if (bounds.spanByValue.size === 0) continue;
+
+    byY.set(y, bounds);
+    rowCenters.push(uniqueRowXValues);
+    min = Math.min(min, bounds.min);
+    max = Math.max(max, bounds.max);
+  }
+
+  const xTopology = classifyXTopology(rowCenters, xTolerance);
+
+  return {
+    byY,
+    min,
+    max,
+    sharedCenters:
+      rowCenters.length > 0 && xTopology === "shared_uniform"
+        ? rowCenters[0]
+        : [],
+    xTopology,
+  };
+}
+
+function buildRowAxisBounds(
+  values: number[],
+  globalValues: number[],
+  xTolerance: number,
+): AxisBounds {
+  if (values.length === 0) {
+    return {
+      min: 0,
+      max: 1,
+      spanByValue: new Map(),
+    };
+  }
+
+  if (values.length === 1) {
+    const center = values[0];
+    const halfWidth = resolveSingletonHalfWidth(
+      center,
+      globalValues,
+      xTolerance,
+    );
+    return {
+      min: center - halfWidth,
+      max: center + halfWidth,
+      spanByValue: new Map([
+        [center, [center - halfWidth, center + halfWidth]],
+      ]),
+    };
+  }
+
+  return buildAxisBounds(values);
+}
+
+function resolveSingletonHalfWidth(
+  center: number,
+  globalValues: number[],
+  xTolerance: number,
+) {
+  let nearest = Infinity;
+  for (const value of globalValues) {
+    const distance = Math.abs(value - center);
+    if (distance <= xTolerance || distance >= nearest) continue;
+    nearest = distance;
+  }
+  return Number.isFinite(nearest) ? nearest / 2 : 0.5;
+}
+
+function classifyXTopology(
+  rowCenters: number[][],
+  xTolerance: number,
+): HeatmapXAxisTopology {
+  if (rowCenters.length === 0) return "shared_uniform";
+
+  const firstCenters = rowCenters[0];
+  const sharesCommonGrid = rowCenters.every((centers) =>
+    arraysAlmostEqual(centers, firstCenters, xTolerance),
+  );
+  const everyRowUniform = rowCenters.every((centers) =>
+    isUniformRow(centers, xTolerance),
+  );
+
+  if (sharesCommonGrid && everyRowUniform) {
+    return "shared_uniform";
+  }
+  if (everyRowUniform) {
+    return "row_local_uniform";
+  }
+  return "jagged";
+}
+
+function isUniformRow(centers: number[], xTolerance: number) {
+  if (centers.length <= 2) return true;
+
+  const baselineStep = centers[1] - centers[0];
+  for (let i = 2; i < centers.length; i++) {
+    if (!almostEqual(centers[i] - centers[i - 1], baselineStep, xTolerance)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function arraysAlmostEqual(
+  left: number[],
+  right: number[],
+  xTolerance: number,
+) {
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (!almostEqual(left[i], right[i], xTolerance)) return false;
+  }
+  return true;
+}
+
+function almostEqual(left: number, right: number, tolerance: number) {
+  return Math.abs(left - right) <= tolerance;
+}
+
+function deriveXTolerance(values: number[]) {
+  if (values.length <= 1) return MIN_COMPARISON_TOLERANCE;
+
+  const span = Math.abs(values[values.length - 1] - values[0]);
+  return Math.max(MIN_COMPARISON_TOLERANCE, span * COMPARISON_TOLERANCE_RATIO);
 }
 
 function buildAxisBounds(values: number[]): AxisBounds {

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapGeometry.ts
@@ -31,10 +31,7 @@ export interface HeatmapAxisCenters {
   yValues: number[];
 }
 
-export type HeatmapXAxisTopology =
-  | "shared_uniform"
-  | "row_local_uniform"
-  | "jagged";
+export type HeatmapXAxisTopology = "shared_grid" | "row_local_grid";
 
 export interface HeatmapLayout {
   geometry: HeatmapGeometry;
@@ -87,7 +84,7 @@ export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
         yMax: EMPTY_HEATMAP_GEOMETRY.yMax,
       },
       centers: EMPTY_HEATMAP_AXIS_CENTERS,
-      xTopology: "shared_uniform",
+      xTopology: "shared_grid",
     };
   }
 
@@ -132,7 +129,7 @@ export function deriveHeatmapLayout(series: HeatmapSeries[]): HeatmapLayout {
     },
     centers: {
       xValues:
-        rowSpans.xTopology === "shared_uniform"
+        rowSpans.xTopology === "shared_grid"
           ? rowSpans.sharedCenters
           : EMPTY_HEATMAP_AXIS_CENTERS.xValues,
       yValues,
@@ -146,7 +143,7 @@ export function getHeatmapXTickValues(
   xTopology: HeatmapXAxisTopology,
   maxExplicitTicks = 10,
 ) {
-  return xTopology === "shared_uniform" &&
+  return xTopology === "shared_grid" &&
     centers.xValues.length <= maxExplicitTicks
     ? centers.xValues
     : undefined;
@@ -233,9 +230,7 @@ function buildRowSpansByY(
     min,
     max,
     sharedCenters:
-      rowCenters.length > 0 && xTopology === "shared_uniform"
-        ? rowCenters[0]
-        : [],
+      rowCenters.length > 0 && xTopology === "shared_grid" ? rowCenters[0] : [],
     xTopology,
   };
 }
@@ -290,35 +285,16 @@ function classifyXTopology(
   rowCenters: number[][],
   xTolerance: number,
 ): HeatmapXAxisTopology {
-  if (rowCenters.length === 0) return "shared_uniform";
+  if (rowCenters.length === 0) return "shared_grid";
 
   const firstCenters = rowCenters[0];
   const sharesCommonGrid = rowCenters.every((centers) =>
     arraysAlmostEqual(centers, firstCenters, xTolerance),
   );
-  const everyRowUniform = rowCenters.every((centers) =>
-    isUniformRow(centers, xTolerance),
-  );
-
-  if (sharesCommonGrid && everyRowUniform) {
-    return "shared_uniform";
+  if (sharesCommonGrid) {
+    return "shared_grid";
   }
-  if (everyRowUniform) {
-    return "row_local_uniform";
-  }
-  return "jagged";
-}
-
-function isUniformRow(centers: number[], xTolerance: number) {
-  if (centers.length <= 2) return true;
-
-  const baselineStep = centers[1] - centers[0];
-  for (let i = 2; i < centers.length; i++) {
-    if (!almostEqual(centers[i] - centers[i - 1], baselineStep, xTolerance)) {
-      return false;
-    }
-  }
-  return true;
+  return "row_local_grid";
 }
 
 function arraysAlmostEqual(

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
@@ -11,6 +11,7 @@ import {
   EMPTY_HEATMAP_GEOMETRY,
   type HeatmapAxisCenters,
   type HeatmapGeometry,
+  type HeatmapXAxisTopology,
 } from "./heatmapGeometry";
 import { heatmapFragmentSource, heatmapVertexSource } from "./shaders/heatmap";
 
@@ -36,6 +37,7 @@ export interface HeatmapRenderState {
     yMax: number;
   };
   centers: HeatmapAxisCenters;
+  xTopology: HeatmapXAxisTopology;
   geometry: HeatmapGeometry;
   vao: WebGLVertexArrayObject;
   valueMin: number;
@@ -101,6 +103,7 @@ export function createHeatmapRenderState(
       xValues: [],
       yValues: [],
     },
+    xTopology: "shared_uniform",
     geometry: EMPTY_HEATMAP_GEOMETRY,
     vao,
     valueMin: 0,
@@ -115,7 +118,7 @@ export function syncHeatmapRenderState(
   state: HeatmapRenderState,
   series: HeatmapSeries[],
 ): void {
-  const { geometry, bounds, centers } = deriveHeatmapLayout(series);
+  const { geometry, bounds, centers, xTopology } = deriveHeatmapLayout(series);
   const { valueMin, valueMax, instanceData } = buildHeatmapInstances(geometry);
   gl.bindBuffer(gl.ARRAY_BUFFER, state.cellBuffer);
   if (
@@ -152,6 +155,7 @@ export function syncHeatmapRenderState(
   state.instanceData = instanceData;
   state.bounds = bounds;
   state.centers = centers;
+  state.xTopology = xTopology;
   state.geometry = geometry;
   state.valueMin = valueMin;
   state.valueMax = valueMax;

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/heatmapRenderer.ts
@@ -103,7 +103,7 @@ export function createHeatmapRenderState(
       xValues: [],
       yValues: [],
     },
-    xTopology: "shared_uniform",
+    xTopology: "shared_grid",
     geometry: EMPTY_HEATMAP_GEOMETRY,
     vao,
     valueMin: 0,

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -5,7 +5,11 @@ import {
   lineDataBounds,
   type LineRenderState,
 } from "./lineRenderer";
-import { deriveHeatmapLayout, EMPTY_HEATMAP_GEOMETRY } from "./heatmapGeometry";
+import {
+  deriveHeatmapLayout,
+  EMPTY_HEATMAP_GEOMETRY,
+  getHeatmapXTickValues,
+} from "./heatmapGeometry";
 import {
   syncHeatmapRenderState,
   type HeatmapRenderState,
@@ -232,7 +236,7 @@ describe("syncHeatmapRenderState", () => {
           seriesId: "heat",
           cells: [
             { x: 10, y: 5, z: 1, x0: 5, x1: 15, y0: 3, y1: 7 },
-            { x: 20, y: 5, z: 2, x0: 15, x1: 30, y0: 3, y1: 7 },
+            { x: 20, y: 5, z: 2, x0: 15, x1: 25, y0: 3, y1: 7 },
             { x: 40, y: 9, z: 3, x0: 30, x1: 50, y0: 7, y1: 11 },
           ],
         },
@@ -257,19 +261,176 @@ describe("syncHeatmapRenderState", () => {
     });
   });
 
-  it("returns sorted unique heatmap axis centers", () => {
+  it("suppresses shared x centers for non-shared uniform heatmaps", () => {
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [46, 310, 1],
+        [7, 120, 2],
+        [19, 185, 3],
+        [7, 310, 4],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.centers).toEqual({
+      xValues: [],
+      yValues: [120, 185, 310],
+    });
+  });
+
+  it("keeps shared x centers only for shared uniform heatmaps", () => {
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [7, 120, 1],
+        [19, 120, 2],
+        [7, 185, 3],
+        [19, 185, 4],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("shared_uniform");
+    expect(layout.centers).toEqual({
+      xValues: [7, 19],
+      yValues: [120, 185],
+    });
+    expect(getHeatmapXTickValues(layout.centers, layout.xTopology)).toEqual([
+      7, 19,
+    ]);
+  });
+
+  it("classifies row-local uniform x grids and suppresses explicit x ticks", () => {
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [0, 0, 1],
+        [10, 0, 2],
+        [10, 1, 3],
+        [30, 1, 4],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.centers).toEqual({
+      xValues: [],
+      yValues: [0, 1],
+    });
+    expect(
+      getHeatmapXTickValues(layout.centers, layout.xTopology),
+    ).toBeUndefined();
+  });
+
+  it("uses axis-span-aware tolerance for very small x ranges", () => {
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [0, 0, 1],
+        [1e-10, 0, 2],
+        [1e-10, 1, 3],
+        [3e-10, 1, 4],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.centers.xValues).toEqual([]);
+  });
+
+  it("uses axis-span-aware tolerance for large x ranges with tiny noise", () => {
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [1e9, 0, 1],
+        [2e9, 0, 2],
+        [1e9 + 1e-6, 1, 3],
+        [2e9 + 1e-6, 1, 4],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("shared_uniform");
+    expect(layout.centers.xValues).toEqual([1e9, 2e9]);
+  });
+
+  it("uses row-local x spans when rows use different steps", () => {
     expect(
       deriveHeatmapLayout([
         xyzSeries("heat", "heat", [
-          [46, 310, 1],
-          [7, 120, 2],
-          [19, 185, 3],
-          [7, 310, 4],
+          [0, 0, 1],
+          [10, 0, 2],
+          [10, 1, 3],
+          [30, 1, 4],
         ]),
-      ]).centers,
+      ]).geometry,
     ).toEqual({
-      xValues: [7, 19, 46],
-      yValues: [120, 185, 310],
+      xMin: -5,
+      xMax: 40,
+      yMin: -0.5,
+      yMax: 1.5,
+      series: [
+        {
+          seriesId: "heat",
+          cells: [
+            { x: 0, y: 0, z: 1, x0: -5, x1: 5, y0: -0.5, y1: 0.5 },
+            { x: 10, y: 0, z: 2, x0: 5, x1: 15, y0: -0.5, y1: 0.5 },
+            { x: 10, y: 1, z: 3, x0: 0, x1: 20, y0: 0.5, y1: 1.5 },
+            { x: 30, y: 1, z: 4, x0: 20, x1: 40, y0: 0.5, y1: 1.5 },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses row-local midpoint spans for jagged x rows", () => {
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [0, 0, 1],
+        [100, 0, 2],
+        [10, 1, 3],
+        [30, 1, 4],
+        [35, 1, 5],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("jagged");
+    expect(layout.geometry).toEqual({
+      xMin: -50,
+      xMax: 150,
+      yMin: -0.5,
+      yMax: 1.5,
+      series: [
+        {
+          seriesId: "heat",
+          cells: [
+            { x: 0, y: 0, z: 1, x0: -50, x1: 50, y0: -0.5, y1: 0.5 },
+            { x: 100, y: 0, z: 2, x0: 50, x1: 150, y0: -0.5, y1: 0.5 },
+            { x: 10, y: 1, z: 3, x0: 0, x1: 20, y0: 0.5, y1: 1.5 },
+            { x: 30, y: 1, z: 4, x0: 20, x1: 32.5, y0: 0.5, y1: 1.5 },
+            { x: 35, y: 1, z: 5, x0: 32.5, x1: 37.5, y0: 0.5, y1: 1.5 },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses the nearest chart-wide spacing for singleton rows", () => {
+    expect(
+      deriveHeatmapLayout([
+        xyzSeries("heat", "heat", [
+          [0, 0, 1],
+          [100, 0, 2],
+          [10, 1, 3],
+        ]),
+      ]).geometry,
+    ).toEqual({
+      xMin: -50,
+      xMax: 150,
+      yMin: -0.5,
+      yMax: 1.5,
+      series: [
+        {
+          seriesId: "heat",
+          cells: [
+            { x: 0, y: 0, z: 1, x0: -50, x1: 50, y0: -0.5, y1: 0.5 },
+            { x: 100, y: 0, z: 2, x0: 50, x1: 150, y0: -0.5, y1: 0.5 },
+            { x: 10, y: 1, z: 3, x0: 5, x1: 15, y0: 0.5, y1: 1.5 },
+          ],
+        },
+      ],
     });
   });
 
@@ -286,16 +447,17 @@ describe("syncHeatmapRenderState", () => {
   });
 
   it("preserves NaN-only rows and columns in axis centers", () => {
-    expect(
-      deriveHeatmapLayout([
-        xyzSeries("heat", "heat", [
-          [0, 0, 1],
-          [1, 0, Number.NaN],
-          [0, 2, 3],
-        ]),
-      ]).centers,
-    ).toEqual({
-      xValues: [0, 1],
+    const layout = deriveHeatmapLayout([
+      xyzSeries("heat", "heat", [
+        [0, 0, 1],
+        [1, 0, Number.NaN],
+        [0, 2, 3],
+      ]),
+    ]);
+
+    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.centers).toEqual({
+      xValues: [],
       yValues: [0, 2],
     });
   });
@@ -326,6 +488,7 @@ describe("syncHeatmapRenderState", () => {
         xValues: [],
         yValues: [],
       },
+      xTopology: "shared_uniform",
       geometry: EMPTY_HEATMAP_GEOMETRY,
       valueMin: 0,
       valueMax: 0,
@@ -366,9 +529,10 @@ describe("syncHeatmapRenderState", () => {
       yMax: 1.5,
     });
     expect(state.centers).toEqual({
-      xValues: [0, 1],
+      xValues: [],
       yValues: [0, 1],
     });
+    expect(state.xTopology).toBe("row_local_uniform");
     expect(bufferData).toHaveBeenCalledWith(
       gl.ARRAY_BUFFER,
       new Float32Array(10),

--- a/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/rendering/rendererBounds.test.ts
@@ -261,24 +261,29 @@ describe("syncHeatmapRenderState", () => {
     });
   });
 
-  it("suppresses shared x centers for non-shared uniform heatmaps", () => {
+  it("keeps shared x centers for shared-grid heatmaps", () => {
     const layout = deriveHeatmapLayout([
       xyzSeries("heat", "heat", [
-        [46, 310, 1],
+        [46, 120, 1],
         [7, 120, 2],
-        [19, 185, 3],
-        [7, 310, 4],
+        [19, 120, 3],
+        [46, 185, 4],
+        [7, 185, 5],
+        [19, 185, 6],
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.xTopology).toBe("shared_grid");
     expect(layout.centers).toEqual({
-      xValues: [],
-      yValues: [120, 185, 310],
+      xValues: [7, 19, 46],
+      yValues: [120, 185],
     });
+    expect(getHeatmapXTickValues(layout.centers, layout.xTopology)).toEqual([
+      7, 19, 46,
+    ]);
   });
 
-  it("keeps shared x centers only for shared uniform heatmaps", () => {
+  it("keeps shared x centers for regular shared-grid heatmaps", () => {
     const layout = deriveHeatmapLayout([
       xyzSeries("heat", "heat", [
         [7, 120, 1],
@@ -288,7 +293,7 @@ describe("syncHeatmapRenderState", () => {
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("shared_uniform");
+    expect(layout.xTopology).toBe("shared_grid");
     expect(layout.centers).toEqual({
       xValues: [7, 19],
       yValues: [120, 185],
@@ -298,7 +303,7 @@ describe("syncHeatmapRenderState", () => {
     ]);
   });
 
-  it("classifies row-local uniform x grids and suppresses explicit x ticks", () => {
+  it("classifies row-local x grids and suppresses explicit x ticks", () => {
     const layout = deriveHeatmapLayout([
       xyzSeries("heat", "heat", [
         [0, 0, 1],
@@ -308,7 +313,7 @@ describe("syncHeatmapRenderState", () => {
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.xTopology).toBe("row_local_grid");
     expect(layout.centers).toEqual({
       xValues: [],
       yValues: [0, 1],
@@ -328,7 +333,7 @@ describe("syncHeatmapRenderState", () => {
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.xTopology).toBe("row_local_grid");
     expect(layout.centers.xValues).toEqual([]);
   });
 
@@ -342,7 +347,7 @@ describe("syncHeatmapRenderState", () => {
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("shared_uniform");
+    expect(layout.xTopology).toBe("shared_grid");
     expect(layout.centers.xValues).toEqual([1e9, 2e9]);
   });
 
@@ -375,7 +380,7 @@ describe("syncHeatmapRenderState", () => {
     });
   });
 
-  it("uses row-local midpoint spans for jagged x rows", () => {
+  it("uses row-local midpoint spans for non-shared x rows", () => {
     const layout = deriveHeatmapLayout([
       xyzSeries("heat", "heat", [
         [0, 0, 1],
@@ -386,7 +391,7 @@ describe("syncHeatmapRenderState", () => {
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("jagged");
+    expect(layout.xTopology).toBe("row_local_grid");
     expect(layout.geometry).toEqual({
       xMin: -50,
       xMax: 150,
@@ -455,7 +460,7 @@ describe("syncHeatmapRenderState", () => {
       ]),
     ]);
 
-    expect(layout.xTopology).toBe("row_local_uniform");
+    expect(layout.xTopology).toBe("row_local_grid");
     expect(layout.centers).toEqual({
       xValues: [],
       yValues: [0, 2],
@@ -488,7 +493,7 @@ describe("syncHeatmapRenderState", () => {
         xValues: [],
         yValues: [],
       },
-      xTopology: "shared_uniform",
+      xTopology: "shared_grid",
       geometry: EMPTY_HEATMAP_GEOMETRY,
       valueMin: 0,
       valueMax: 0,
@@ -532,7 +537,7 @@ describe("syncHeatmapRenderState", () => {
       xValues: [],
       yValues: [0, 1],
     });
-    expect(state.xTopology).toBe("row_local_uniform");
+    expect(state.xTopology).toBe("row_local_grid");
     expect(bufferData).toHaveBeenCalledWith(
       gl.ARRAY_BUFFER,
       new Float32Array(10),

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartTooltip.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartTooltip.test.tsx
@@ -170,6 +170,51 @@ describe("getTooltipLines", () => {
     ).toEqual(["x: 2, y: 20", "z: 200"]);
   });
 
+  it("uses row-local heatmap geometry for hover hit testing", () => {
+    const data: ChartOptions = {
+      type: "heatmap",
+      xName: "x",
+      yName: "y",
+      series: [
+        xyzSeries("z", "z", [
+          [0, 0, 1],
+          [100, 0, 2],
+          [10, 20, 3],
+          [30, 20, 4],
+        ]),
+      ],
+    };
+    const layout = deriveHeatmapLayout(data.series);
+
+    const interactionState: ChartInteractionState = {
+      type: "heatmap",
+      xMin: layout.bounds.xMin,
+      xMax: layout.bounds.xMax,
+      yMin: layout.bounds.yMin,
+      yMax: layout.bounds.yMax,
+      margin,
+      zoomState: {
+        scaleX: 1,
+        scaleY: 1,
+        translateX: 0,
+        translateY: 0,
+      },
+      geometry: layout.geometry,
+    };
+
+    expect(
+      getTooltipLines(
+        data,
+        DEFAULT_NUMERIC_LABEL_FORMAT,
+        interactionState,
+        25.5,
+        25,
+        100,
+        100,
+      ),
+    ).toEqual(["x: 10, y: 20", "z: 3"]);
+  });
+
   it("reuses the configured formatter for tooltip values", () => {
     const data: ChartOptions = {
       type: "xy",

--- a/examples/dataset/create_jagged_heatmap_test_case.py
+++ b/examples/dataset/create_jagged_heatmap_test_case.py
@@ -1,0 +1,127 @@
+"""Generate one jagged heatmap dataset for non-shared X-grid testing.
+
+This creates exactly one dataset:
+- `testcase_dataset_08_heatmap_jagged_trace_for_non_shared_x_grid`
+
+The dataset includes two trace quantities that are useful for heatmap testing:
+- `trace_variable_jagged_intensity`: explicit per-row X arrays with jagged spacing
+- `trace_fixed_row_scan_intensity`: per-row fixed-step scans with different x0/step
+
+Run:
+    uv run python examples/dataset/create_jagged_heatmap_test_case.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from typing import cast
+
+import numpy as np
+from dotenv import find_dotenv, load_dotenv
+from fricon import DatasetManager, Trace, Workspace
+
+DATASET_NAME = "testcase_dataset_08_heatmap_jagged_trace_for_non_shared_x_grid"
+
+
+def _load_workspace_from_env() -> str | None:
+    _ = load_dotenv(find_dotenv(usecwd=True), override=False)
+    return os.getenv("FRICON_WORKSPACE")
+
+
+def _build_variable_scan_x(row_index: int) -> np.ndarray:
+    base = 1e-10 * row_index
+    if row_index % 3 == 1:
+        offsets = np.array([0.0, 1.0e-10, 1.8e-10, 4.1e-10, 7.2e-10])
+    elif row_index % 3 == 2:
+        offsets = np.array([0.0, 0.8e-10, 2.7e-10, 3.3e-10, 6.9e-10, 8.4e-10])
+    else:
+        offsets = np.array([0.0, 1.6e-10, 2.2e-10, 5.5e-10])
+    return base + offsets
+
+
+def _build_variable_scan_values(
+    x_values: np.ndarray,
+    row_index: int,
+    wafer_id: int,
+) -> np.ndarray:
+    scaled_x = x_values * 1e10
+    envelope = 62.0 + wafer_id * 1.7 - row_index * 0.8
+    ripple = 3.8 * np.sin(scaled_x * 0.9 + wafer_id * 0.35)
+    tilt = -0.45 * scaled_x
+    return envelope + ripple + tilt
+
+
+def _build_fixed_scan_values(length: int, row_index: int, wafer_id: int) -> np.ndarray:
+    sample_index = np.arange(length, dtype=np.float64)
+    baseline = 54.0 + wafer_id * 2.1 - row_index * 0.65
+    ripple = 4.2 * np.cos(sample_index / 1.7 + row_index * 0.4)
+    shoulder = 0.9 * np.sin(sample_index * 0.8 + wafer_id * 0.25)
+    return baseline + ripple + shoulder
+
+
+def create_jagged_heatmap_case(manager: DatasetManager) -> None:
+    print(f"Creating {DATASET_NAME}")
+
+    with manager.create(
+        DATASET_NAME,
+        description=(
+            "Trace heatmap test case with per-row jagged X arrays and per-row "
+            "fixed-step scans using different x0/step values"
+        ),
+        tags=["testcase", "heatmap", "trace", "jagged", "non-shared-x-grid"],
+    ) as writer:
+        for idx_wafer in range(1, 3):
+            for idx_scan_row in range(1, 7):
+                variable_x = _build_variable_scan_x(idx_scan_row)
+                variable_values = _build_variable_scan_values(
+                    variable_x, idx_scan_row, idx_wafer
+                )
+
+                fixed_x0_m = (idx_scan_row - 1) * 1.4e-10 + idx_wafer * 0.3e-10
+                fixed_step_m = 0.7e-10 + (idx_scan_row % 3) * 0.35e-10
+                fixed_length = 4 + (idx_scan_row % 3)
+                fixed_values = _build_fixed_scan_values(
+                    fixed_length, idx_scan_row, idx_wafer
+                )
+
+                center_mm = 140.0 + idx_scan_row * 23.0 + idx_wafer * 4.5
+                row_metric = 90.0 + idx_wafer * 2.5 - idx_scan_row * 1.3
+                row_metric += 1.2 * math.sin(idx_scan_row / 2)
+
+                writer.write(
+                    idx_wafer=idx_wafer,
+                    idx_scan_row=idx_scan_row,
+                    idx_scan_center_mm=center_mm,
+                    scalar_regular_row_metric=row_metric,
+                    trace_variable_jagged_intensity=Trace.variable_step(
+                        variable_x, variable_values
+                    ),
+                    trace_fixed_row_scan_intensity=Trace.fixed_step(
+                        fixed_x0_m,
+                        fixed_step_m,
+                        fixed_values,
+                    ),
+                )
+
+    print(f"Finished {DATASET_NAME}")
+
+
+def main() -> None:
+    default_workspace = _load_workspace_from_env() or ".dev/ws"
+    parser = argparse.ArgumentParser(description=__doc__)
+    _ = parser.add_argument(
+        "--workspace",
+        default=default_workspace,
+        help=("Workspace path (default: FRICON_WORKSPACE if set, otherwise .dev/ws)"),
+    )
+    args = parser.parse_args()
+    workspace_path = cast(str, args.workspace)
+
+    ws = Workspace.connect(workspace_path)
+    create_jagged_heatmap_case(ws.dataset_manager)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add row-local heatmap X-span derivation so rows with different X sampling render correct cell widths
- classify heatmap X topology as shared vs row-local to keep explicit X ticks only when one grid is shared
- add a dataset generator for jagged heatmap trace data to exercise non-shared X-grid scenarios
- expand chart tests for row-local geometry, tooltip hit testing, shared-grid ticks, and span-aware tolerance

## Testing
- `pnpm --dir crates/fricon-ui/frontend exec vitest run src/features/charts/rendering/rendererBounds.test.ts src/features/charts/ui/ChartTooltip.test.tsx src/features/charts/hooks/useWebGLChart.test.tsx`
- `pnpm --dir crates/fricon-ui/frontend run type-check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
