### PR TITLE
chore: Update Rust toolchain to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 [workspace.package]
 version = "0.1.3"
 edition = "2024"
+rust-version = "1.95"
 description = "Data collection automation framework."
 repository = "https://github.com/kahojyun/fricon"
 license = "MIT OR Apache-2.0"

--- a/crates/fricon-cli/Cargo.toml
+++ b/crates/fricon-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fricon-cli"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/fricon-py/Cargo.toml
+++ b/crates/fricon-py/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fricon-py"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/fricon-ui/Cargo.toml
+++ b/crates/fricon-ui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fricon-ui"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/fricon-ui/build.rs
+++ b/crates/fricon-ui/build.rs
@@ -25,8 +25,7 @@ fn find_pnpm_executable() -> &'static str {
             if Command::new(candidate)
                 .arg("--version")
                 .output()
-                .map(|output| output.status.success())
-                .unwrap_or(false)
+                .is_ok_and(|output| output.status.success())
             {
                 return candidate;
             }

--- a/crates/fricon-ui/src/features/charts/filter_table.rs
+++ b/crates/fricon-ui/src/features/charts/filter_table.rs
@@ -269,7 +269,7 @@ pub(crate) async fn build_filter_batch(
     let arrays = filter_schema
         .fields()
         .iter()
-        .zip(selected_filters.into_iter())
+        .zip(selected_filters)
         .map(|(field, (_, value))| build_filter_array(field.data_type(), value))
         .collect::<Result<Vec<_>>>()?;
 

--- a/crates/fricon-ui/src/features/charts/filter_table.rs
+++ b/crates/fricon-ui/src/features/charts/filter_table.rs
@@ -112,11 +112,12 @@ fn build_float64_array(value: &serde_json::Value) -> Result<ArrayRef> {
 }
 
 fn is_complex_fields(fields: &Fields) -> bool {
-    fields.len() == 2
-        && fields[0].name() == "real"
-        && fields[1].name() == "imag"
-        && matches!(fields[0].data_type(), DataType::Float64)
-        && matches!(fields[1].data_type(), DataType::Float64)
+    fields.as_ref().as_array::<2>().is_some_and(|[real, imag]| {
+        real.name() == "real"
+            && imag.name() == "imag"
+            && matches!(real.data_type(), DataType::Float64)
+            && matches!(imag.data_type(), DataType::Float64)
+    })
 }
 
 fn build_complex_array(fields: &Fields, value: &serde_json::Value) -> Result<ArrayRef> {

--- a/crates/fricon-ui/src/launch/resolve.rs
+++ b/crates/fricon-ui/src/launch/resolve.rs
@@ -52,17 +52,18 @@ pub(crate) fn select_workspace_path(launch_source: &LaunchSource) -> Result<Opti
     loop {
         match prompt_missing_workspace_action(launch_source) {
             MissingWorkspaceAction::ChooseWorkspace => {}
-            MissingWorkspaceAction::ShowCliHelpAndExit => {
+            MissingWorkspaceAction::ShowCliHelpAndExit
                 if let LaunchSource::Cli {
                     command_name,
                     cli_help,
-                } = launch_source
-                {
-                    show_cli_help(command_name, cli_help);
-                }
+                } = launch_source =>
+            {
+                show_cli_help(command_name, cli_help);
                 return Ok(None);
             }
-            MissingWorkspaceAction::Exit => return Ok(None),
+            MissingWorkspaceAction::ShowCliHelpAndExit | MissingWorkspaceAction::Exit => {
+                return Ok(None);
+            }
         }
 
         let Some(path) = FileDialog::new().pick_folder() else {

--- a/crates/fricon/Cargo.toml
+++ b/crates/fricon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fricon"
 version.workspace = true
 edition.workspace = true
-rust-version = "1.89"
+rust-version = "1.95"
 description.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/fricon/Cargo.toml
+++ b/crates/fricon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fricon"
 version.workspace = true
 edition.workspace = true
-rust-version = "1.95"
+rust-version.workspace = true
 description.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/fricon/src/dataset/schema/model.rs
+++ b/crates/fricon/src/dataset/schema/model.rs
@@ -90,32 +90,30 @@ impl TraceKind {
     #[must_use]
     pub fn parse_data_type(data_type: &DataType) -> Option<(TraceKind, &Field)> {
         fn parse_fixed_step(fields: &[FieldRef]) -> Option<(TraceKind, &Field)> {
+            let [x0, step, y] = fields.as_array::<3>()?;
             (fields.iter().map(|f| f.name()).eq(["x0", "step", "y"])
-                && !fields[0].is_nullable()
-                && !fields[1].is_nullable()
-                && !fields[2].is_nullable())
-            .then(|| match [0, 1, 2].map(|i| fields[i].data_type()) {
+                && !x0.is_nullable()
+                && !step.is_nullable()
+                && !y.is_nullable())
+            .then(|| match [x0.data_type(), step.data_type(), y.data_type()] {
                 [DataType::Float64, DataType::Float64, DataType::List(y)] => {
                     Some((TraceKind::FixedStep, y.as_ref()))
                 }
                 _ => None,
-            })
-            .flatten()
+            })?
         }
 
         fn parse_variable_step(fields: &[FieldRef]) -> Option<(TraceKind, &Field)> {
-            (fields.iter().map(|f| f.name()).eq(["x", "y"])
-                && !fields[0].is_nullable()
-                && !fields[1].is_nullable())
-            .then(|| match [0, 1].map(|i| fields[i].data_type()) {
-                [DataType::List(x), DataType::List(y)]
-                    if matches!(x.data_type(), DataType::Float64) && !x.is_nullable() =>
-                {
-                    Some((TraceKind::VariableStep, y.as_ref()))
-                }
-                _ => None,
-            })
-            .flatten()
+            let [x, y] = fields.as_array::<2>()?;
+            (fields.iter().map(|f| f.name()).eq(["x", "y"]) && !x.is_nullable() && !y.is_nullable())
+                .then(|| match [x.data_type(), y.data_type()] {
+                    [DataType::List(x), DataType::List(y)]
+                        if matches!(x.data_type(), DataType::Float64) && !x.is_nullable() =>
+                    {
+                        Some((TraceKind::VariableStep, y.as_ref()))
+                    }
+                    _ => None,
+                })?
         }
 
         match data_type {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary
- Bump the workspace toolchain to Rust 1.95 and align the `fricon` crate MSRV declaration
- Fix two clippy issues exposed by the newer compiler in the UI build script and filter table code

## Testing
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`