### PR TITLE
feat(ui): use binary chart IPC for chart data

### DIFF
--- a/.agents/skills/pr-preflight-checklist/SKILL.md
+++ b/.agents/skills/pr-preflight-checklist/SKILL.md
@@ -43,6 +43,7 @@ Reduce PR back-and-forth by running the smallest complete check set before pushi
 
 - Prefer `pnpm` and `uv` for package management commands.
 - Run `uv run maturin develop` before `uv run pytest` for Python binding tests.
+- Treat `cargo clippy --all-targets --all-features -- -D warnings` as the required Rust lint gate for preflight, not a warnings-only advisory pass.
 - Never hand-edit `crates/fricon-ui/frontend/src/shared/lib/bindings.ts`; regenerate it.
 - Treat `pnpm run check` as the default frontend gate and ensure frontend slice-boundary validation is covered by it or by `pnpm run depcruise:frontend` when commands are split.
 - Treat `pnpm run test` as a batch command only; choose `test:unit` or `test:browser` for targeted reruns.

--- a/.agents/skills/pr-preflight-checklist/references/checklist-matrix.md
+++ b/.agents/skills/pr-preflight-checklist/references/checklist-matrix.md
@@ -28,7 +28,7 @@ Run only for changed areas.
 ```bash
 cargo +nightly fmt --all --check
 cargo check
-cargo clippy --all-targets --all-features
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test --workspace
 ```
 
@@ -101,7 +101,7 @@ Run once before opening/updating PR.
 cargo +nightly fmt --all --check
 cargo check
 cargo build --workspace --locked
