### PR TITLE
chore: ignore webdriver driver build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,5 +7,7 @@ minimumReleaseAgeExclude:
 
 ignoredBuiltDependencies:
   - "@tailwindcss/oxide"
+  - edgedriver
   - esbuild
+  - geckodriver
   - msw


### PR DESCRIPTION
## Summary
- add `edgedriver` and `geckodriver` to `ignoredBuiltDependencies` in `pnpm-workspace.yaml`
- keep pnpm from prompting on those install scripts during dependency installation

## Why
- these packages are transitive WebDriver helpers under `@wdio/utils`
- this repository's active frontend test paths use Playwright and the desktop smoke path starts `tauri-driver`, so ignoring these install scripts does not affect the current macOS, Linux, or Windows workflows

## Validation
- commit hooks passed: `check yaml`
- verified the repo test entrypoints and smoke config to confirm the change only affects unused install-time driver wrappers