-cargo clippy --all-targets --all-features
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test --workspace
 cargo deny --workspace --all-features check
 ```

--- a/crates/fricon-ui/frontend/src/app/ui/DatasetExplorerScreen.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/app/ui/DatasetExplorerScreen.browser.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { clearMocks, mockIPC } from "@tauri-apps/api/mocks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { encodeChartSnapshotForTest } from "@/shared/test/chartWire";
 import { DatasetExplorerScreen } from "./DatasetExplorerScreen";
 
 const { datasetCreatedListenMock, datasetUpdatedListenMock } = vi.hoisted(
@@ -148,7 +149,7 @@ describe("DatasetExplorerScreen integration", () => {
             columnUniqueValues: {},
           };
         case "dataset_chart_data":
-          return {
+          return encodeChartSnapshotForTest({
             type: "xy",
             plotMode: "quantity_vs_sweep",
             drawStyle: "line",
@@ -159,10 +160,10 @@ describe("DatasetExplorerScreen integration", () => {
                 id: "signal",
                 label: "signal",
                 pointCount: 2,
-                values: [0, 1, 1, 2],
+                values: new Float64Array([0, 1, 1, 2]),
               },
             ],
-          };
+          });
         case "get_dataset_write_status":
           return { rowCount: 0 };
         default:

--- a/crates/fricon-ui/frontend/src/app/ui/DatasetExplorerScreen.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/app/ui/DatasetExplorerScreen.browser.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { clearMocks, mockIPC } from "@tauri-apps/api/mocks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { encodeChartSnapshotForTest } from "@/shared/test/chartWire";
+import { encodeChartSnapshotBufferForTest } from "@/shared/test/chartWire";
 import { DatasetExplorerScreen } from "./DatasetExplorerScreen";
 
 const { datasetCreatedListenMock, datasetUpdatedListenMock } = vi.hoisted(
@@ -149,7 +149,7 @@ describe("DatasetExplorerScreen integration", () => {
             columnUniqueValues: {},
           };
         case "dataset_chart_data":
-          return encodeChartSnapshotForTest({
+          return encodeChartSnapshotBufferForTest({
             type: "xy",
             plotMode: "quantity_vs_sweep",
             drawStyle: "line",

--- a/crates/fricon-ui/frontend/src/features/charts/api/client.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/client.ts
@@ -1,13 +1,11 @@
 import {
-  commands,
   type DatasetWriteStatus,
   type TableData as WireFilterTableData,
+  commands,
 } from "@/shared/lib/bindings";
-import { invoke } from "@/shared/lib/tauri";
+import { invoke, invokeRawBytes } from "@/shared/lib/tauri";
 import {
-  normalizeChartSnapshot,
   normalizeFilterTableData,
-  normalizeLiveChartUpdate,
   toWireChartOptions,
   toWireLiveChartOptions,
   type ChartDataOptions,
@@ -15,10 +13,14 @@ import {
   type FilterTableOptions,
   type LiveChartDataOptions,
 } from "./types";
+import { decodeChartSnapshot, decodeLiveChartUpdate } from "./wire";
 
 export async function fetchChartData(id: number, options: ChartDataOptions) {
-  return normalizeChartSnapshot(
-    await invoke(commands.datasetChartData(id, toWireChartOptions(options))),
+  return decodeChartSnapshot(
+    await invokeRawBytes("dataset_chart_data", {
+      id,
+      options: toWireChartOptions(options),
+    }),
   );
 }
 
@@ -27,16 +29,14 @@ export async function fetchLiveChartData(
   options: LiveChartDataOptions,
   knownRowCount: number | null,
 ) {
-  return normalizeLiveChartUpdate(
-    await invoke(
-      commands.datasetLiveChartData(
-        id,
-        toWireLiveChartOptions({
-          ...options,
-          knownRowCount,
-        }),
-      ),
-    ),
+  return decodeLiveChartUpdate(
+    await invokeRawBytes("dataset_live_chart_data", {
+      id,
+      options: toWireLiveChartOptions({
+        ...options,
+        knownRowCount,
+      }),
+    }),
   );
 }
 

--- a/crates/fricon-ui/frontend/src/features/charts/api/types.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.test.ts
@@ -143,6 +143,31 @@ describe("chart api wire decoding", () => {
     );
   });
 
+  it("rejects trailing numeric payload bytes in snapshots", () => {
+    const bytes = encodeChartSnapshotForTest({
+      type: "xy",
+      plotMode: "xy",
+      drawStyle: "points",
+      xName: "timestamp",
+      yName: "value",
+      series: [
+        {
+          id: "signal",
+          label: "signal",
+          pointCount: 1,
+          values: new Float64Array([1, 2]),
+        },
+      ],
+    });
+    const extended = new Uint8Array(bytes.byteLength + 8);
+    extended.set(bytes, 0);
+    new Float64Array(extended.buffer, bytes.byteLength, 1)[0] = 99;
+
+    expect(() => decodeChartSnapshot(extended)).toThrow(
+      "Chart wire payload has trailing numeric bytes.",
+    );
+  });
+
   it("rejects invalid live payload metadata", () => {
     const bytes = encodeLiveChartUpdateForTest({
       mode: "append",

--- a/crates/fricon-ui/frontend/src/features/charts/api/types.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.test.ts
@@ -5,6 +5,11 @@ import {
   encodeLiveChartUpdateForTest,
 } from "@/shared/test/chartWire";
 
+function alignUp(value: number, alignment: number): number {
+  const remainder = value % alignment;
+  return remainder === 0 ? value : value + alignment - remainder;
+}
+
 describe("chart api wire decoding", () => {
   it("preserves 64-bit precision for snapshot series values", () => {
     const snapshot = encodeChartSnapshotForTest({
@@ -26,9 +31,34 @@ describe("chart api wire decoding", () => {
     const result = decodeChartSnapshot(snapshot);
 
     expect(result.series[0]?.values).toBeInstanceOf(Float64Array);
+    expect(result.series[0]?.values.buffer).toBe(snapshot.buffer);
     expect(Array.from(result.series[0]?.values ?? [])).toEqual([
       1710000000000, 1, 1710000000001, 2,
     ]);
+  });
+
+  it("rejects misaligned numeric payload views", () => {
+    const snapshot = encodeChartSnapshotForTest({
+      type: "xy",
+      plotMode: "xy",
+      drawStyle: "points",
+      xName: "timestamp",
+      yName: "value",
+      series: [
+        {
+          id: "signal",
+          label: "signal",
+          pointCount: 1,
+          values: new Float64Array([1, 2]),
+        },
+      ],
+    });
+    const container = new Uint8Array(snapshot.length + 1);
+    container.set(snapshot, 1);
+
+    expect(() => decodeChartSnapshot(container.subarray(1))).toThrow(
+      "Chart wire numeric payload is not aligned.",
+    );
   });
 
   it("preserves 64-bit precision for live append payloads", () => {
@@ -84,10 +114,10 @@ describe("chart api wire decoding", () => {
       yName: "value",
       series: [],
     });
-    bytes[4] = 2;
+    bytes[4] = 3;
 
     expect(() => decodeChartSnapshot(bytes)).toThrow(
-      "Unsupported chart wire version: 2",
+      "Unsupported chart wire version: 3",
     );
   });
 
@@ -126,9 +156,11 @@ describe("chart api wire decoding", () => {
         },
       ],
     });
-    const metadataLength = new DataView(bytes.buffer).getUint32(6, true);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const metadataLength = view.getUint32(8, true);
+    const numericOffset = view.getUint32(12, true);
     const metadata = JSON.parse(
-      new TextDecoder().decode(bytes.subarray(10, 10 + metadataLength)),
+      new TextDecoder().decode(bytes.subarray(16, 16 + metadataLength)),
     ) as {
       ops: Record<string, unknown>[];
     };
@@ -139,13 +171,16 @@ describe("chart api wire decoding", () => {
       shape: "xy",
     };
     const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
+    const patchedNumericOffset = alignUp(16 + metadataBytes.length, 8);
     const patched = new Uint8Array(
-      10 + metadataBytes.length + (bytes.length - 10 - metadataLength),
+      patchedNumericOffset + (bytes.length - numericOffset),
     );
-    patched.set(bytes.subarray(0, 10), 0);
-    new DataView(patched.buffer).setUint32(6, metadataBytes.length, true);
-    patched.set(metadataBytes, 10);
-    patched.set(bytes.subarray(10 + metadataLength), 10 + metadataBytes.length);
+    patched.set(bytes.subarray(0, 16), 0);
+    const patchedView = new DataView(patched.buffer);
+    patchedView.setUint32(8, metadataBytes.length, true);
+    patchedView.setUint32(12, patchedNumericOffset, true);
+    patched.set(metadataBytes, 16);
+    patched.set(bytes.subarray(numericOffset), patchedNumericOffset);
 
     expect(() => decodeLiveChartUpdate(patched)).toThrow(
       "Expected ops[0].seriesId to be a string.",

--- a/crates/fricon-ui/frontend/src/features/charts/api/types.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.test.ts
@@ -1,13 +1,13 @@
-import type {
-  ChartSnapshot as WireChartSnapshot,
-  LiveChartDataResponse as WireLiveChartResponse,
-} from "@/shared/lib/bindings";
 import { describe, expect, it } from "vitest";
-import { normalizeChartSnapshot, normalizeLiveChartUpdate } from "./types";
+import { decodeChartSnapshot, decodeLiveChartUpdate } from "./wire";
+import {
+  encodeChartSnapshotForTest,
+  encodeLiveChartUpdateForTest,
+} from "@/shared/test/chartWire";
 
-describe("chart api types", () => {
+describe("chart api wire decoding", () => {
   it("preserves 64-bit precision for snapshot series values", () => {
-    const snapshot = {
+    const snapshot = encodeChartSnapshotForTest({
       type: "xy",
       plotMode: "xy",
       drawStyle: "points",
@@ -18,12 +18,12 @@ describe("chart api types", () => {
           id: "signal",
           label: "signal",
           pointCount: 2,
-          values: [1710000000000, 1, 1710000000001, 2],
+          values: new Float64Array([1710000000000, 1, 1710000000001, 2]),
         },
       ],
-    } satisfies WireChartSnapshot;
+    });
 
-    const result = normalizeChartSnapshot(snapshot);
+    const result = decodeChartSnapshot(snapshot);
 
     expect(result.series[0]?.values).toBeInstanceOf(Float64Array);
     expect(Array.from(result.series[0]?.values ?? [])).toEqual([
@@ -32,20 +32,20 @@ describe("chart api types", () => {
   });
 
   it("preserves 64-bit precision for live append payloads", () => {
-    const response = {
+    const response = encodeLiveChartUpdateForTest({
       mode: "append",
-      row_count: 2,
+      rowCount: 2,
       ops: [
         {
           kind: "append_points",
-          series_id: "signal",
-          point_count: 1,
-          values: [1710000000000, 1],
+          seriesId: "signal",
+          pointCount: 1,
+          values: new Float64Array([1710000000000, 1]),
         },
       ],
-    } satisfies WireLiveChartResponse;
+    });
 
-    const update = normalizeLiveChartUpdate(response);
+    const update = decodeLiveChartUpdate(response);
 
     expect(update.mode).toBe("append");
     if (update.mode !== "append") {
@@ -59,22 +59,96 @@ describe("chart api types", () => {
     }
   });
 
-  it("rejects unknown chart snapshot types instead of silently treating them as xy", () => {
-    expect(() =>
-      normalizeChartSnapshot({
-        type: "line",
-        xName: "timestamp",
-        series: [],
-      } as unknown as WireChartSnapshot),
-    ).toThrow("Unknown chart snapshot type: line");
+  it("rejects invalid chart wire payload kinds", () => {
+    const bytes = encodeChartSnapshotForTest({
+      type: "xy",
+      plotMode: "xy",
+      drawStyle: "points",
+      xName: "timestamp",
+      yName: "value",
+      series: [],
+    });
+    bytes[5] = 9;
+
+    expect(() => decodeChartSnapshot(bytes)).toThrow(
+      "Unknown chart wire payload kind: 9",
+    );
   });
 
-  it("rejects unknown live update modes instead of silently treating them as append", () => {
-    expect(() =>
-      normalizeLiveChartUpdate({
-        mode: "delta",
-        row_count: 2,
-      } as unknown as WireLiveChartResponse),
-    ).toThrow("Unknown live chart update mode: delta");
+  it("rejects unsupported chart wire versions", () => {
+    const bytes = encodeChartSnapshotForTest({
+      type: "xy",
+      plotMode: "xy",
+      drawStyle: "points",
+      xName: "timestamp",
+      yName: "value",
+      series: [],
+    });
+    bytes[4] = 2;
+
+    expect(() => decodeChartSnapshot(bytes)).toThrow(
+      "Unsupported chart wire version: 2",
+    );
+  });
+
+  it("rejects truncated numeric payloads", () => {
+    const bytes = encodeChartSnapshotForTest({
+      type: "xy",
+      plotMode: "xy",
+      drawStyle: "points",
+      xName: "timestamp",
+      yName: "value",
+      series: [
+        {
+          id: "signal",
+          label: "signal",
+          pointCount: 1,
+          values: new Float64Array([1, 2]),
+        },
+      ],
+    }).subarray(0, -1);
+
+    expect(() => decodeChartSnapshot(bytes)).toThrow(
+      "Chart wire numeric payload is truncated.",
+    );
+  });
+
+  it("rejects invalid live payload metadata", () => {
+    const bytes = encodeLiveChartUpdateForTest({
+      mode: "append",
+      rowCount: 1,
+      ops: [
+        {
+          kind: "append_points",
+          seriesId: "signal",
+          pointCount: 1,
+          values: new Float64Array([1, 2]),
+        },
+      ],
+    });
+    const metadataLength = new DataView(bytes.buffer).getUint32(6, true);
+    const metadata = JSON.parse(
+      new TextDecoder().decode(bytes.subarray(10, 10 + metadataLength)),
+    ) as {
+      ops: Record<string, unknown>[];
+    };
+    metadata.ops[0] = {
+      kind: "append_points",
+      pointCount: 1,
+      valueCount: 2,
+      shape: "xy",
+    };
+    const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
+    const patched = new Uint8Array(
+      10 + metadataBytes.length + (bytes.length - 10 - metadataLength),
+    );
+    patched.set(bytes.subarray(0, 10), 0);
+    new DataView(patched.buffer).setUint32(6, metadataBytes.length, true);
+    patched.set(metadataBytes, 10);
+    patched.set(bytes.subarray(10 + metadataLength), 10 + metadataBytes.length);
+
+    expect(() => decodeLiveChartUpdate(patched)).toThrow(
+      "Expected ops[0].seriesId to be a string.",
+    );
   });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.ts
@@ -1,16 +1,10 @@
 import type {
-  ChartSnapshot as WireChartSnapshot,
   ColumnUniqueValue,
   ColumnInfo,
   DatasetChartDataOptions as WireChartDataOptions,
   DatasetWriteStatus,
   FilterTableOptions,
-  FlatSeries as WireFlatSeries,
-  FlatXYSeries as WireFlatXYSeries,
-  FlatXYZSeries as WireFlatXYZSeries,
-  LiveChartAppendOperation as WireLiveChartAppendOperation,
   LiveChartDataOptions as WireLiveChartDataOptions,
-  LiveChartDataResponse as WireLiveChartResponse,
   Row as FilterTableRow,
   TableData as WireFilterTableData,
   UiDatasetStatus as DatasetStatus,
@@ -188,56 +182,6 @@ export function toWireLiveChartOptions(
   };
 }
 
-export function normalizeChartSnapshot(result: WireChartSnapshot): ChartModel {
-  switch (result.type) {
-    case "heatmap":
-      return {
-        type: "heatmap",
-        xName: result.xName,
-        yName: result.yName,
-        series: result.series.map(normalizeXYZSeries),
-      };
-    case "xy":
-      return {
-        type: "xy",
-        plotMode: result.plotMode,
-        drawStyle: result.drawStyle,
-        xName: result.xName,
-        yName: result.yName,
-        series: result.series.map(normalizeXYSeries),
-      };
-    default:
-      return assertNever(
-        result,
-        `Unknown chart snapshot type: ${String((result as { type?: unknown }).type)}`,
-      );
-  }
-}
-
-export function normalizeLiveChartUpdate(
-  result: WireLiveChartResponse,
-): LiveChartUpdate {
-  switch (result.mode) {
-    case "reset":
-      return {
-        mode: "reset",
-        rowCount: result.row_count,
-        snapshot: normalizeChartSnapshot(result.snapshot),
-      };
-    case "append":
-      return {
-        mode: "append",
-        rowCount: result.row_count,
-        ops: result.ops.map(normalizeLiveChartAppendOperation),
-      };
-    default:
-      return assertNever(
-        result,
-        `Unknown live chart update mode: ${String((result as { mode?: unknown }).mode)}`,
-      );
-  }
-}
-
 export function normalizeFilterTableData(
   result: WireFilterTableData,
 ): FilterTableData {
@@ -288,70 +232,4 @@ function toWireXYPlotMode(options: XYPlotModeOptions):
         quantity: options.quantity,
       };
   }
-}
-
-function normalizeXYSeries(series: WireFlatXYSeries) {
-  return {
-    id: series.id,
-    label: series.label,
-    values: Float64Array.from(series.values),
-    pointCount: series.pointCount,
-  };
-}
-
-function normalizeXYZSeries(series: WireFlatXYZSeries) {
-  return {
-    id: series.id,
-    label: series.label,
-    values: Float64Array.from(series.values),
-    pointCount: series.pointCount,
-  };
-}
-
-function normalizeFlatSeries(series: WireFlatSeries) {
-  switch (series.shape) {
-    case "xy":
-      return {
-        shape: "xy" as const,
-        series: normalizeXYSeries(series),
-      };
-    case "xyz":
-      return {
-        shape: "xyz" as const,
-        series: normalizeXYZSeries(series),
-      };
-    default:
-      return assertNever(
-        series,
-        `Unknown flat series shape: ${String((series as { shape?: unknown }).shape)}`,
-      );
-  }
-}
-
-function normalizeLiveChartAppendOperation(
-  operation: WireLiveChartAppendOperation,
-): LiveChartAppendOperation {
-  switch (operation.kind) {
-    case "append_points":
-      return {
-        kind: "append_points",
-        seriesId: operation.series_id,
-        values: Float64Array.from(operation.values),
-        pointCount: operation.point_count,
-      };
-    case "append_series":
-      return {
-        kind: "append_series",
-        series: normalizeFlatSeries(operation.series),
-      };
-    default:
-      return assertNever(
-        operation,
-        `Unknown live chart operation kind: ${String((operation as { kind?: unknown }).kind)}`,
-      );
-  }
-}
-
-function assertNever(_value: never, message: string): never {
-  throw new Error(message);
 }

--- a/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
@@ -8,8 +8,8 @@ import type {
 import type { LiveChartAppendOperation, LiveChartUpdate } from "./types";
 
 const MAGIC = "FCHT";
-const VERSION = 1;
-const HEADER_LENGTH = 10;
+const VERSION = 2;
+const HEADER_LENGTH = 16;
 
 const textDecoder = new TextDecoder();
 
@@ -137,10 +137,17 @@ function parseFrame(bytes: Uint8Array): {
   }
 
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  const metadataLength = view.getUint32(6, true);
+  const metadataLength = view.getUint32(8, true);
   const metadataEnd = HEADER_LENGTH + metadataLength;
+  const numericOffset = view.getUint32(12, true);
   if (metadataEnd > bytes.byteLength) {
     throw new Error("Chart wire metadata is truncated.");
+  }
+  if (numericOffset < metadataEnd || numericOffset > bytes.byteLength) {
+    throw new Error("Chart wire numeric payload offset is invalid.");
+  }
+  if (numericOffset % 8 !== 0) {
+    throw new Error("Chart wire numeric payload offset must be 8-byte aligned.");
   }
 
   const metadataBytes = bytes.subarray(HEADER_LENGTH, metadataEnd);
@@ -157,7 +164,7 @@ function parseFrame(bytes: Uint8Array): {
   return {
     kind,
     metadata,
-    values: bytes.subarray(metadataEnd),
+    values: bytes.subarray(numericOffset),
   };
 }
 
@@ -261,8 +268,14 @@ function createNumericReader(bytes: Uint8Array) {
   if (bytes.byteLength % 8 !== 0) {
     throw new Error("Chart wire numeric payload is truncated.");
   }
-
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (bytes.byteOffset % 8 !== 0) {
+    throw new Error("Chart wire numeric payload is not aligned.");
+  }
+  const alignedFloatView = new Float64Array(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength / 8,
+  );
   let offset = 0;
 
   return {
@@ -272,12 +285,11 @@ function createNumericReader(bytes: Uint8Array) {
         throw new Error("Chart wire numeric payload is truncated.");
       }
 
-      const result = new Float64Array(valueCount);
-      for (let index = 0; index < valueCount; index += 1) {
-        result[index] = view.getFloat64(offset + index * 8, true);
-      }
       offset += byteLength;
-      return result;
+      return alignedFloatView.subarray(
+        (offset - byteLength) / 8,
+        offset / 8,
+      );
     },
     finish() {
       if (offset !== bytes.byteLength) {

--- a/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
@@ -78,6 +78,13 @@ export function decodeChartSnapshot(bytes: Uint8Array): ChartModel {
   }
 }
 
+/**
+ * Decodes the feature-local `FCHT` chart frame emitted by the Tauri backend.
+ *
+ * This decoder assumes the transport hands back an aligned `ArrayBuffer`
+ * wrapped as a zero-offset `Uint8Array` at the raw invoke boundary. The frame
+ * still validates its own numeric offset so payload corruption fails loudly.
+ */
 export function decodeLiveChartUpdate(bytes: Uint8Array): LiveChartUpdate {
   const frame = parseFrame(bytes);
   switch (frame.kind) {

--- a/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
@@ -183,7 +183,7 @@ function decodeXySnapshot(
 ): Extract<ChartModel, { type: "xy" }> {
   const metadata = readXySnapshotMetadata(metadataValue);
   const reader = createNumericReader(values);
-  return {
+  const snapshot: Extract<ChartModel, { type: "xy" }> = {
     type: "xy",
     plotMode: metadata.plotMode,
     drawStyle: metadata.drawStyle,
@@ -194,6 +194,8 @@ function decodeXySnapshot(
       values: reader.read(series.valueCount),
     })),
   };
+  reader.finish();
+  return snapshot;
 }
 
 function decodeHeatmapSnapshot(
@@ -202,7 +204,7 @@ function decodeHeatmapSnapshot(
 ): Extract<ChartModel, { type: "heatmap" }> {
   const metadata = readHeatmapSnapshotMetadata(metadataValue);
   const reader = createNumericReader(values);
-  return {
+  const snapshot: Extract<ChartModel, { type: "heatmap" }> = {
     type: "heatmap",
     xName: metadata.xName,
     yName: metadata.yName,
@@ -211,6 +213,8 @@ function decodeHeatmapSnapshot(
       values: reader.read(series.valueCount),
     })),
   };
+  reader.finish();
+  return snapshot;
 }
 
 function decodeLiveAppend(

--- a/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
@@ -154,7 +154,9 @@ function parseFrame(bytes: Uint8Array): {
     throw new Error("Chart wire numeric payload offset is invalid.");
   }
   if (numericOffset % 8 !== 0) {
-    throw new Error("Chart wire numeric payload offset must be 8-byte aligned.");
+    throw new Error(
+      "Chart wire numeric payload offset must be 8-byte aligned.",
+    );
   }
 
   const metadataBytes = bytes.subarray(HEADER_LENGTH, metadataEnd);
@@ -293,10 +295,7 @@ function createNumericReader(bytes: Uint8Array) {
       }
 
       offset += byteLength;
-      return alignedFloatView.subarray(
-        (offset - byteLength) / 8,
-        offset / 8,
-      );
+      return alignedFloatView.subarray((offset - byteLength) / 8, offset / 8);
     },
     finish() {
       if (offset !== bytes.byteLength) {

--- a/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/wire.ts
@@ -1,0 +1,487 @@
+import type {
+  ChartSeries,
+  ChartModel,
+  HeatmapSeries,
+  XYDrawStyle,
+  XYPlotMode,
+} from "@/shared/lib/chartTypes";
+import type { LiveChartAppendOperation, LiveChartUpdate } from "./types";
+
+const MAGIC = "FCHT";
+const VERSION = 1;
+const HEADER_LENGTH = 10;
+
+const textDecoder = new TextDecoder();
+
+type PayloadKind = 1 | 2 | 3 | 4 | 5;
+type SeriesShape = "xy" | "xyz";
+
+interface SeriesMetadata {
+  id: string;
+  label: string;
+  pointCount: number;
+  valueCount: number;
+}
+
+interface XySnapshotMetadata {
+  plotMode: XYPlotMode;
+  drawStyle: XYDrawStyle;
+  xName: string;
+  yName: string | null;
+  series: SeriesMetadata[];
+}
+
+interface HeatmapSnapshotMetadata {
+  xName: string;
+  yName: string;
+  series: SeriesMetadata[];
+}
+
+interface LiveResetMetadata<T> {
+  rowCount: number;
+  snapshot: T;
+}
+
+type LiveAppendOperationMetadata =
+  | {
+      kind: "append_points";
+      seriesId: string;
+      shape: SeriesShape;
+      pointCount: number;
+      valueCount: number;
+    }
+  | {
+      kind: "append_series";
+      shape: SeriesShape;
+      id: string;
+      label: string;
+      pointCount: number;
+      valueCount: number;
+    };
+
+interface LiveAppendMetadata {
+  rowCount: number;
+  ops: LiveAppendOperationMetadata[];
+}
+
+export function decodeChartSnapshot(bytes: Uint8Array): ChartModel {
+  const frame = parseFrame(bytes);
+  switch (frame.kind) {
+    case 1:
+      return decodeXySnapshot(frame.metadata, frame.values);
+    case 2:
+      return decodeHeatmapSnapshot(frame.metadata, frame.values);
+    default:
+      throw new Error(
+        `Expected chart snapshot payload, received kind ${frame.kind}.`,
+      );
+  }
+}
+
+export function decodeLiveChartUpdate(bytes: Uint8Array): LiveChartUpdate {
+  const frame = parseFrame(bytes);
+  switch (frame.kind) {
+    case 3: {
+      const metadata = readLiveResetMetadata<XySnapshotMetadata>(
+        frame.metadata,
+        readXySnapshotMetadata,
+      );
+      return {
+        mode: "reset",
+        rowCount: metadata.rowCount,
+        snapshot: decodeXySnapshot(metadata.snapshot, frame.values),
+      };
+    }
+    case 4: {
+      const metadata = readLiveResetMetadata<HeatmapSnapshotMetadata>(
+        frame.metadata,
+        readHeatmapSnapshotMetadata,
+      );
+      return {
+        mode: "reset",
+        rowCount: metadata.rowCount,
+        snapshot: decodeHeatmapSnapshot(metadata.snapshot, frame.values),
+      };
+    }
+    case 5:
+      return decodeLiveAppend(frame.metadata, frame.values);
+    default:
+      throw new Error(
+        `Expected live chart payload, received kind ${frame.kind}.`,
+      );
+  }
+}
+
+function parseFrame(bytes: Uint8Array): {
+  kind: PayloadKind;
+  metadata: unknown;
+  values: Uint8Array;
+} {
+  if (bytes.byteLength < HEADER_LENGTH) {
+    throw new Error("Chart wire payload is truncated.");
+  }
+
+  const magic = textDecoder.decode(bytes.subarray(0, 4));
+  if (magic !== MAGIC) {
+    throw new Error(`Invalid chart wire magic: ${magic}`);
+  }
+
+  const version = bytes[4];
+  if (version !== VERSION) {
+    throw new Error(`Unsupported chart wire version: ${version}`);
+  }
+
+  const kind = bytes[5];
+  if (!isPayloadKind(kind)) {
+    throw new Error(`Unknown chart wire payload kind: ${kind}`);
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const metadataLength = view.getUint32(6, true);
+  const metadataEnd = HEADER_LENGTH + metadataLength;
+  if (metadataEnd > bytes.byteLength) {
+    throw new Error("Chart wire metadata is truncated.");
+  }
+
+  const metadataBytes = bytes.subarray(HEADER_LENGTH, metadataEnd);
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(textDecoder.decode(metadataBytes));
+  } catch (error) {
+    throw new Error(
+      `Failed to parse chart wire metadata: ${(error as Error).message}`,
+      { cause: error },
+    );
+  }
+
+  return {
+    kind,
+    metadata,
+    values: bytes.subarray(metadataEnd),
+  };
+}
+
+function decodeXySnapshot(
+  metadataValue: unknown,
+  values: Uint8Array,
+): Extract<ChartModel, { type: "xy" }> {
+  const metadata = readXySnapshotMetadata(metadataValue);
+  const reader = createNumericReader(values);
+  return {
+    type: "xy",
+    plotMode: metadata.plotMode,
+    drawStyle: metadata.drawStyle,
+    xName: metadata.xName,
+    yName: metadata.yName,
+    series: metadata.series.map((series) => ({
+      ...series,
+      values: reader.read(series.valueCount),
+    })),
+  };
+}
+
+function decodeHeatmapSnapshot(
+  metadataValue: unknown,
+  values: Uint8Array,
+): Extract<ChartModel, { type: "heatmap" }> {
+  const metadata = readHeatmapSnapshotMetadata(metadataValue);
+  const reader = createNumericReader(values);
+  return {
+    type: "heatmap",
+    xName: metadata.xName,
+    yName: metadata.yName,
+    series: metadata.series.map((series) => ({
+      ...series,
+      values: reader.read(series.valueCount),
+    })),
+  };
+}
+
+function decodeLiveAppend(
+  metadataValue: unknown,
+  values: Uint8Array,
+): LiveChartUpdate {
+  const metadata = readLiveAppendMetadata(metadataValue);
+  const reader = createNumericReader(values);
+  const ops: LiveChartAppendOperation[] = metadata.ops.map((operation) => {
+    const decodedValues = reader.read(operation.valueCount);
+    if (operation.kind === "append_points") {
+      validateShapeValueCount(
+        operation.shape,
+        operation.pointCount,
+        operation.valueCount,
+      );
+      return {
+        kind: "append_points",
+        seriesId: operation.seriesId,
+        pointCount: operation.pointCount,
+        values: decodedValues,
+      };
+    }
+
+    validateShapeValueCount(
+      operation.shape,
+      operation.pointCount,
+      operation.valueCount,
+    );
+    return {
+      kind: "append_series",
+      series:
+        operation.shape === "xy"
+          ? {
+              shape: "xy" as const,
+              series: {
+                id: operation.id,
+                label: operation.label,
+                pointCount: operation.pointCount,
+                values: decodedValues,
+              } satisfies ChartSeries,
+            }
+          : {
+              shape: "xyz" as const,
+              series: {
+                id: operation.id,
+                label: operation.label,
+                pointCount: operation.pointCount,
+                values: decodedValues,
+              } satisfies HeatmapSeries,
+            },
+    };
+  });
+
+  reader.finish();
+  return {
+    mode: "append",
+    rowCount: metadata.rowCount,
+    ops,
+  };
+}
+
+function createNumericReader(bytes: Uint8Array) {
+  if (bytes.byteLength % 8 !== 0) {
+    throw new Error("Chart wire numeric payload is truncated.");
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 0;
+
+  return {
+    read(valueCount: number): Float64Array {
+      const byteLength = valueCount * 8;
+      if (offset + byteLength > bytes.byteLength) {
+        throw new Error("Chart wire numeric payload is truncated.");
+      }
+
+      const result = new Float64Array(valueCount);
+      for (let index = 0; index < valueCount; index += 1) {
+        result[index] = view.getFloat64(offset + index * 8, true);
+      }
+      offset += byteLength;
+      return result;
+    },
+    finish() {
+      if (offset !== bytes.byteLength) {
+        throw new Error("Chart wire payload has trailing numeric bytes.");
+      }
+    },
+  };
+}
+
+function readXySnapshotMetadata(value: unknown): XySnapshotMetadata {
+  const object = readObject(value, "xy snapshot metadata");
+  return {
+    plotMode: readXYPlotMode(object.plotMode),
+    drawStyle: readXYDrawStyle(object.drawStyle),
+    xName: readString(object.xName, "xName"),
+    yName: readNullableString(object.yName, "yName"),
+    series: readSeriesMetadataArray(object.series),
+  };
+}
+
+function readHeatmapSnapshotMetadata(value: unknown): HeatmapSnapshotMetadata {
+  const object = readObject(value, "heatmap snapshot metadata");
+  return {
+    xName: readString(object.xName, "xName"),
+    yName: readString(object.yName, "yName"),
+    series: readSeriesMetadataArray(object.series),
+  };
+}
+
+function readLiveResetMetadata<T>(
+  value: unknown,
+  readSnapshot: (snapshot: unknown) => T,
+): LiveResetMetadata<T> {
+  const object = readObject(value, "live reset metadata");
+  return {
+    rowCount: readNonNegativeInteger(object.rowCount, "rowCount"),
+    snapshot: readSnapshot(object),
+  };
+}
+
+function readLiveAppendMetadata(value: unknown): LiveAppendMetadata {
+  const object = readObject(value, "live append metadata");
+  return {
+    rowCount: readNonNegativeInteger(object.rowCount, "rowCount"),
+    ops: readArray(object.ops, "ops").map((item, index) =>
+      readLiveAppendOperationMetadata(item, `ops[${index}]`),
+    ),
+  };
+}
+
+function readLiveAppendOperationMetadata(
+  value: unknown,
+  path: string,
+): LiveAppendOperationMetadata {
+  const object = readObject(value, path);
+  const kind = readLiteral(
+    object.kind,
+    `${path}.kind`,
+    "append_points",
+    "append_series",
+  );
+  if (kind === "append_points") {
+    return {
+      kind,
+      seriesId: readString(object.seriesId, `${path}.seriesId`),
+      shape: readSeriesShape(object.shape, `${path}.shape`),
+      pointCount: readNonNegativeInteger(
+        object.pointCount,
+        `${path}.pointCount`,
+      ),
+      valueCount: readNonNegativeInteger(
+        object.valueCount,
+        `${path}.valueCount`,
+      ),
+    };
+  }
+
+  return {
+    kind,
+    shape: readSeriesShape(object.shape, `${path}.shape`),
+    id: readString(object.id, `${path}.id`),
+    label: readString(object.label, `${path}.label`),
+    pointCount: readNonNegativeInteger(object.pointCount, `${path}.pointCount`),
+    valueCount: readNonNegativeInteger(object.valueCount, `${path}.valueCount`),
+  };
+}
+
+function readSeriesMetadataArray(value: unknown): SeriesMetadata[] {
+  return readArray(value, "series").map((item, index) =>
+    readSeriesMetadata(item, `series[${index}]`),
+  );
+}
+
+function readSeriesMetadata(value: unknown, path: string): SeriesMetadata {
+  const object = readObject(value, path);
+  const pointCount = readNonNegativeInteger(
+    object.pointCount,
+    `${path}.pointCount`,
+  );
+  const valueCount = readNonNegativeInteger(
+    object.valueCount,
+    `${path}.valueCount`,
+  );
+  const shape = inferShapeFromValueCount(pointCount, valueCount, path);
+  validateShapeValueCount(shape, pointCount, valueCount);
+  return {
+    id: readString(object.id, `${path}.id`),
+    label: readString(object.label, `${path}.label`),
+    pointCount,
+    valueCount,
+  };
+}
+
+function inferShapeFromValueCount(
+  pointCount: number,
+  valueCount: number,
+  path: string,
+): SeriesShape {
+  if (valueCount === pointCount * 2) {
+    return "xy";
+  }
+  if (valueCount === pointCount * 3) {
+    return "xyz";
+  }
+  throw new Error(`${path}.valueCount does not match XY or XYZ layout.`);
+}
+
+function validateShapeValueCount(
+  shape: SeriesShape,
+  pointCount: number,
+  valueCount: number,
+) {
+  const expected = pointCount * (shape === "xy" ? 2 : 3);
+  if (valueCount !== expected) {
+    throw new Error(
+      `Expected ${expected} values for ${shape} payload, received ${valueCount}.`,
+    );
+  }
+}
+
+function readXYPlotMode(value: unknown): XYPlotMode {
+  return readLiteral(
+    value,
+    "plotMode",
+    "quantity_vs_sweep",
+    "xy",
+    "complex_plane",
+  );
+}
+
+function readXYDrawStyle(value: unknown): XYDrawStyle {
+  return readLiteral(value, "drawStyle", "line", "points", "line_points");
+}
+
+function readSeriesShape(value: unknown, path: string): SeriesShape {
+  return readLiteral(value, path, "xy", "xyz");
+}
+
+function readObject(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw new Error(`Expected ${label} to be an object.`);
+}
+
+function readArray(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected ${path} to be an array.`);
+  }
+  return value;
+}
+
+function readString(value: unknown, path: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Expected ${path} to be a string.`);
+  }
+  return value;
+}
+
+function readNullableString(value: unknown, path: string): string | null {
+  if (value === null) {
+    return null;
+  }
+  return readString(value, path);
+}
+
+function readNonNegativeInteger(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`Expected ${path} to be a non-negative integer.`);
+  }
+  return value;
+}
+
+function readLiteral<T extends string>(
+  value: unknown,
+  path: string,
+  ...allowed: T[]
+): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new Error(`Expected ${path} to be one of: ${allowed.join(", ")}.`);
+  }
+  return value as T;
+}
+
+function isPayloadKind(value: number): value is PayloadKind {
+  return value >= 1 && value <= 5;
+}

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.browser.test.tsx
@@ -12,6 +12,10 @@ import { clearMocks, mockIPC } from "@tauri-apps/api/mocks";
 import { describe, expect, it, vi } from "vitest";
 import type { DatasetDetail } from "../api/types";
 import type { NumericLabelFormatOptions } from "@/shared/lib/chartTypes";
+import {
+  encodeChartSnapshotForTest,
+  encodeLiveChartUpdateForTest,
+} from "@/shared/test/chartWire";
 import { ChartViewer } from "./ChartViewer";
 
 const chartWrapperMock = vi.fn();
@@ -87,7 +91,7 @@ describe("ChartViewer", () => {
         return { fields: [], rows: [], columnUniqueValues: {} };
       }
       if (cmd === "dataset_chart_data") {
-        return {
+        return encodeChartSnapshotForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -98,10 +102,10 @@ describe("ChartViewer", () => {
               id: "signal",
               label: "signal",
               pointCount: 2,
-              values: [0, 1, 1, 2],
+              values: new Float64Array([0, 1, 1, 2]),
             },
           ],
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 0 };
@@ -147,7 +151,7 @@ describe("ChartViewer", () => {
         return { fields: [], rows: [], columnUniqueValues: {} };
       }
       if (cmd === "dataset_chart_data") {
-        return {
+        return encodeChartSnapshotForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -158,10 +162,10 @@ describe("ChartViewer", () => {
               id: "signal",
               label: "signal",
               pointCount: 2,
-              values: [0, 1, 1, 2],
+              values: new Float64Array([0, 1, 1, 2]),
             },
           ],
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 0 };
@@ -305,7 +309,7 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           chartPayloads.push(payload as Record<string, unknown>);
         }
-        return {
+        return encodeChartSnapshotForTest({
           type: "heatmap",
           xName: "trace index",
           yName: "idxB",
@@ -314,10 +318,10 @@ describe("ChartViewer", () => {
               id: "trace_signal",
               label: "trace_signal",
               pointCount: 2,
-              values: [0, 10, 1, 1, 10, 2],
+              values: new Float64Array([0, 10, 1, 1, 10, 2]),
             },
           ],
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 0 };
@@ -395,7 +399,7 @@ describe("ChartViewer", () => {
       }
       if (cmd === "dataset_chart_data") {
         chartCallCount += 1;
-        return {
+        return encodeChartSnapshotForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -406,10 +410,10 @@ describe("ChartViewer", () => {
               id: "signal",
               label: "signal",
               pointCount: 2,
-              values: [0, 1, 1, 2],
+              values: new Float64Array([0, 1, 1, 2]),
             },
           ],
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 0 };
@@ -481,14 +485,21 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           chartPayloads.push(payload as Record<string, unknown>);
         }
-        return {
+        return encodeChartSnapshotForTest({
           type: "xy",
           plotMode: "complex_plane",
           drawStyle: "points",
           xName: "c (real)",
           yName: "c (imag)",
-          series: [{ id: "c", label: "c", pointCount: 1, values: [1, 2] }],
-        };
+          series: [
+            {
+              id: "c",
+              label: "c",
+              pointCount: 1,
+              values: new Float64Array([1, 2]),
+            },
+          ],
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 0 };
@@ -552,16 +563,21 @@ describe("ChartViewer", () => {
         };
       }
       if (cmd === "dataset_chart_data") {
-        return {
+        return encodeChartSnapshotForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
           xName: "idxB",
           yName: null,
           series: [
-            { id: "signal", label: "signal", pointCount: 1, values: [0, 1] },
+            {
+              id: "signal",
+              label: "signal",
+              pointCount: 1,
+              values: new Float64Array([0, 1]),
+            },
           ],
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 0 };
@@ -615,9 +631,9 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           livePayloads.push(payload as Record<string, unknown>);
         }
-        return {
+        return encodeLiveChartUpdateForTest({
           mode: "reset",
-          row_count: 1,
+          rowCount: 1,
           snapshot: {
             type: "xy",
             plotMode: "quantity_vs_sweep",
@@ -629,11 +645,11 @@ describe("ChartViewer", () => {
                 id: "sig:real",
                 label: "sig (real)",
                 pointCount: 1,
-                values: [0, 1],
+                values: new Float64Array([0, 1]),
               },
             ],
           },
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 1 };
@@ -704,9 +720,9 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           livePayloads.push(payload as Record<string, unknown>);
         }
-        return {
+        return encodeLiveChartUpdateForTest({
           mode: "reset",
-          row_count: 6,
+          rowCount: 6,
           snapshot: {
             type: "xy",
             plotMode: "complex_plane",
@@ -718,11 +734,11 @@ describe("ChartViewer", () => {
                 id: "group:4",
                 label: "impedance [idx_cycle=2, idx_y=1]",
                 pointCount: 2,
-                values: [1, 2, 3, 4],
+                values: new Float64Array([1, 2, 3, 4]),
               },
             ],
           },
-        };
+        });
       }
       if (cmd === "get_dataset_write_status") {
         return { rowCount: 6 };

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.browser.test.tsx
@@ -13,8 +13,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { DatasetDetail } from "../api/types";
 import type { NumericLabelFormatOptions } from "@/shared/lib/chartTypes";
 import {
-  encodeChartSnapshotForTest,
-  encodeLiveChartUpdateForTest,
+  encodeChartSnapshotBufferForTest,
+  encodeLiveChartUpdateBufferForTest,
 } from "@/shared/test/chartWire";
 import { ChartViewer } from "./ChartViewer";
 
@@ -91,7 +91,7 @@ describe("ChartViewer", () => {
         return { fields: [], rows: [], columnUniqueValues: {} };
       }
       if (cmd === "dataset_chart_data") {
-        return encodeChartSnapshotForTest({
+        return encodeChartSnapshotBufferForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -151,7 +151,7 @@ describe("ChartViewer", () => {
         return { fields: [], rows: [], columnUniqueValues: {} };
       }
       if (cmd === "dataset_chart_data") {
-        return encodeChartSnapshotForTest({
+        return encodeChartSnapshotBufferForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -309,7 +309,7 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           chartPayloads.push(payload as Record<string, unknown>);
         }
-        return encodeChartSnapshotForTest({
+        return encodeChartSnapshotBufferForTest({
           type: "heatmap",
           xName: "trace index",
           yName: "idxB",
@@ -399,7 +399,7 @@ describe("ChartViewer", () => {
       }
       if (cmd === "dataset_chart_data") {
         chartCallCount += 1;
-        return encodeChartSnapshotForTest({
+        return encodeChartSnapshotBufferForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -485,7 +485,7 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           chartPayloads.push(payload as Record<string, unknown>);
         }
-        return encodeChartSnapshotForTest({
+        return encodeChartSnapshotBufferForTest({
           type: "xy",
           plotMode: "complex_plane",
           drawStyle: "points",
@@ -563,7 +563,7 @@ describe("ChartViewer", () => {
         };
       }
       if (cmd === "dataset_chart_data") {
-        return encodeChartSnapshotForTest({
+        return encodeChartSnapshotBufferForTest({
           type: "xy",
           plotMode: "quantity_vs_sweep",
           drawStyle: "line",
@@ -631,7 +631,7 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           livePayloads.push(payload as Record<string, unknown>);
         }
-        return encodeLiveChartUpdateForTest({
+        return encodeLiveChartUpdateBufferForTest({
           mode: "reset",
           rowCount: 1,
           snapshot: {
@@ -720,7 +720,7 @@ describe("ChartViewer", () => {
         if (payload && typeof payload === "object") {
           livePayloads.push(payload as Record<string, unknown>);
         }
-        return encodeLiveChartUpdateForTest({
+        return encodeLiveChartUpdateBufferForTest({
           mode: "reset",
           rowCount: 6,
           snapshot: {

--- a/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
@@ -20,9 +20,7 @@ export const commands = {
 } | null) => typedError<DatasetInfo[], ApiError>(__TAURI_INVOKE("list_datasets", { options })),
 	listDatasetTags: () => typedError<string[], ApiError>(__TAURI_INVOKE("list_dataset_tags")),
 	datasetDetail: (id: number) => typedError<DatasetDetail, ApiError>(__TAURI_INVOKE("dataset_detail", { id })),
-	datasetChartData: (id: number, options: DatasetChartDataOptions) => typedError<ChartSnapshot, ApiError>(__TAURI_INVOKE("dataset_chart_data", { id, options })),
 	getFilterTableData: (id: number, options: FilterTableOptions) => typedError<TableData, ApiError>(__TAURI_INVOKE("get_filter_table_data", { id, options })),
-	datasetLiveChartData: (id: number, options: LiveChartDataOptions) => typedError<LiveChartDataResponse, ApiError>(__TAURI_INVOKE("dataset_live_chart_data", { id, options })),
 	updateDatasetFavorite: (id: number, update: DatasetFavoriteUpdate) => typedError<null, ApiError>(__TAURI_INVOKE("update_dataset_favorite", { id, update })),
 	updateDatasetInfo: (id: number, update: DatasetInfoUpdate) => typedError<null, ApiError>(__TAURI_INVOKE("update_dataset_info", { id, update })),
 	getDatasetWriteStatus: (id: number) => typedError<DatasetWriteStatus, ApiError>(__TAURI_INVOKE("get_dataset_write_status", { id })),
@@ -65,8 +63,6 @@ export type ChartCommonOptions = {
 	indexFilters: number[] | null,
 	excludeColumns: string[] | null,
 };
-
-export type ChartSnapshot = { type: "xy" } & (XYChartSnapshot) | { type: "heatmap" } & (HeatmapChartSnapshot);
 
 export type ColumnInfo = {
 	name: string,
@@ -194,22 +190,6 @@ export type FilterTableOptions = {
 	excludeColumns?: string[] | null,
 };
 
-export type FlatSeries = { shape: "xy" } & (FlatXYSeries) | { shape: "xyz" } & (FlatXYZSeries);
-
-export type FlatXYSeries = {
-	id: string,
-	label: string,
-	values: number[],
-	pointCount: number,
-};
-
-export type FlatXYZSeries = {
-	id: string,
-	label: string,
-	values: number[],
-	pointCount: number,
-};
-
 export type HeatmapChartDataOptions = {
 	quantity: string,
 	xColumn: string | null,
@@ -217,17 +197,7 @@ export type HeatmapChartDataOptions = {
 	complexViewSingle: ComplexViewOption | null,
 } & (ChartCommonOptions);
 
-export type HeatmapChartSnapshot = {
-	xName: string,
-	yName: string,
-	series: FlatXYZSeries[],
-};
-
-export type LiveChartAppendOperation = { kind: "append_points"; series_id: string; values: number[]; point_count: number } | { kind: "append_series"; series: FlatSeries };
-
 export type LiveChartDataOptions = { view: "xy" } & (LiveXYOptions) | { view: "heatmap" } & (LiveHeatmapOptions);
-
-export type LiveChartDataResponse = { mode: "reset"; row_count: number; snapshot: ChartSnapshot } | { mode: "append"; row_count: number; ops: LiveChartAppendOperation[] };
 
 export type LiveHeatmapOptions = {
 	quantity: string,
@@ -298,17 +268,7 @@ export type XYChartDataOptions = {
 	drawStyle: XYDrawStyle,
 } & (XYPlotModeOptions) & (XYTraceRoleOptions) & (ChartCommonOptions);
 
-export type XYChartSnapshot = {
-	plotMode: XYPlotMode,
-	drawStyle: XYDrawStyle,
-	xName: string,
-	yName: string | null,
-	series: FlatXYSeries[],
-};
-
 export type XYDrawStyle = "line" | "points" | "line_points";
-
-export type XYPlotMode = "quantity_vs_sweep" | "xy" | "complex_plane";
 
 export type XYPlotModeOptions = { plotMode: "quantity_vs_sweep"; quantity: string; complex_views: ComplexViewOption[] | null } | { plotMode: "xy"; xColumn: string; yColumn: string } | { plotMode: "complex_plane"; quantity: string };
 

--- a/crates/fricon-ui/frontend/src/shared/lib/tauri.test.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/tauri.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { tauriInvokeMock } = vi.hoisted(() => ({
+  tauriInvokeMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriInvokeMock,
+}));
+
 import {
   ApiError,
+  invokeRaw,
+  invokeRawBytes,
   isApiError,
   normalizeRawBytes,
   normalizeCreatedAtDate,
@@ -10,6 +21,10 @@ import {
 } from "./tauri";
 
 describe("tauri helpers", () => {
+  beforeEach(() => {
+    tauriInvokeMock.mockReset();
+  });
+
   it("unwraps ok results", () => {
     expect(unwrapResult({ status: "ok", data: 42 })).toBe(42);
   });
@@ -39,6 +54,41 @@ describe("tauri helpers", () => {
       expect((error as ApiError).code).toBe("archive_version_unsupported");
       expect((error as ApiError).apiMessage).toBe("archive is too new");
     }
+  });
+
+  it("wraps raw invoke object rejections as ApiError", async () => {
+    tauriInvokeMock.mockRejectedValueOnce({
+      code: "charts",
+      message: "binary payload decode failed",
+    });
+
+    await expect(invokeRaw("dataset_chart_data")).rejects.toMatchObject({
+      name: "ApiError",
+      code: "charts",
+      apiMessage: "binary payload decode failed",
+      message: "[charts] binary payload decode failed",
+    });
+  });
+
+  it("passes through raw invoke Error rejections unchanged", async () => {
+    const error = new Error("transport exploded");
+    tauriInvokeMock.mockRejectedValueOnce(error);
+
+    await expect(invokeRaw("dataset_chart_data")).rejects.toBe(error);
+  });
+
+  it("wraps raw byte invoke object rejections as ApiError", async () => {
+    tauriInvokeMock.mockRejectedValueOnce({
+      code: "workspace",
+      message: "workspace unavailable",
+    });
+
+    await expect(invokeRawBytes("dataset_chart_data")).rejects.toMatchObject({
+      name: "ApiError",
+      code: "workspace",
+      apiMessage: "workspace unavailable",
+      message: "[workspace] workspace unavailable",
+    });
   });
 
   it("rejects invalid date values", () => {

--- a/crates/fricon-ui/frontend/src/shared/lib/tauri.test.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/tauri.test.ts
@@ -123,17 +123,15 @@ describe("tauri helpers", () => {
     expect(normalized.deletedAt).toBeNull();
   });
 
-  it("normalizes raw number arrays to Uint8Array", () => {
-    expect(normalizeRawBytes([1, 2, 3])).toEqual(new Uint8Array([1, 2, 3]));
-  });
-
   it("normalizes ArrayBuffer payloads to Uint8Array", () => {
     const value = new Uint8Array([4, 5, 6]).buffer;
     expect(normalizeRawBytes(value)).toEqual(new Uint8Array([4, 5, 6]));
   });
 
-  it("passes through Uint8Array payloads", () => {
+  it("rejects non-ArrayBuffer raw payloads", () => {
     const value = new Uint8Array([7, 8, 9]);
-    expect(normalizeRawBytes(value)).toBe(value);
+    expect(() => normalizeRawBytes(value)).toThrow(
+      "Expected an ArrayBuffer raw response from backend.",
+    );
   });
 });

--- a/crates/fricon-ui/frontend/src/shared/lib/tauri.test.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/tauri.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ApiError,
   isApiError,
+  normalizeRawBytes,
   normalizeCreatedAtDate,
   normalizeDatasetDates,
   toDate,
@@ -70,5 +71,19 @@ describe("tauri helpers", () => {
       "2026-01-02T03:04:05.000Z",
     );
     expect(normalized.deletedAt).toBeNull();
+  });
+
+  it("normalizes raw number arrays to Uint8Array", () => {
+    expect(normalizeRawBytes([1, 2, 3])).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("normalizes ArrayBuffer payloads to Uint8Array", () => {
+    const value = new Uint8Array([4, 5, 6]).buffer;
+    expect(normalizeRawBytes(value)).toEqual(new Uint8Array([4, 5, 6]));
+  });
+
+  it("passes through Uint8Array payloads", () => {
+    const value = new Uint8Array([7, 8, 9]);
+    expect(normalizeRawBytes(value)).toBe(value);
   });
 });

--- a/crates/fricon-ui/frontend/src/shared/lib/tauri.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/tauri.ts
@@ -1,3 +1,4 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 import type { ApiError as WireError } from "@/shared/lib/bindings";
 
 export class ApiError extends Error {
@@ -32,6 +33,53 @@ export async function invoke<T>(
   >,
 ): Promise<T> {
   return unwrapResult(await commandCall);
+}
+
+export async function invokeRaw<T>(
+  command: string,
+  args?: Record<string, unknown>,
+): Promise<T> {
+  try {
+    return await tauriInvoke<T>(command, args);
+  } catch (error) {
+    const apiError = toApiError(error);
+    if (apiError) {
+      throw apiError;
+    }
+    throw error;
+  }
+}
+
+export function normalizeRawBytes(value: unknown): Uint8Array {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        typeof item === "number" &&
+        Number.isInteger(item) &&
+        item >= 0 &&
+        item <= 255,
+    )
+  ) {
+    return Uint8Array.from(value);
+  }
+  throw new Error("Expected a raw byte response from backend.");
+}
+
+export async function invokeRawBytes(
+  command: string,
+  args?: Record<string, unknown>,
+): Promise<Uint8Array> {
+  return normalizeRawBytes(await invokeRaw(command, args));
 }
 
 export function toDate(value: string): Date {
@@ -70,4 +118,18 @@ export function normalizeDatasetDates<
     trashedAt: value.trashedAt === null ? null : toDate(value.trashedAt),
     deletedAt: value.deletedAt === null ? null : toDate(value.deletedAt),
   };
+}
+
+function toApiError(error: unknown): ApiError | null {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    "message" in error &&
+    typeof error.code === "string" &&
+    typeof error.message === "string"
+  ) {
+    return new ApiError(error as WireError);
+  }
+  return null;
 }

--- a/crates/fricon-ui/frontend/src/shared/lib/tauri.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/tauri.ts
@@ -51,35 +51,17 @@ export async function invokeRaw<T>(
 }
 
 export function normalizeRawBytes(value: unknown): Uint8Array {
-  if (value instanceof Uint8Array) {
-    return value;
-  }
   if (value instanceof ArrayBuffer) {
     return new Uint8Array(value);
   }
-  if (ArrayBuffer.isView(value)) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-  }
-  if (
-    Array.isArray(value) &&
-    value.every(
-      (item) =>
-        typeof item === "number" &&
-        Number.isInteger(item) &&
-        item >= 0 &&
-        item <= 255,
-    )
-  ) {
-    return Uint8Array.from(value);
-  }
-  throw new Error("Expected a raw byte response from backend.");
+  throw new Error("Expected an ArrayBuffer raw response from backend.");
 }
 
 export async function invokeRawBytes(
   command: string,
   args?: Record<string, unknown>,
 ): Promise<Uint8Array> {
-  return normalizeRawBytes(await invokeRaw(command, args));
+  return normalizeRawBytes(await invokeRaw<ArrayBuffer>(command, args));
 }
 
 export function toDate(value: string): Date {

--- a/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
+++ b/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
@@ -174,8 +174,7 @@ function inferShape(pointCount: number, valueCount: number): SeriesShape {
 }
 
 function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength,
-  );
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
 }

--- a/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
+++ b/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
@@ -42,6 +42,12 @@ export function encodeChartSnapshotForTest(chart: ChartModel): Uint8Array {
   );
 }
 
+export function encodeChartSnapshotBufferForTest(
+  chart: ChartModel,
+): ArrayBuffer {
+  return toExactArrayBuffer(encodeChartSnapshotForTest(chart));
+}
+
 export function encodeLiveChartUpdateForTest(
   update: LiveChartUpdate,
 ): Uint8Array {
@@ -114,6 +120,12 @@ export function encodeLiveChartUpdateForTest(
   );
 }
 
+export function encodeLiveChartUpdateBufferForTest(
+  update: LiveChartUpdate,
+): ArrayBuffer {
+  return toExactArrayBuffer(encodeLiveChartUpdateForTest(update));
+}
+
 function encodeFrame(
   kind: number,
   metadata: unknown,
@@ -159,4 +171,11 @@ function inferShape(pointCount: number, valueCount: number): SeriesShape {
     return "xyz";
   }
   throw new Error("Test payload values do not match XY or XYZ layout.");
+}
+
+function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
 }

--- a/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
+++ b/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
@@ -2,6 +2,7 @@ import type { ChartModel } from "@/shared/lib/chartTypes";
 import type { LiveChartUpdate } from "@/features/charts/api/types";
 
 const encoder = new TextEncoder();
+const HEADER_LENGTH = 16;
 
 type SeriesShape = "xy" | "xyz";
 
@@ -119,27 +120,35 @@ function encodeFrame(
   values: Float64Array[],
 ): Uint8Array {
   const metadataBytes = encoder.encode(JSON.stringify(metadata));
+  const numericOffset = alignUp(HEADER_LENGTH + metadataBytes.length, 8);
   const numericBytes = values.reduce(
     (total, item) => total + item.length * 8,
     0,
   );
-  const bytes = new Uint8Array(10 + metadataBytes.length + numericBytes);
+  const bytes = new Uint8Array(numericOffset + numericBytes);
   bytes.set(encoder.encode("FCHT"), 0);
-  bytes[4] = 1;
+  bytes[4] = 2;
   bytes[5] = kind;
-  new DataView(bytes.buffer).setUint32(6, metadataBytes.length, true);
-  bytes.set(metadataBytes, 10);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(8, metadataBytes.length, true);
+  view.setUint32(12, numericOffset, true);
+  bytes.set(metadataBytes, HEADER_LENGTH);
 
-  let offset = 10 + metadataBytes.length;
+  let offset = numericOffset;
   for (const block of values) {
-    const view = new DataView(bytes.buffer, offset, block.length * 8);
+    const blockView = new Float64Array(bytes.buffer, offset, block.length);
     for (let index = 0; index < block.length; index += 1) {
-      view.setFloat64(index * 8, block[index] ?? 0, true);
+      blockView[index] = block[index] ?? 0;
     }
     offset += block.length * 8;
   }
 
   return bytes;
+}
+
+function alignUp(value: number, alignment: number): number {
+  const remainder = value % alignment;
+  return remainder === 0 ? value : value + alignment - remainder;
 }
 
 function inferShape(pointCount: number, valueCount: number): SeriesShape {

--- a/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
+++ b/crates/fricon-ui/frontend/src/shared/test/chartWire.ts
@@ -1,0 +1,153 @@
+import type { ChartModel } from "@/shared/lib/chartTypes";
+import type { LiveChartUpdate } from "@/features/charts/api/types";
+
+const encoder = new TextEncoder();
+
+type SeriesShape = "xy" | "xyz";
+
+export function encodeChartSnapshotForTest(chart: ChartModel): Uint8Array {
+  if (chart.type === "xy") {
+    return encodeFrame(
+      1,
+      {
+        plotMode: chart.plotMode,
+        drawStyle: chart.drawStyle,
+        xName: chart.xName,
+        yName: chart.yName,
+        series: chart.series.map((series) => ({
+          id: series.id,
+          label: series.label,
+          pointCount: series.pointCount,
+          valueCount: series.values.length,
+        })),
+      },
+      chart.series.map((series) => series.values),
+    );
+  }
+
+  return encodeFrame(
+    2,
+    {
+      xName: chart.xName,
+      yName: chart.yName,
+      series: chart.series.map((series) => ({
+        id: series.id,
+        label: series.label,
+        pointCount: series.pointCount,
+        valueCount: series.values.length,
+      })),
+    },
+    chart.series.map((series) => series.values),
+  );
+}
+
+export function encodeLiveChartUpdateForTest(
+  update: LiveChartUpdate,
+): Uint8Array {
+  if (update.mode === "reset") {
+    if (update.snapshot.type === "xy") {
+      return encodeFrame(
+        3,
+        {
+          rowCount: update.rowCount,
+          plotMode: update.snapshot.plotMode,
+          drawStyle: update.snapshot.drawStyle,
+          xName: update.snapshot.xName,
+          yName: update.snapshot.yName,
+          series: update.snapshot.series.map((series) => ({
+            id: series.id,
+            label: series.label,
+            pointCount: series.pointCount,
+            valueCount: series.values.length,
+          })),
+        },
+        update.snapshot.series.map((series) => series.values),
+      );
+    }
+
+    return encodeFrame(
+      4,
+      {
+        rowCount: update.rowCount,
+        xName: update.snapshot.xName,
+        yName: update.snapshot.yName,
+        series: update.snapshot.series.map((series) => ({
+          id: series.id,
+          label: series.label,
+          pointCount: series.pointCount,
+          valueCount: series.values.length,
+        })),
+      },
+      update.snapshot.series.map((series) => series.values),
+    );
+  }
+
+  return encodeFrame(
+    5,
+    {
+      rowCount: update.rowCount,
+      ops: update.ops.map((operation) =>
+        operation.kind === "append_points"
+          ? {
+              kind: "append_points",
+              seriesId: operation.seriesId,
+              shape: inferShape(operation.pointCount, operation.values.length),
+              pointCount: operation.pointCount,
+              valueCount: operation.values.length,
+            }
+          : {
+              kind: "append_series",
+              shape: operation.series.shape,
+              id: operation.series.series.id,
+              label: operation.series.series.label,
+              pointCount: operation.series.series.pointCount,
+              valueCount: operation.series.series.values.length,
+            },
+      ),
+    },
+    update.ops.map((operation) =>
+      operation.kind === "append_points"
+        ? operation.values
+        : operation.series.series.values,
+    ),
+  );
+}
+
+function encodeFrame(
+  kind: number,
+  metadata: unknown,
+  values: Float64Array[],
+): Uint8Array {
+  const metadataBytes = encoder.encode(JSON.stringify(metadata));
+  const numericBytes = values.reduce(
+    (total, item) => total + item.length * 8,
+    0,
+  );
+  const bytes = new Uint8Array(10 + metadataBytes.length + numericBytes);
+  bytes.set(encoder.encode("FCHT"), 0);
+  bytes[4] = 1;
+  bytes[5] = kind;
+  new DataView(bytes.buffer).setUint32(6, metadataBytes.length, true);
+  bytes.set(metadataBytes, 10);
+
+  let offset = 10 + metadataBytes.length;
+  for (const block of values) {
+    const view = new DataView(bytes.buffer, offset, block.length * 8);
+    for (let index = 0; index < block.length; index += 1) {
+      view.setFloat64(index * 8, block[index] ?? 0, true);
+    }
+    offset += block.length * 8;
+  }
+
+  return bytes;
+}
+
+function inferShape(pointCount: number, valueCount: number): SeriesShape {
+  if (valueCount === pointCount * 2) {
+    return "xy";
+  }
+  if (valueCount === pointCount * 3) {
+    return "xyz";
+  }
+  throw new Error("Test payload values do not match XY or XYZ layout.");
+}

--- a/crates/fricon-ui/src/desktop_runtime/runtime.rs
+++ b/crates/fricon-ui/src/desktop_runtime/runtime.rs
@@ -102,10 +102,11 @@ fn prepare_workspace_runtime(workspace_path: &Path) -> Result<WorkspaceLaunchOut
 
 fn run_with_app_state(app_state: AppState) -> Result<()> {
     let specta_builder = tauri_api::specta_builder();
+    let invoke_handler = tauri_api::invoke_handler();
     #[expect(clippy::exit, reason = "Required by Tauri framework")]
     let tauri_app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(specta_builder.invoke_handler())
+        .invoke_handler(invoke_handler)
         .manage(app_state)
         .setup(move |app| {
             install_ctrl_c_handler(app);

--- a/crates/fricon-ui/src/features/charts.rs
+++ b/crates/fricon-ui/src/features/charts.rs
@@ -2,4 +2,5 @@ mod chart_data;
 mod filter_table;
 pub(crate) mod tauri;
 pub(crate) mod transform;
-mod types;
+pub(crate) mod types;
+mod wire;

--- a/crates/fricon-ui/src/features/charts/tauri.rs
+++ b/crates/fricon-ui/src/features/charts/tauri.rs
@@ -1,28 +1,28 @@
-use tauri::State;
+use tauri::{State, ipc::Response};
 use tracing::instrument;
 
 use crate::{
     desktop_runtime::app_state::AppState,
     features::charts::{
         chart_data, filter_table,
-        types::{
-            ChartSnapshot, DatasetChartDataOptions, FilterTableOptions, LiveChartDataOptions,
-            LiveChartDataResponse, TableData,
-        },
+        types::{DatasetChartDataOptions, FilterTableOptions, LiveChartDataOptions, TableData},
+        wire,
     },
     tauri_api::ApiError,
 };
 
 #[tauri::command]
-#[specta::specta]
 #[instrument(level = "debug", skip(state, options), fields(dataset_id = id))]
 pub(crate) async fn dataset_chart_data(
     state: State<'_, AppState>,
     id: i32,
     options: DatasetChartDataOptions,
-) -> Result<ChartSnapshot, ApiError> {
-    chart_data::dataset_chart_data(state.session(), id, &options)
+) -> Result<Response, ApiError> {
+    let snapshot = chart_data::dataset_chart_data(state.session(), id, &options)
         .await
+        .map_err(ApiError::charts)?;
+    wire::encode_chart_snapshot(&snapshot)
+        .map(Response::new)
         .map_err(ApiError::charts)
 }
 
@@ -39,14 +39,16 @@ pub(crate) async fn get_filter_table_data(
 }
 
 #[tauri::command]
-#[specta::specta]
 #[instrument(level = "debug", skip(state, options), fields(dataset_id = id))]
 pub(crate) async fn dataset_live_chart_data(
     state: State<'_, AppState>,
     id: i32,
     options: LiveChartDataOptions,
-) -> Result<LiveChartDataResponse, ApiError> {
-    chart_data::dataset_live_chart_data(state.session(), id, &options)
+) -> Result<Response, ApiError> {
+    let response = chart_data::dataset_live_chart_data(state.session(), id, &options)
         .await
+        .map_err(ApiError::charts)?;
+    wire::encode_live_chart_data(&response)
+        .map(Response::new)
         .map_err(ApiError::charts)
 }

--- a/crates/fricon-ui/src/features/charts/wire.rs
+++ b/crates/fricon-ui/src/features/charts/wire.rs
@@ -7,7 +7,8 @@ use super::types::{
 };
 
 const MAGIC: &[u8; 4] = b"FCHT";
-const VERSION: u8 = 1;
+const VERSION: u8 = 2;
+const HEADER_LENGTH: usize = 16;
 
 #[derive(Clone, Copy)]
 #[repr(u8)]
@@ -242,6 +243,15 @@ fn encode_frame(
     let metadata =
         serde_json::to_vec(metadata).context("Failed to serialize chart wire metadata")?;
     let metadata_len = u32::try_from(metadata.len()).context("Chart wire metadata too large")?;
+    let metadata_end = HEADER_LENGTH
+        .checked_add(metadata.len())
+        .context("Chart wire metadata too large")?;
+    let numeric_offset = align_up(metadata_end, 8)?;
+    let numeric_offset_u32 =
+        u32::try_from(numeric_offset).context("Chart wire numeric payload offset too large")?;
+    let padding_len = numeric_offset
+        .checked_sub(metadata_end)
+        .context("Chart wire padding underflow")?;
     let value_bytes_len = value_blocks
         .iter()
         .try_fold(0usize, |acc, block| {
@@ -249,18 +259,32 @@ fn encode_frame(
         })
         .context("Chart wire numeric payload too large")?;
 
-    let mut bytes = Vec::with_capacity(10 + metadata.len() + value_bytes_len);
+    let mut bytes = Vec::with_capacity(numeric_offset + value_bytes_len);
     bytes.extend_from_slice(MAGIC);
     bytes.push(VERSION);
     bytes.push(payload_kind.as_byte());
+    bytes.extend_from_slice(&[0, 0]);
     bytes.extend_from_slice(&metadata_len.to_le_bytes());
+    bytes.extend_from_slice(&numeric_offset_u32.to_le_bytes());
     bytes.extend_from_slice(&metadata);
+    bytes.extend(std::iter::repeat_n(0, padding_len));
     for block in value_blocks {
         for value in block {
-            bytes.extend_from_slice(&value.to_le_bytes());
+            bytes.extend_from_slice(&value.to_ne_bytes());
         }
     }
     Ok(bytes)
+}
+
+fn align_up(value: usize, alignment: usize) -> anyhow::Result<usize> {
+    let remainder = value % alignment;
+    if remainder == 0 {
+        Ok(value)
+    } else {
+        value
+            .checked_add(alignment - remainder)
+            .context("Chart wire payload offset overflowed")
+    }
 }
 
 fn encode_xy_series_metadata(series: &FlatXYSeries) -> anyhow::Result<SeriesMetadata<'_>> {
@@ -373,14 +397,14 @@ mod tests {
 
     fn parse_metadata(bytes: &[u8]) -> Value {
         let metadata_len =
-            u32::from_le_bytes(bytes[6..10].try_into().expect("metadata length")) as usize;
-        serde_json::from_slice(&bytes[10..10 + metadata_len]).expect("metadata json")
+            u32::from_le_bytes(bytes[8..12].try_into().expect("metadata length")) as usize;
+        serde_json::from_slice(&bytes[16..16 + metadata_len]).expect("metadata json")
     }
 
     fn numeric_payload(bytes: &[u8]) -> &[u8] {
-        let metadata_len =
-            u32::from_le_bytes(bytes[6..10].try_into().expect("metadata length")) as usize;
-        &bytes[10 + metadata_len..]
+        let numeric_offset =
+            u32::from_le_bytes(bytes[12..16].try_into().expect("numeric offset")) as usize;
+        &bytes[numeric_offset..]
     }
 
     #[test]
@@ -407,6 +431,10 @@ mod tests {
         assert_eq!(metadata["plotMode"], "xy");
         assert_eq!(metadata["drawStyle"], "points");
         assert_eq!(metadata["series"][0]["valueCount"], 4);
+        assert_eq!(
+            u32::from_le_bytes(bytes[12..16].try_into().expect("numeric offset")) as usize % 8,
+            0
+        );
         assert_eq!(numeric_payload(&bytes).len(), 4 * 8);
     }
 

--- a/crates/fricon-ui/src/features/charts/wire.rs
+++ b/crates/fricon-ui/src/features/charts/wire.rs
@@ -7,7 +7,18 @@ use super::types::{
 };
 
 const MAGIC: &[u8; 4] = b"FCHT";
+/// Feature-local chart wire format version.
+///
+/// Bump this whenever the binary frame layout changes incompatibly, including
+/// header shape, metadata encoding, numeric payload layout, or alignment rules.
 const VERSION: u8 = 2;
+/// Frame header layout:
+/// - bytes 0..4: magic (`FCHT`)
+/// - byte 4: version
+/// - byte 5: payload kind
+/// - bytes 6..8: reserved
+/// - bytes 8..12: metadata byte length (little-endian u32)
+/// - bytes 12..16: numeric payload start offset (little-endian u32)
 const HEADER_LENGTH: usize = 16;
 
 #[derive(Clone, Copy)]
@@ -93,6 +104,12 @@ struct LiveAppendMetadata<'a> {
     ops: Vec<LiveAppendOperationMetadata<'a>>,
 }
 
+/// Encodes a chart snapshot into the feature-local `FCHT` binary frame.
+///
+/// The numeric payload is stored as host-native `f64` bytes and padded so the
+/// numeric section begins at an 8-byte-aligned offset for typed-array views on
+/// the frontend. This format is intentionally local to the desktop UI bridge
+/// and is not a portable persistence or interchange format.
 pub(crate) fn encode_chart_snapshot(snapshot: &ChartSnapshot) -> anyhow::Result<Vec<u8>> {
     match snapshot {
         ChartSnapshot::Xy(snapshot) => {
@@ -144,6 +161,8 @@ pub(crate) fn encode_chart_snapshot(snapshot: &ChartSnapshot) -> anyhow::Result<
     }
 }
 
+/// Encodes a live chart update into the same `FCHT` frame family used for
+/// snapshots, with payload kind distinguishing reset and append variants.
 pub(crate) fn encode_live_chart_data(response: &LiveChartDataResponse) -> anyhow::Result<Vec<u8>> {
     match response {
         LiveChartDataResponse::Reset {

--- a/crates/fricon-ui/src/features/charts/wire.rs
+++ b/crates/fricon-ui/src/features/charts/wire.rs
@@ -1,0 +1,511 @@
+use anyhow::{Context, bail, ensure};
+use serde::Serialize;
+
+use super::types::{
+    ChartSnapshot, FlatSeries, FlatXYSeries, FlatXYZSeries, LiveChartAppendOperation,
+    LiveChartDataResponse, XYDrawStyle, XYPlotMode,
+};
+
+const MAGIC: &[u8; 4] = b"FCHT";
+const VERSION: u8 = 1;
+
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum PayloadKind {
+    SnapshotXy = 1,
+    SnapshotHeatmap = 2,
+    LiveResetXy = 3,
+    LiveResetHeatmap = 4,
+    LiveAppend = 5,
+}
+
+impl PayloadKind {
+    const fn as_byte(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SeriesShape {
+    Xy,
+    Xyz,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SeriesMetadata<'a> {
+    id: &'a str,
+    label: &'a str,
+    point_count: usize,
+    value_count: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct XySnapshotMetadata<'a> {
+    plot_mode: XYPlotMode,
+    draw_style: XYDrawStyle,
+    x_name: &'a str,
+    y_name: Option<&'a str>,
+    series: Vec<SeriesMetadata<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HeatmapSnapshotMetadata<'a> {
+    x_name: &'a str,
+    y_name: &'a str,
+    series: Vec<SeriesMetadata<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LiveResetMetadata<T> {
+    row_count: usize,
+    #[serde(flatten)]
+    snapshot: T,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum LiveAppendOperationMetadata<'a> {
+    AppendPoints {
+        series_id: &'a str,
+        shape: SeriesShape,
+        point_count: usize,
+        value_count: usize,
+    },
+    AppendSeries {
+        shape: SeriesShape,
+        id: &'a str,
+        label: &'a str,
+        point_count: usize,
+        value_count: usize,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LiveAppendMetadata<'a> {
+    row_count: usize,
+    ops: Vec<LiveAppendOperationMetadata<'a>>,
+}
+
+pub(crate) fn encode_chart_snapshot(snapshot: &ChartSnapshot) -> anyhow::Result<Vec<u8>> {
+    match snapshot {
+        ChartSnapshot::Xy(snapshot) => {
+            let mut values = Vec::with_capacity(snapshot.series.len());
+            let series = snapshot
+                .series
+                .iter()
+                .map(|series| {
+                    let meta = encode_xy_series_metadata(series)?;
+                    values.push(series.values.as_slice());
+                    Ok(meta)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            encode_frame(
+                PayloadKind::SnapshotXy,
+                &XySnapshotMetadata {
+                    plot_mode: snapshot.plot_mode,
+                    draw_style: snapshot.draw_style,
+                    x_name: &snapshot.x_name,
+                    y_name: snapshot.y_name.as_deref(),
+                    series,
+                },
+                values,
+            )
+        }
+        ChartSnapshot::Heatmap(snapshot) => {
+            let mut values = Vec::with_capacity(snapshot.series.len());
+            let series = snapshot
+                .series
+                .iter()
+                .map(|series| {
+                    let meta = encode_xyz_series_metadata(series)?;
+                    values.push(series.values.as_slice());
+                    Ok(meta)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            encode_frame(
+                PayloadKind::SnapshotHeatmap,
+                &HeatmapSnapshotMetadata {
+                    x_name: &snapshot.x_name,
+                    y_name: &snapshot.y_name,
+                    series,
+                },
+                values,
+            )
+        }
+    }
+}
+
+pub(crate) fn encode_live_chart_data(response: &LiveChartDataResponse) -> anyhow::Result<Vec<u8>> {
+    match response {
+        LiveChartDataResponse::Reset {
+            row_count,
+            snapshot: ChartSnapshot::Xy(snapshot),
+        } => {
+            let mut values = Vec::with_capacity(snapshot.series.len());
+            let series = snapshot
+                .series
+                .iter()
+                .map(|series| {
+                    let meta = encode_xy_series_metadata(series)?;
+                    values.push(series.values.as_slice());
+                    Ok(meta)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            encode_frame(
+                PayloadKind::LiveResetXy,
+                &LiveResetMetadata {
+                    row_count: *row_count,
+                    snapshot: XySnapshotMetadata {
+                        plot_mode: snapshot.plot_mode,
+                        draw_style: snapshot.draw_style,
+                        x_name: &snapshot.x_name,
+                        y_name: snapshot.y_name.as_deref(),
+                        series,
+                    },
+                },
+                values,
+            )
+        }
+        LiveChartDataResponse::Reset {
+            row_count,
+            snapshot: ChartSnapshot::Heatmap(snapshot),
+        } => {
+            let mut values = Vec::with_capacity(snapshot.series.len());
+            let series = snapshot
+                .series
+                .iter()
+                .map(|series| {
+                    let meta = encode_xyz_series_metadata(series)?;
+                    values.push(series.values.as_slice());
+                    Ok(meta)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            encode_frame(
+                PayloadKind::LiveResetHeatmap,
+                &LiveResetMetadata {
+                    row_count: *row_count,
+                    snapshot: HeatmapSnapshotMetadata {
+                        x_name: &snapshot.x_name,
+                        y_name: &snapshot.y_name,
+                        series,
+                    },
+                },
+                values,
+            )
+        }
+        LiveChartDataResponse::Append { row_count, ops } => {
+            let mut value_blocks = Vec::with_capacity(ops.len());
+            let ops = ops
+                .iter()
+                .map(|operation| {
+                    let metadata = encode_live_append_metadata(operation)?;
+                    match operation {
+                        LiveChartAppendOperation::AppendPoints { values, .. } => {
+                            value_blocks.push(values.as_slice());
+                        }
+                        LiveChartAppendOperation::AppendSeries { series } => match series {
+                            FlatSeries::Xy(series) => value_blocks.push(series.values.as_slice()),
+                            FlatSeries::Xyz(series) => value_blocks.push(series.values.as_slice()),
+                        },
+                    }
+                    Ok(metadata)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            encode_frame(
+                PayloadKind::LiveAppend,
+                &LiveAppendMetadata {
+                    row_count: *row_count,
+                    ops,
+                },
+                value_blocks,
+            )
+        }
+    }
+}
+
+fn encode_frame(
+    payload_kind: PayloadKind,
+    metadata: &impl Serialize,
+    value_blocks: Vec<&[f64]>,
+) -> anyhow::Result<Vec<u8>> {
+    let metadata =
+        serde_json::to_vec(metadata).context("Failed to serialize chart wire metadata")?;
+    let metadata_len = u32::try_from(metadata.len()).context("Chart wire metadata too large")?;
+    let value_bytes_len = value_blocks
+        .iter()
+        .try_fold(0usize, |acc, block| {
+            acc.checked_add(block.len().checked_mul(8)?)
+        })
+        .context("Chart wire numeric payload too large")?;
+
+    let mut bytes = Vec::with_capacity(10 + metadata.len() + value_bytes_len);
+    bytes.extend_from_slice(MAGIC);
+    bytes.push(VERSION);
+    bytes.push(payload_kind.as_byte());
+    bytes.extend_from_slice(&metadata_len.to_le_bytes());
+    bytes.extend_from_slice(&metadata);
+    for block in value_blocks {
+        for value in block {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+    }
+    Ok(bytes)
+}
+
+fn encode_xy_series_metadata(series: &FlatXYSeries) -> anyhow::Result<SeriesMetadata<'_>> {
+    validate_value_count(series.values.len(), series.point_count, SeriesShape::Xy)
+        .with_context(|| format!("XY series '{}' has invalid value count", series.id))?;
+    Ok(SeriesMetadata {
+        id: &series.id,
+        label: &series.label,
+        point_count: series.point_count,
+        value_count: series.values.len(),
+    })
+}
+
+fn encode_xyz_series_metadata(series: &FlatXYZSeries) -> anyhow::Result<SeriesMetadata<'_>> {
+    validate_value_count(series.values.len(), series.point_count, SeriesShape::Xyz)
+        .with_context(|| format!("XYZ series '{}' has invalid value count", series.id))?;
+    Ok(SeriesMetadata {
+        id: &series.id,
+        label: &series.label,
+        point_count: series.point_count,
+        value_count: series.values.len(),
+    })
+}
+
+fn encode_live_append_metadata(
+    operation: &LiveChartAppendOperation,
+) -> anyhow::Result<LiveAppendOperationMetadata<'_>> {
+    match operation {
+        LiveChartAppendOperation::AppendPoints {
+            series_id,
+            values,
+            point_count,
+        } => {
+            let shape = infer_shape(values.len(), *point_count).with_context(|| {
+                format!("Live append points for series '{series_id}' have invalid value count")
+            })?;
+            Ok(LiveAppendOperationMetadata::AppendPoints {
+                series_id,
+                shape,
+                point_count: *point_count,
+                value_count: values.len(),
+            })
+        }
+        LiveChartAppendOperation::AppendSeries { series } => match series {
+            FlatSeries::Xy(series) => {
+                let metadata = encode_xy_series_metadata(series)?;
+                Ok(LiveAppendOperationMetadata::AppendSeries {
+                    shape: SeriesShape::Xy,
+                    id: metadata.id,
+                    label: metadata.label,
+                    point_count: metadata.point_count,
+                    value_count: metadata.value_count,
+                })
+            }
+            FlatSeries::Xyz(series) => {
+                let metadata = encode_xyz_series_metadata(series)?;
+                Ok(LiveAppendOperationMetadata::AppendSeries {
+                    shape: SeriesShape::Xyz,
+                    id: metadata.id,
+                    label: metadata.label,
+                    point_count: metadata.point_count,
+                    value_count: metadata.value_count,
+                })
+            }
+        },
+    }
+}
+
+fn infer_shape(value_count: usize, point_count: usize) -> anyhow::Result<SeriesShape> {
+    ensure!(
+        point_count > 0,
+        "Point count must be greater than zero for append payloads"
+    );
+    if value_count == point_count.saturating_mul(2) {
+        Ok(SeriesShape::Xy)
+    } else if value_count == point_count.saturating_mul(3) {
+        Ok(SeriesShape::Xyz)
+    } else {
+        bail!("Value count does not match XY or XYZ point layout");
+    }
+}
+
+fn validate_value_count(
+    value_count: usize,
+    point_count: usize,
+    shape: SeriesShape,
+) -> anyhow::Result<()> {
+    let expected = point_count
+        .checked_mul(match shape {
+            SeriesShape::Xy => 2,
+            SeriesShape::Xyz => 3,
+        })
+        .context("Point count overflowed while validating chart wire payload")?;
+    ensure!(
+        value_count == expected,
+        "Expected {expected} values for {point_count} points, got {value_count}"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::{MAGIC, VERSION, encode_chart_snapshot, encode_live_chart_data};
+    use crate::features::charts::types::{
+        ChartSnapshot, FlatSeries, FlatXYSeries, FlatXYZSeries, LiveChartAppendOperation,
+        LiveChartDataResponse, XYChartSnapshot,
+    };
+
+    fn parse_metadata(bytes: &[u8]) -> Value {
+        let metadata_len =
+            u32::from_le_bytes(bytes[6..10].try_into().expect("metadata length")) as usize;
+        serde_json::from_slice(&bytes[10..10 + metadata_len]).expect("metadata json")
+    }
+
+    fn numeric_payload(bytes: &[u8]) -> &[u8] {
+        let metadata_len =
+            u32::from_le_bytes(bytes[6..10].try_into().expect("metadata length")) as usize;
+        &bytes[10 + metadata_len..]
+    }
+
+    #[test]
+    fn encodes_xy_snapshot_frame() {
+        let bytes = encode_chart_snapshot(&ChartSnapshot::Xy(XYChartSnapshot {
+            plot_mode: crate::features::charts::types::XYPlotMode::Xy,
+            draw_style: crate::features::charts::types::XYDrawStyle::Points,
+            x_name: "time".to_string(),
+            y_name: Some("value".to_string()),
+            series: vec![FlatXYSeries::new(
+                "signal",
+                "signal",
+                vec![1.0, 2.0, 3.0, 4.0],
+                2,
+            )],
+        }))
+        .expect("frame");
+
+        assert_eq!(&bytes[..4], MAGIC);
+        assert_eq!(bytes[4], VERSION);
+        assert_eq!(bytes[5], 1);
+
+        let metadata = parse_metadata(&bytes);
+        assert_eq!(metadata["plotMode"], "xy");
+        assert_eq!(metadata["drawStyle"], "points");
+        assert_eq!(metadata["series"][0]["valueCount"], 4);
+        assert_eq!(numeric_payload(&bytes).len(), 4 * 8);
+    }
+
+    #[test]
+    fn encodes_heatmap_snapshot_frame() {
+        let bytes = encode_chart_snapshot(&ChartSnapshot::Heatmap(
+            crate::features::charts::types::HeatmapChartSnapshot {
+                x_name: "x".to_string(),
+                y_name: "y".to_string(),
+                series: vec![FlatXYZSeries::new(
+                    "heat",
+                    "heat",
+                    vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                    2,
+                )],
+            },
+        ))
+        .expect("frame");
+
+        assert_eq!(bytes[5], 2);
+        let metadata = parse_metadata(&bytes);
+        assert_eq!(metadata["series"][0]["pointCount"], 2);
+        assert_eq!(metadata["series"][0]["valueCount"], 6);
+        assert_eq!(numeric_payload(&bytes).len(), 6 * 8);
+    }
+
+    #[test]
+    fn encodes_live_reset_and_append_frames() {
+        let reset = encode_live_chart_data(&LiveChartDataResponse::Reset {
+            row_count: 5,
+            snapshot: ChartSnapshot::Xy(XYChartSnapshot {
+                plot_mode: crate::features::charts::types::XYPlotMode::QuantityVsSweep,
+                draw_style: crate::features::charts::types::XYDrawStyle::Line,
+                x_name: "step".to_string(),
+                y_name: None,
+                series: vec![FlatXYSeries::new("signal", "signal", vec![0.0, 1.0], 1)],
+            }),
+        })
+        .expect("reset frame");
+        assert_eq!(reset[5], 3);
+        assert_eq!(parse_metadata(&reset)["rowCount"], 5);
+
+        let append = encode_live_chart_data(&LiveChartDataResponse::Append {
+            row_count: 6,
+            ops: vec![
+                LiveChartAppendOperation::AppendPoints {
+                    series_id: "signal".to_string(),
+                    values: vec![2.0, 3.0],
+                    point_count: 1,
+                },
+                LiveChartAppendOperation::AppendSeries {
+                    series: FlatSeries::Xyz(FlatXYZSeries::new(
+                        "heat",
+                        "heat",
+                        vec![0.0, 1.0, 2.0],
+                        1,
+                    )),
+                },
+            ],
+        })
+        .expect("append frame");
+        assert_eq!(append[5], 5);
+        let metadata = parse_metadata(&append);
+        assert_eq!(metadata["rowCount"], 6);
+        assert_eq!(metadata["ops"][0]["kind"], "append_points");
+        assert_eq!(metadata["ops"][1]["shape"], "xyz");
+    }
+
+    #[test]
+    fn rejects_invalid_series_lengths() {
+        let error = encode_chart_snapshot(&ChartSnapshot::Xy(XYChartSnapshot {
+            plot_mode: crate::features::charts::types::XYPlotMode::Xy,
+            draw_style: crate::features::charts::types::XYDrawStyle::Points,
+            x_name: "x".to_string(),
+            y_name: Some("y".to_string()),
+            series: vec![FlatXYSeries::new(
+                "signal",
+                "signal",
+                vec![1.0, 2.0, 3.0],
+                2,
+            )],
+        }))
+        .expect_err("invalid frame");
+
+        assert!(error.to_string().contains("invalid value count"));
+    }
+
+    #[test]
+    fn rejects_invalid_append_point_lengths() {
+        let error = encode_live_chart_data(&LiveChartDataResponse::Append {
+            row_count: 1,
+            ops: vec![LiveChartAppendOperation::AppendPoints {
+                series_id: "signal".to_string(),
+                values: vec![1.0, 2.0, 3.0, 4.0],
+                point_count: 1,
+            }],
+        })
+        .expect_err("invalid append");
+
+        assert!(error.to_string().contains("invalid value count"));
+    }
+}

--- a/crates/fricon-ui/src/features/charts/wire.rs
+++ b/crates/fricon-ui/src/features/charts/wire.rs
@@ -410,8 +410,8 @@ mod tests {
 
     use super::{MAGIC, VERSION, encode_chart_snapshot, encode_live_chart_data};
     use crate::features::charts::types::{
-        ChartSnapshot, FlatSeries, FlatXYSeries, FlatXYZSeries, LiveChartAppendOperation,
-        LiveChartDataResponse, XYChartSnapshot,
+        ChartSnapshot, FlatSeries, FlatXYSeries, FlatXYZSeries, HeatmapChartSnapshot,
+        LiveChartAppendOperation, LiveChartDataResponse, XYChartSnapshot, XYDrawStyle, XYPlotMode,
     };
 
     fn parse_metadata(bytes: &[u8]) -> Value {
@@ -429,8 +429,8 @@ mod tests {
     #[test]
     fn encodes_xy_snapshot_frame() {
         let bytes = encode_chart_snapshot(&ChartSnapshot::Xy(XYChartSnapshot {
-            plot_mode: crate::features::charts::types::XYPlotMode::Xy,
-            draw_style: crate::features::charts::types::XYDrawStyle::Points,
+            plot_mode: XYPlotMode::Xy,
+            draw_style: XYDrawStyle::Points,
             x_name: "time".to_string(),
             y_name: Some("value".to_string()),
             series: vec![FlatXYSeries::new(
@@ -459,18 +459,16 @@ mod tests {
 
     #[test]
     fn encodes_heatmap_snapshot_frame() {
-        let bytes = encode_chart_snapshot(&ChartSnapshot::Heatmap(
-            crate::features::charts::types::HeatmapChartSnapshot {
-                x_name: "x".to_string(),
-                y_name: "y".to_string(),
-                series: vec![FlatXYZSeries::new(
-                    "heat",
-                    "heat",
-                    vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
-                    2,
-                )],
-            },
-        ))
+        let bytes = encode_chart_snapshot(&ChartSnapshot::Heatmap(HeatmapChartSnapshot {
+            x_name: "x".to_string(),
+            y_name: "y".to_string(),
+            series: vec![FlatXYZSeries::new(
+                "heat",
+                "heat",
+                vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                2,
+            )],
+        }))
         .expect("frame");
 
         assert_eq!(bytes[5], 2);
@@ -485,8 +483,8 @@ mod tests {
         let reset = encode_live_chart_data(&LiveChartDataResponse::Reset {
             row_count: 5,
             snapshot: ChartSnapshot::Xy(XYChartSnapshot {
-                plot_mode: crate::features::charts::types::XYPlotMode::QuantityVsSweep,
-                draw_style: crate::features::charts::types::XYDrawStyle::Line,
+                plot_mode: XYPlotMode::QuantityVsSweep,
+                draw_style: XYDrawStyle::Line,
                 x_name: "step".to_string(),
                 y_name: None,
                 series: vec![FlatXYSeries::new("signal", "signal", vec![0.0, 1.0], 1)],
@@ -525,8 +523,8 @@ mod tests {
     #[test]
     fn rejects_invalid_series_lengths() {
         let error = encode_chart_snapshot(&ChartSnapshot::Xy(XYChartSnapshot {
-            plot_mode: crate::features::charts::types::XYPlotMode::Xy,
-            draw_style: crate::features::charts::types::XYDrawStyle::Points,
+            plot_mode: XYPlotMode::Xy,
+            draw_style: XYDrawStyle::Points,
             x_name: "x".to_string(),
             y_name: Some("y".to_string()),
             series: vec![FlatXYSeries::new(

--- a/crates/fricon-ui/src/features/charts/wire.rs
+++ b/crates/fricon-ui/src/features/charts/wire.rs
@@ -82,12 +82,14 @@ struct LiveResetMetadata<T> {
 #[derive(Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum LiveAppendOperationMetadata<'a> {
+    #[serde(rename_all = "camelCase")]
     AppendPoints {
         series_id: &'a str,
         shape: SeriesShape,
         point_count: usize,
         value_count: usize,
     },
+    #[serde(rename_all = "camelCase")]
     AppendSeries {
         shape: SeriesShape,
         id: &'a str,
@@ -517,7 +519,12 @@ mod tests {
         let metadata = parse_metadata(&append);
         assert_eq!(metadata["rowCount"], 6);
         assert_eq!(metadata["ops"][0]["kind"], "append_points");
+        assert_eq!(metadata["ops"][0]["seriesId"], "signal");
+        assert_eq!(metadata["ops"][0]["pointCount"], 1);
+        assert_eq!(metadata["ops"][0]["valueCount"], 2);
         assert_eq!(metadata["ops"][1]["shape"], "xyz");
+        assert_eq!(metadata["ops"][1]["pointCount"], 1);
+        assert_eq!(metadata["ops"][1]["valueCount"], 3);
     }
 
     #[test]

--- a/crates/fricon-ui/src/tauri_api.rs
+++ b/crates/fricon-ui/src/tauri_api.rs
@@ -14,7 +14,10 @@ use tauri::ipc::Invoke;
 use tauri_specta::{Builder, collect_commands, collect_events};
 
 use crate::features::{
-    charts::tauri as charts,
+    charts::{
+        tauri as charts,
+        types::{DatasetChartDataOptions, LiveChartDataOptions},
+    },
     datasets::{
         error::UiDatasetError,
         tauri as datasets,
@@ -206,8 +209,8 @@ pub(crate) fn specta_builder() -> Builder {
         .commands(app_commands!(specta))
         .events(collect_events![DatasetChanged])
         .typ::<DatasetInfo>()
-        .typ::<crate::features::charts::types::DatasetChartDataOptions>()
-        .typ::<crate::features::charts::types::LiveChartDataOptions>()
+        .typ::<DatasetChartDataOptions>()
+        .typ::<LiveChartDataOptions>()
 }
 
 pub(crate) fn invoke_handler() -> impl Fn(Invoke) -> bool + Send + Sync + 'static {

--- a/crates/fricon-ui/src/tauri_api.rs
+++ b/crates/fricon-ui/src/tauri_api.rs
@@ -10,6 +10,7 @@ use fricon::{
     CatalogAppError, ReadAppError,
     dataset::{catalog::CatalogError, read::ReadError},
 };
+use tauri::ipc::Invoke;
 use tauri_specta::{Builder, collect_commands, collect_events};
 
 use crate::features::{
@@ -22,6 +23,56 @@ use crate::features::{
     },
     workspace::tauri as workspace,
 };
+
+macro_rules! define_app_commands {
+    (
+        shared: [$($shared:tt)*],
+        raw_only: [$($raw_only:tt)*]
+    ) => {
+        macro_rules! app_commands {
+            (specta) => {
+                collect_commands![
+                    $($shared)*
+                ]
+            };
+            (invoke) => {
+                tauri::generate_handler![
+                    $($shared)*
+                    $($raw_only)*
+                ]
+            };
+        }
+    };
+}
+
+define_app_commands! {
+    shared: [
+        workspace::get_workspace_info,
+        datasets::list_datasets,
+        datasets::list_dataset_tags,
+        datasets::dataset_detail,
+        charts::get_filter_table_data,
+        datasets::update_dataset_favorite,
+        datasets::update_dataset_info,
+        datasets::get_dataset_write_status,
+        datasets::delete_datasets,
+        datasets::trash_datasets,
+        datasets::restore_datasets,
+        datasets::empty_trash,
+        datasets::batch_update_dataset_tags,
+        datasets::delete_tag,
+        datasets::rename_tag,
+        datasets::merge_tag,
+        datasets::export_datasets_dialog,
+        datasets::preview_import_dialog,
+        datasets::preview_import_files,
+        datasets::import_dataset,
+    ],
+    raw_only: [
+        charts::dataset_chart_data,
+        charts::dataset_live_chart_data
+    ]
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, specta::Type)]
 #[serde(rename_all = "snake_case")]
@@ -152,32 +203,15 @@ impl From<UiDatasetError> for ApiError {
 
 pub(crate) fn specta_builder() -> Builder {
     Builder::new()
-        .commands(collect_commands![
-            workspace::get_workspace_info,
-            datasets::list_datasets,
-            datasets::list_dataset_tags,
-            datasets::dataset_detail,
-            charts::dataset_chart_data,
-            charts::get_filter_table_data,
-            charts::dataset_live_chart_data,
-            datasets::update_dataset_favorite,
-            datasets::update_dataset_info,
-            datasets::get_dataset_write_status,
-            datasets::delete_datasets,
-            datasets::trash_datasets,
-            datasets::restore_datasets,
-            datasets::empty_trash,
-            datasets::batch_update_dataset_tags,
-            datasets::delete_tag,
-            datasets::rename_tag,
-            datasets::merge_tag,
-            datasets::export_datasets_dialog,
-            datasets::preview_import_dialog,
-            datasets::preview_import_files,
-            datasets::import_dataset
-        ])
+        .commands(app_commands!(specta))
         .events(collect_events![DatasetChanged])
         .typ::<DatasetInfo>()
+        .typ::<crate::features::charts::types::DatasetChartDataOptions>()
+        .typ::<crate::features::charts::types::LiveChartDataOptions>()
+}
+
+pub(crate) fn invoke_handler() -> impl Fn(Invoke) -> bool + Send + Sync + 'static {
+    app_commands!(invoke)
 }
 
 pub fn export_bindings(path: impl AsRef<Path>) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- switch chart snapshot and live chart responses from JSON IPC payloads to a feature-local binary wire format
- route raw chart commands through Tauri runtime registration while keeping Specta-generated bindings for the remaining JSON commands
- align the chart numeric payload for typed-array decoding on the frontend and tighten the raw transport helper to the desktop `ArrayBuffer` contract

## Why
The chart data path was serializing large numeric payloads as JSON arrays, which adds avoidable overhead on both the Rust and frontend sides. This change moves chart transport onto a binary path while leaving the rest of the UI API on the existing Specta flow.

## Validation
- `cargo +nightly fmt --all --check`
- `pnpm run check`
- `pnpm run format:check`
- `pnpm --filter fricon-ui run gen:bindings`
- `git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts`
- `cargo check`
- `cargo build --workspace --locked`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `cargo deny --workspace --all-features check`
- `pnpm run test`
- `pnpm run build`
- `git diff --exit-code crates/fricon-ui/frontend/src/routeTree.gen.ts`

## Notes
- this is a feature-local UI bridge change inside `fricon-ui`; it does not change the repo-wide IPC/gRPC compatibility contract
- the PR also updates the local preflight checklist skill to require `clippy -D warnings`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
