### PR TITLE
docs: add dataset semantic architecture proposal and implementation plan

### DIFF
--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -21,8 +21,8 @@ The target architecture should:
 - stop treating chart semantics as a side effect of row adjacency heuristics
 - keep dataset-local meaning separate from higher-level run or measurement
   context
-- preserve the existing scalar, complex, and trace payload types as orthogonal
-  to semantic interpretation
+- keep scalar, complex, and trace payload types as the primary description of
+  column kind, with metadata used only for display and chart hints
 
 ## Why Change
 
@@ -72,6 +72,8 @@ workspace/
         dataset_manifest.json
         data_chunk_0.arrow
         data_chunk_1.arrow
+        index_chunk_0.arrow      # optional logical-index sidecar
+        index_chunk_1.arrow      # optional logical-index sidecar
         ...
 ```
 
@@ -79,6 +81,9 @@ Notes:
 
 - File names can still be revised, but the proposal assumes chunked Arrow IPC
   files remain the physical storage substrate.
+- Logical index sidecar chunks are optional. Regular ordered scans should not
+  pay a main-payload storage cost for indices that can be derived from append
+  order and scan shape.
 - SQLite dataset metadata remains separate and continues to own workspace-level
   catalog concerns such as name, description, tags, favorite state, and status.
 - A higher-level run or measurement manifest is explicitly out of scope for
@@ -91,19 +96,30 @@ Notes:
 Each stored row records an observation that happened. Rows are not overwritten
 in place to represent retries, resumes, or corrections.
 
-### 2. Schema Is Fixed At Dataset Creation
+### 2. Schema Is Fixed Once Writing Starts
 
 Fricon currently fixes schema from the first row and requires later rows to
 match exactly. The clean architecture should keep the "fixed schema" invariant,
-but move schema choice to dataset creation rather than accidental first-row
-shape.
+while allowing the simple API to infer schema from the first written row.
+Semantic mode may declare columns earlier; minimal mode freezes payload columns
+once writing starts.
 
 Implication:
 
-- any system columns that may appear later must be declared up front
-- optional system columns should be nullable, not absent from some rows
+- payload columns are fixed once the dataset starts writing
+- `__ds_point_id` is always materialized by the writer
+- durable logical indices live in an index sidecar when they cannot be derived
+  from append order
+- optional future system payload columns should be declared explicitly rather
+  than appearing mid-stream
 
 This avoids hidden schema drift and keeps the write path simple.
+
+For v1, null-heavy workflows are deliberately out of scope:
+
+- the first written row should contain all payload columns
+- values should be non-null
+- nullable or late-appearing columns should require an explicit future API
 
 ### 3. `__ds_` Is Reserved For System Fields
 
@@ -117,11 +133,6 @@ Examples:
 
 - `__ds_point_id`
 - `__ds_time_ns`
-- `__ds_idx_x`
-- `__ds_idx_y`
-- `__ds_sweep_id`
-- `__ds_frame_id`
-- `__ds_status`
 
 Collision with user columns should be a hard creation-time error.
 
@@ -145,11 +156,11 @@ Semantics:
 The manifest, not Arrow field order and not chart heuristics, is the canonical
 source for:
 
-- column roles
+- column metadata and display hints
 - axis identity
 - logical index mapping
 - scan-plan hints
-- live grouping semantics
+- active live grouping defaults
 - default view suggestions
 
 ### 6. Compatibility Inference Is A Fallback Layer
@@ -175,16 +186,91 @@ Recommended top-level sections:
 
 - `manifest_version`
 - `columns`
-- `scan_plan`
 - `realization`
-- `live_grouping`
-- `view_defaults`
 - `compatibility`
+- `scan_plan`
+- `live_defaults`
+- `view_defaults`
 
-### Semantic Roles Are Orthogonal To Data Types
+Only the first four sections are required for the minimal manifest. Other
+sections should be added only when the user or a higher-level system supplies
+the relevant information, or when an implementation needs to cache a resolved
+interpretation.
 
-The semantic layer describes what a column means in the experiment, not how its
-payload is encoded inside a row.
+### Minimal Manifest
+
+Bare `write(col=...)` should create a small manifest that records only the
+durable facts needed by all datasets:
+
+```json
+{
+    "manifest_version": 1,
+    "columns": {
+        "__ds_point_id": {
+            "dtype": {
+                "kind": "uint64"
+            },
+            "system": {
+                "kind": "point_id"
+            }
+        },
+        "x": {
+            "dtype": {
+                "kind": "float64"
+            }
+        },
+        "signal": {
+            "dtype": {
+                "kind": "float64"
+            }
+        }
+    },
+    "realization": {
+        "append_only": true,
+        "point_id_column": "__ds_point_id",
+        "index_realization": {
+            "kind": "none"
+        },
+        "duplicate_resolution_default": {
+            "kind": "latest_by_point_id"
+        }
+    },
+    "compatibility": {
+        "allow_inference": true
+    }
+}
+```
+
+This is the baseline for datasets created without `columns=`, `scan=`, or
+explicit `logical_indices=`.
+
+Notes:
+
+- `columns` mirrors the frozen payload schema plus Fricon-owned system fields.
+- `scan_plan` is absent until the user passes `scan=` or the system later
+  materializes inferred scan metadata.
+- `index_realization.kind = "none"` means no durable logical index space has
+  been declared yet; charts may use compatibility inference if needed.
+- `live_defaults` and `view_defaults` are absent until explicitly provided or
+  cached by a future implementation.
+- Adding optional sections later should not require rewriting payload chunks.
+
+The manifest is not a user-authored JSON format. Design it for Rust serde
+maintenance:
+
+- prefer internally tagged enums such as `{"kind": "none"}` over bare strings
+  or booleans when a value may later gain fields
+- keep optional top-level sections as `Option<T>` with serde defaults
+- avoid `untagged` enums for durable manifest fields
+- do not use `deny_unknown_fields` unless intentionally rejecting newer
+  manifests
+- keep invariant checks in explicit validation code after deserialization
+
+### Column Metadata Complements Data Types
+
+Do not introduce a broad separate column-role system in v1. Most remaining
+role-like concepts are better expressed by dataset data types plus small display
+or chart hints.
 
 This proposal should preserve Fricon's existing data-type distinctions:
 
@@ -192,46 +278,44 @@ This proposal should preserve Fricon's existing data-type distinctions:
 - complex scalar columns
 - trace columns
 
-Examples:
+V1 may extend or refine the datatype vocabulary when a distinction has direct
+storage or rendering consequences, for example:
 
-- a `measurement` may be a scalar or a trace
-- a `scan_axis` is usually scalar
-- grid and live-grouping semantics describe row-to-row structure, not the
-  internal X axis of a trace payload
+- timestamp-like scalar columns, if user-provided timestamps need first-class
+  rendering or formatting
+- categorical scalar columns, if categorical handling differs from plain string
+  or numeric values
 
-This separation avoids forcing scan semantics and trace rendering into the same
-abstraction.
+System timestamps should use an explicit Fricon-owned system field such as
+`__ds_time_ns` when needed. A normal user timestamp column should just be a
+typed payload column.
 
-### Column Semantics
+### Column Metadata And Chart Hints
 
-Each column may declare:
+Column metadata should stay lightweight. Users more naturally describe:
 
-- `role`
+- stored payload columns and their optional types, units, and labels
+- scan axes and optional static coordinate values
+- framework-owned logical indices when append order is insufficient
+
+The public API should therefore accept column metadata such as:
+
+- `dtype`
 - `label`
 - `unit`
 - `hidden_by_default`
-- `axis_id`
+- `chart_axis`
 
-Recommended v1 role vocabulary:
-
-- `point_id`
-- `scan_axis`
-- `logical_index`
-- `measurement`
-- `timestamp`
-- `sweep_id`
-- `frame_id`
-- `status`
-- `categorical`
-- `annotation`
-- `unknown`
-
-Do not add a large ontology in v1.
+`chart_axis` means "this stored column is a good coordinate-axis candidate in
+chart UI." It does not create a separate durable coordinate model. All other
+chart defaults should be resolved from datatype, scan axes, index realization,
+and compatibility inference.
 
 ### Scan Plan
 
-`scan_plan` should be lightweight and permissive. It is a hint layer, not a
-full planner state dump.
+`scan_plan` should be lightweight and permissive. It describes the dataset's
+logical index space and optional static coordinate values, not a full planner
+state dump.
 
 Recommended fields:
 
@@ -241,14 +325,66 @@ Recommended fields:
 - `strictness`
 - `allows_partial`
 - `allows_duplicate_positions`
+- `index_realization`
 
 Each axis should describe:
 
 - axis identity
-- value column
-- optional logical index column
+- optional static coordinate values
 - mode: `linear`, `list`, `categorical`, `adaptive`, `implicit_index`,
   `unknown`
+
+Scan axes are not necessarily stored Arrow payload columns. For example,
+`scan={"x": [1, 2, 3], "y": ["left", "right"]}` declares a logical scan grid
+whose coordinate lookup values can live in the manifest. For unbounded or
+unknown-length axes such as minimizer steps, use an implicit integer index axis
+rather than a static list.
+
+If a dataset also stores user columns such as `gate_v` or `field_t`, those
+columns remain ordinary payload columns. The scan axis and the payload column
+may share a practical relationship, but v1 should not require a one-to-one
+mapping between them.
+
+Do not add a separate derived-coordinate model in v1. Scan axes and chart
+coordinates can be many-to-many, and derived coordinates are often transforms
+of multiple logical indices. If a derived coordinate must be visible after
+reopen or export, materialize it as an ordinary stored column and mark it as
+usable for chart axes with column metadata such as `chart_axis=True`.
+
+### Logical Index Realization
+
+Logical indices should have three realization modes:
+
+- `implicit`: derive indices from `__ds_point_id`, scan shape, and traversal
+- `sidecar`: store append-only index chunks mapping `__ds_point_id` to logical
+  index values
+- `embedded`: reserve for rare future cases where indices are part of the main
+  payload schema
+
+V1 should implement `implicit` and `sidecar`.
+
+Regular ordered scans should default to `implicit`. A scan like:
+
+```python
+scan={"gate": [-0.2, -0.1, 0.0, 0.1], "bias": [0.0, 0.01, 0.02]}
+```
+
+can derive logical indices from append order and traversal. No per-row index
+columns are needed in the main payload.
+
+When append order is insufficient, for example shuffled acquisition, retries,
+resumes, adaptive scans, or ragged groups, the writer can persist a sidecar
+index table. The sidecar schema should be compact:
+
+```text
+__ds_point_id: uint64
+<axis_id>: int64
+...
+```
+
+Sidecar chunks remain append-only and use the same chunking discipline as the
+payload. They are dataset facts, but they stay separate from user payload
+columns.
 
 ### Realization
 
@@ -259,6 +395,7 @@ Recommended v1 fields:
 
 - `append_only: true`
 - `point_id_column`
+- `index_realization`
 - `duplicate_resolution_default`
 
 Avoid storing counters such as `actual_points` in the manifest unless there is
@@ -266,19 +403,21 @@ clear write ownership and consistency logic.
 
 ### Live Grouping
 
-Live grouping must become explicit.
+Live grouping should be explicit in the active write session, but it does not
+need to be persisted as dataset payload in v1.
 
-Recommended fields:
+Recommended v1 behavior:
 
-- `sweep_id_column`
-- `frame_id_column`
-- `fallback_group_by_axes`
-
-Critical rule:
-
-- non-contiguous scans should require explicit `sweep_id` or `frame_id` for
-  correct live grouping
+- live refresh grouping may use in-memory write-session state
+- chart projections after reopen should depend on persisted facts:
+  `__ds_point_id`, manifest scan axes, and optional sidecar logical indices
 - adjacency-based grouping remains valid only for contiguous legacy scans
+- non-contiguous scans that must be reproducible after reopen should persist
+  logical indices in the sidecar, not live-only frame markers
+
+Do not persist `sweep_id` or `frame_id` by default in v1. They mainly control
+when live charts refresh, and durable execution segments belong more naturally
+to a future run or measurement layer.
 
 ### View Defaults Versus Saved Views
 
@@ -333,8 +472,10 @@ stable, chart-ready semantics.
 It should expose a resolved model such as:
 
 - scan axes
-- logical index columns
-- measurement candidates
+- logical index realization
+- value columns
+- chart-axis candidate columns
+- column display metadata
 - live grouping rules
 - default views
 - duplicate resolution policy
@@ -349,12 +490,13 @@ primary abstraction.
 Instead, `crates/fricon-ui` should receive richer dataset interpretation data,
 for example:
 
-- `role`
-- `isMeasurement`
-- `isScanAxis`
 - `isLogicalIndex`
+- `isChartAxisCandidate`
 - `axisId`
 - `hiddenByDefault`
+- `label`
+- `unit`
+- resolved scan axes
 - resolved live grouping defaults
 - resolved default views
 
@@ -365,27 +507,88 @@ but it should not remain the canonical contract.
 
 ### Creation Phase
 
-Dataset creation should become explicit even for the simple API.
+Dataset creation should support progressive optional metadata while preserving
+the simple `write(col=...)` path.
 
-Creation computes and freezes:
-
-- payload schema
-- selected system columns
-- initial manifest
-
-Suggested API shape:
+Public Python API shape:
 
 ```python
 with manager.create(
     "name",
-    semantics=DatasetSemantics(
-        columns=...,
-        scan_plan=...,
-        system_fields=...,
-    ),
+    columns={
+        "signal": float,
+        "phase": Column(float, unit="rad"),
+        "trace": Trace[float],
+    },
+    scan={
+        "gate": [-0.2, -0.1, 0.0, 0.1],
+        "bias": [0.0, 0.01, 0.02],
+        "step": IndexAxis(),
+    },
+    description="optional",
+    tags=["optional"],
 ) as writer:
     ...
 ```
+
+All new semantic parameters should be optional. Users can start with no
+metadata, then progressively add the information they consider useful.
+
+Recommended top-level creation arguments:
+
+- `columns`: optional stored payload column definitions
+- `scan`: optional logical scan-axis definitions
+- future `views`: optional dataset-owned default views, if needed
+
+Avoid making normal users construct or edit the raw manifest. A `semantics=`
+escape hatch may be useful later for framework authors, but the primary public
+API should stay close to the user's mental model.
+
+### Python Typing Goals
+
+The public Python API should have modern, explicit typing in the `.pyi` stubs so
+IDEs, AI coding tools, and static checkers can understand common usage.
+
+Recommended typing direction:
+
+```python
+@dataclass(frozen=True)
+class Column:
+    dtype: ColumnDType | None = None
+    unit: str | None = None
+    label: str | None = None
+    chart_axis: bool | None = None
+    hidden_by_default: bool = False
+
+@dataclass(frozen=True)
+class IndexAxis:
+    label: str | None = None
+
+ColumnSpec = type[float] | type[int] | TraceType | Column
+ScanAxisSpec = Sequence[ScalarValue] | IndexAxis | None
+```
+
+The runtime may accept plain mappings for convenience, but the documented API
+should prefer typed helpers for completion and readability.
+
+Column definitions should support both concise and typed forms:
+
+```python
+with manager.create(
+    "typed_dataset",
+    columns={
+        "a": float,
+        "b": int,
+        "c": Trace[float],
+        "v": Column(float, unit="V", label="Voltage"),
+    },
+) as writer:
+    ...
+```
+
+If a column definition omits `dtype`, the type is inferred from the first
+written row. If no column metadata is supplied, the first row still determines
+the user payload schema.
 
 For bare writes:
 
@@ -399,24 +602,42 @@ For bare writes:
 Each row writes:
 
 - user fields
-- nullable system fields declared at creation
+- `__ds_point_id`, materialized automatically
+- optional logical index entries through a sidecar when append-order inference
+  is insufficient
 
-Suggested ergonomic Python surface:
+Keep the high-friction system path out of `write(**kwargs)`. The public
+`write()` method should remain a clean row-writing API:
 
 ```python
-writer.write(
-    x=0.1,
-    y=2.0,
-    signal=0.95,
-    ds={
-        "idx": {"x": 10, "y": 2},
-        "sweep_id": 7,
-    },
+writer.write(x=0.1, y=2.0, signal=0.95)
+```
+
+Framework and advanced callers should use `write_dict` for structured write
+context:
+
+```python
+writer.write_dict(
+    {"gate_v": gate_v, "bias_v": bias_v, "signal_v": signal_v},
+    logical_indices={"gate": gate_index, "bias": bias_index},
 )
 ```
 
-The `ds` helper is only API sugar. Internally it maps to fixed nullable
-`__ds_*` columns.
+`logical_indices` is durable dataset context. Supplying it should switch the
+dataset's index realization to a sidecar table if implicit realization is not
+already sufficient. Do not introduce `status`, `sweep_id`, or `frame_id` as v1
+write parameters unless a future run/execution model gives them durable
+meaning.
+
+### Transport Creation Contract
+
+Arrow schema should continue to be carried by the IPC stream payload. Creation
+metadata should carry only dataset catalog metadata plus optional semantic
+creation metadata such as `columns` and `scan`.
+
+This avoids duplicating schema ownership between `CreateMetadata` and the Arrow
+payload. If semantic creation metadata changes the protobuf request shape,
+`IPC_PROTOCOL_VERSION` should be bumped.
 
 ## Reader Architecture
 
@@ -427,15 +648,19 @@ Suggested responsibilities:
 - `reader.points()` -> raw row access
 - `reader.manifest()` -> raw manifest
 - `reader.interpret()` -> resolved dataset semantics
+- `reader.indexes()` -> resolved logical indices, derived or sidecar-backed
 - `reader.grid(value=...)` -> grid projection using resolved interpretation
-- `reader.live_groups(k=...)` -> live grouping using resolved semantics
+- `reader.select(index={...})` -> selection in logical index coordinates
+- `reader.live_groups(k=...)` -> live grouping using active-session semantics
 
 Important rule:
 
 - duplicate grid placement must be resolved in the interpretation layer, not
   separately reimplemented in each chart path
+- ragged grids should be represented as observed sparse index pairs rather than
+  forced into rectangular planned shapes
 
-## Duplicate And Status Semantics
+## Duplicate Semantics
 
 Duplicate logical positions are allowed and expected.
 
@@ -443,15 +668,12 @@ Recommended v1 rule:
 
 - default duplicate policy: `latest_by_point_id`
 
-Do not use `latest_valid_by_point_id` in v1 unless status semantics are made
-mandatory and precisely defined.
-
-If status support is needed, define a compact status vocabulary first:
-
-- `valid`
-- `invalid`
-- `aborted`
-- `unknown`
+Do not add status-aware duplicate policies in v1. Dataset payloads are
+append-only facts; when the same logical scan point is written more than once,
+the default projection should use the later `__ds_point_id`. If a future
+workflow needs invalidation or execution-quality state, it should be designed
+with the run or measurement layer rather than added as an under-specified
+dataset column.
 
 ## Live Monitor Rules
 
@@ -466,19 +688,48 @@ Allowed fallback:
 
 Preferred path:
 
-- use explicit `sweep_id`
-- use explicit `frame_id`
-- use manifest-configured fallback grouping only when scans are still
-  contiguous
+- use manifest scan axes and resolved logical indices
+- use in-memory live grouping for active write-session refresh timing
+- use manifest-configured fallback grouping only when scans are contiguous
 
 ### Non-Contiguous Scans
 
 For shuffled scans, resumes, ROI-first acquisition, or retries:
 
-- explicit grouping IDs are required for correctness
+- explicit logical indices are required for durable correctness
 - adjacency heuristics are not sufficient
+- the durable representation should be the logical-index sidecar, not
+  `sweep_id` or `frame_id` payload columns
 
 This should be documented as a hard semantic contract, not a best-effort hope.
+
+### Unknown-Length And Ragged Scans
+
+Unknown-length axes are first-class in v1 for minimizer and adaptive workflows.
+The common minimizer case should be modeled as an implicit integer index:
+
+```python
+scan={"step": IndexAxis()}
+```
+
+or a concise equivalent chosen by the Python API.
+
+This axis has no planned length and no static coordinate list. By default,
+`step` is derived from append order. If a workflow has multiple ragged groups,
+for example restarts with different minimizer lengths, it should persist a
+sidecar logical index table:
+
+```text
+__ds_point_id | restart | step
+0             | 0       | 0
+1             | 0       | 1
+2             | 0       | 2
+3             | 1       | 0
+4             | 1       | 1
+```
+
+Charts should treat this as an observed sparse grid. Missing cells are empty;
+the dataset does not need to claim a rectangular `planned_shape`.
 
 ## V1 Scope
 
@@ -487,21 +738,32 @@ The clean v1 should include:
 - chunked append-only Arrow payloads
 - `dataset_manifest.json`
 - `__ds_point_id`
-- explicit column roles
-- optional logical index columns
+- a minimal manifest for bare writes with column metadata, realization, and
+  compatibility settings
+- optional typed `columns=` creation metadata
+- optional `scan=` creation metadata
+- implicit logical-index realization for regular ordered scans
+- optional append-only logical-index sidecar chunks
 - scan-plan-lite
-- explicit live grouping fields
+- active-session live grouping that does not require durable `sweep_id` or
+  `frame_id` payload columns
 - resolved interpretation API
 - chart integration that prefers resolved semantics over inference
+- column metadata that can mark stored columns as chart-axis candidates
+- unknown-length integer index axes for minimizer-style workflows
+- ragged heatmap projection from observed sparse index pairs
 
 The clean v1 should defer:
 
 - measurement or run manifest design
 - execution segment tables
+- status or invalidation semantics
 - rich provenance graph
 - expanded planned-point tables
 - multiple duplicate-resolution policies
 - user-editable manifest history
+- a separate durable derived-coordinate model
+- null-heavy or late-appearing column workflows
 
 ## Worked Use Cases
 
@@ -557,8 +819,10 @@ Recommended internal behavior:
 1. The first row determines the user column set and data types.
 2. Fricon materializes `__ds_point_id` automatically.
 3. Fricon writes a minimal manifest with:
-    - all user columns marked as `unknown`
-    - `__ds_point_id` marked as `point_id`
+    - observed payload column metadata
+    - `__ds_point_id` as the point-id system field
+    - no scan plan
+    - no durable logical index realization
     - compatibility mode enabled
 4. Readers and charts may still use compatibility inference for this dataset.
 
@@ -571,17 +835,19 @@ Result:
 Optional upgrade path:
 
 If the user wants slightly better semantics without much extra ceremony, the
-API should allow a small amount of opt-in metadata:
+API should allow top-level `columns` and `scan` metadata:
 
 ```python
 with ws.dataset_manager.create(
     "quick_iv_map",
-    semantics={
-        "columns": {
-            "gate_v": {"role": "scan_axis", "axis_id": "gate", "unit": "V"},
-            "bias_v": {"role": "scan_axis", "axis_id": "bias", "unit": "V"},
-            "current_a": {"role": "measurement", "unit": "A"},
-        }
+    columns={
+        "gate_v": Column(float, unit="V"),
+        "bias_v": Column(float, unit="V"),
+        "current_a": Column(float, unit="A"),
+    },
+    scan={
+        "gate": [-0.2, -0.1, 0.0, 0.1, 0.2],
+        "bias": [0.0, 0.01, 0.02],
     },
 ) as ds:
     for ix, gate_v in enumerate([-0.2, -0.1, 0.0, 0.1, 0.2]):
@@ -589,8 +855,24 @@ with ws.dataset_manager.create(
             ds.write(gate_v=gate_v, bias_v=bias_v, current_a=measure_current())
 ```
 
-This is still small enough for a Python user to tolerate. The key is that the
-semantic path is available but not mandatory.
+The `scan` declaration communicates logical axes without asking the user to
+learn role vocabulary. For this regular ordered scan, Fricon can derive logical
+indices from append order and scan traversal.
+
+For a minimizer or adaptive workflow, the user can declare an unknown-length
+integer index axis:
+
+```python
+with ws.dataset_manager.create(
+    "minimize",
+    columns={"loss": float, "x": float, "y": float},
+    scan={"step": IndexAxis()},
+) as ds:
+    for step in optimizer:
+        ds.write(loss=step.loss, x=step.x, y=step.y)
+```
+
+This keeps the semantic path available but not mandatory.
 
 ### Use Case 2: Fully Wired Experiment System
 
@@ -599,7 +881,7 @@ Scenario:
 - the user works inside a higher-level experiment system
 - scan configuration, loop structure, planner state, and system columns are
   wired by the experiment runtime
-- the experiment author should focus on semantic intent and the loop body, not
+- the experiment author should focus on dataset intent and the loop body, not
   on dataset plumbing
 
 Recommended split of responsibility:
@@ -608,10 +890,11 @@ Recommended split of responsibility:
     - scan specification
     - traversal policy
     - retry or resume policy
-    - grouping IDs
+    - explicit logical indices when append order is insufficient
+    - live grouping state for active refresh timing
     - loop orchestration
 - the experiment author owns:
-    - semantic declarations that matter to the experiment
+    - dataset declarations that matter to the experiment
     - the loop body function or measurement function
 
 Example shape:
@@ -621,16 +904,14 @@ Example shape:
     dataset={
         "name": "transport_map",
         "columns": {
-            "gate_v": {"role": "scan_axis", "axis_id": "gate", "unit": "V"},
-            "field_t": {"role": "scan_axis", "axis_id": "field", "unit": "T"},
-            "signal_v": {"role": "measurement", "unit": "V"},
+            "gate_v": {"dtype": float, "unit": "V"},
+            "field_t": {"dtype": float, "unit": "T"},
+            "signal_v": {"dtype": float, "unit": "V"},
         },
     },
     scan={
-        "axes": [
-            {"id": "gate", "values": gate_points},
-            {"id": "field", "values": field_points},
-        ],
+        "gate": gate_points,
+        "field": field_points,
         "traversal": {"fast_axis": "gate", "slow_axes": ["field"]},
     },
 )
@@ -644,31 +925,26 @@ Recommended runtime behavior:
 
 1. The experiment system computes the full dataset schema before acquisition
    starts.
-2. It requests the system fields it needs up front, for example:
-    - `__ds_point_id`
-    - `__ds_idx_gate`
-    - `__ds_idx_field`
-    - `__ds_sweep_id`
-    - `__ds_frame_id` when relevant
-    - `__ds_status` if retries or invalidation are supported
+2. It decides whether logical indices are implicit or sidecar-backed:
+    - regular ordered scans can use implicit realization
+    - shuffled, resumed, adaptive, or ragged scans should use sidecar
+      realization
 3. It creates the manifest before the first data row is written.
-4. Each loop iteration writes one row with both user values and system values.
+4. Each loop iteration writes one payload row, plus sidecar logical indices
+   when needed.
 
-The actual write path may look like:
+The actual write path for a non-contiguous or ragged scan may look like:
 
 ```python
-ds.write(
-    gate_v=ctx.axis("gate").value,
-    field_t=ctx.axis("field").value,
-    signal_v=lockin_read(),
-    ds={
-        "idx": {
-            "gate": ctx.axis("gate").index,
-            "field": ctx.axis("field").index,
-        },
-        "sweep_id": ctx.sweep_id,
-        "frame_id": ctx.frame_id,
-        "status": "valid",
+ds.write_dict(
+    {
+        "gate_v": ctx.axis("gate").value,
+        "field_t": ctx.axis("field").value,
+        "signal_v": lockin_read(),
+    },
+    logical_indices={
+        "gate": ctx.axis("gate").index,
+        "field": ctx.axis("field").index,
     },
 )
 ```
@@ -682,7 +958,7 @@ Result:
 - live monitor and chart behavior become correct for non-trivial scans
 - retries, resumes, and non-contiguous acquisition can be represented without
   hacking chart heuristics
-- the experiment author only writes semantic intent plus measurement logic
+- the experiment author only writes dataset intent plus measurement logic
 
 ## API Design Implication
 
@@ -694,8 +970,9 @@ The public API should intentionally support two entry modes:
     - compatibility inference remains acceptable
 - semantic mode:
     - optimized for framework-owned execution
-    - semantics declared before acquisition starts
-    - fixed schema, fixed system columns, explicit grouping, explicit scan plan
+    - columns and scan declared before acquisition starts where possible
+    - fixed payload schema, explicit logical indices when needed, explicit scan
+      plan
 
 These modes should converge on the same storage and interpretation model. They
 should differ only in how much information is supplied at creation time.
@@ -770,11 +1047,15 @@ The architecture is considered successful when:
 
 - a known 2D scan opens correctly from explicit semantics without relying on
   first-two-row inference
-- shuffled scans with logical indices render to the correct grid cells
+- regular ordered scans can derive logical indices implicitly without storing
+  index columns in the main payload
+- shuffled scans with sidecar logical indices render to the correct grid cells
 - retries and resumes preserve all fact rows while default projections use the
   latest row by `__ds_point_id`
-- live views for non-contiguous scans behave correctly when explicit grouping
-  IDs are present
+- live views for active writes can use in-memory grouping without requiring
+  durable `sweep_id` or `frame_id` payload columns
+- minimizer-style unknown-length index axes can be sliced by index coordinate
+- ragged heatmaps render from observed sparse index pairs
 - bare `write(col=...)` still works, but now produces a minimal semantic
   manifest owned by the dataset layer
 

--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -254,8 +254,11 @@ Notes:
   Dtypes are Fricon dataset dtypes. Primitive scalar variants should use the
   same concrete names as Arrow where there is a direct one-to-one mapping, such
   as `float64`, `int64`, and `uint64`. Avoid arbitrary bit-width fields in the
-  durable JSON. Fricon-owned business dtypes such as `trace[float]` and
+  durable JSON. Fricon-owned business dtypes such as `trace[float64]` and
   `timestamp_us` can extend that vocabulary when they carry semantic meaning.
+- Arrow payload schema remains the physical schema. The manifest is the
+  semantic authority. New semantic datasets should not rely on Arrow extension
+  types to identify Fricon concepts.
 - `scan_plan` is absent until the user passes `scan=` or the system later
   materializes inferred scan metadata.
 - `index_realization.kind = "none"` means no durable logical index space has
@@ -298,6 +301,85 @@ direct storage or rendering consequences, for example:
 System timestamps should use `__ds_recorded_at` with the Fricon `timestamp_us`
 business dtype when needed. A normal user timestamp column should just be a
 typed payload column. The manifest should not expose Arrow timestamp internals.
+
+### Plain Arrow Storage, Manifest Semantics
+
+With a dataset manifest, Arrow extension types become redundant. New semantic
+datasets should store plain Arrow physical schemas and put all Fricon-specific
+meaning in `dataset_manifest.json`.
+
+Recommended physical layouts:
+
+- `complex128`: `struct<real: float64, imag: float64>`
+- simple trace: `list<value>`, with an implicit integer sample index axis
+- fixed-step trace: `struct<x0: axis, step: axis, y: list<value>>`
+- variable-step trace: `struct<x: list<axis>, y: list<value>>`
+
+`axis` should be a numeric trace-axis dtype, not hard-coded to `float64`.
+`value` should be a scalar trace-value dtype such as `float64` or
+`complex128`. Nested traces are not a meaningful dataset value and should not
+be representable in the trace value type.
+
+The current project has not reached production use, so this is the right time
+to remove `fricon.complex` and `fricon.trace` extension metadata as a durable
+storage dependency. Compatibility fallback, where kept, should infer from plain
+Arrow field shape rather than treating extension metadata as canonical.
+
+### DatasetDataType Refactor Direction
+
+The current runtime `DatasetDataType` collapses physical details into broad
+business categories such as numeric scalar, complex scalar, and trace. That was
+simple, but it makes future support for `float32`, `int64`, `uint64`,
+timestamps, strings, or booleans awkward.
+
+Do not replace it with an arbitrary `(business_kind, arrow_type)` pair. That
+would be easy to serialize but would allow many invalid combinations. Prefer a
+constrained Fricon-owned dtype enum that uses Arrow-aligned primitive variants
+and structured business variants:
+
+```rust
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum DatasetDType {
+    Float64,
+    Float32,
+    Int64,
+    UInt64,
+    Bool,
+    Utf8,
+    TimestampUs,
+    Complex128,
+    Trace(TraceDType),
+}
+
+struct TraceDType {
+    layout: TraceLayout,
+    axis: TraceAxisDType,
+    value: TraceValueDType,
+}
+
+enum TraceAxisDType {
+    Float64,
+    Float32,
+    Int64,
+    UInt64,
+}
+
+enum TraceValueDType {
+    Float64,
+    Float32,
+    Int64,
+    UInt64,
+    Complex128,
+}
+```
+
+Validation should check each dtype against the actual plain Arrow physical
+schema, but basic invariants should also be encoded in the Rust types. In
+particular, nested traces should be impossible to construct rather than merely
+rejected later by validation. Runtime consumers should ask semantic questions
+through helper methods such as `is_trace`, `is_complex`, `is_numeric`, and
+`is_chart_scalar`, instead of pattern-matching every physical primitive
+everywhere.
 
 ### Column Metadata And Chart Hints
 

--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -107,7 +107,7 @@ once writing starts.
 Implication:
 
 - payload columns are fixed once the dataset starts writing
-- `__ds_point_id` is always materialized by the writer
+- `__ds_record_id` is always materialized by the writer
 - durable logical indices live in an index sidecar when they cannot be derived
   from append order
 - optional future system payload columns should be declared explicitly rather
@@ -131,17 +131,17 @@ __ds_
 
 Examples:
 
-- `__ds_point_id`
-- `__ds_time_ns`
+- `__ds_record_id`
+- `__ds_recorded_at`
 
 Collision with user columns should be a hard creation-time error.
 
-### 4. `__ds_point_id` Is Mandatory For New Semantic Datasets
+### 4. `__ds_record_id` Is Mandatory For New Semantic Datasets
 
 New-format datasets should always materialize:
 
 ```text
-__ds_point_id: uint64
+__ds_record_id: uint64
 ```
 
 Semantics:
@@ -150,6 +150,10 @@ Semantics:
 - stable across restarts, export, and import
 - defines append order
 - is the tie-breaker for duplicate logical positions
+
+`__ds_recorded_at` is optional in v1. When present, it should use Fricon's
+timestamp business dtype with microsecond precision, mapped internally to the
+appropriate Arrow timestamp representation.
 
 ### 5. Manifest Is Canonical For Dataset Meaning
 
@@ -206,12 +210,12 @@ durable facts needed by all datasets:
 {
     "manifest_version": 1,
     "columns": {
-        "__ds_point_id": {
+        "__ds_record_id": {
             "dtype": {
                 "kind": "uint64"
             },
             "system": {
-                "kind": "point_id"
+                "kind": "record_id"
             }
         },
         "x": {
@@ -227,12 +231,12 @@ durable facts needed by all datasets:
     },
     "realization": {
         "append_only": true,
-        "point_id_column": "__ds_point_id",
+        "record_id_column": "__ds_record_id",
         "index_realization": {
             "kind": "none"
         },
         "duplicate_resolution_default": {
-            "kind": "latest_by_point_id"
+            "kind": "latest_by_record_id"
         }
     },
     "compatibility": {
@@ -247,6 +251,11 @@ explicit `logical_indices=`.
 Notes:
 
 - `columns` mirrors the frozen payload schema plus Fricon-owned system fields.
+  Dtypes are Fricon dataset dtypes. Primitive scalar variants should use the
+  same concrete names as Arrow where there is a direct one-to-one mapping, such
+  as `float64`, `int64`, and `uint64`. Avoid arbitrary bit-width fields in the
+  durable JSON. Fricon-owned business dtypes such as `trace[float]` and
+  `timestamp_us` can extend that vocabulary when they carry semantic meaning.
 - `scan_plan` is absent until the user passes `scan=` or the system later
   materializes inferred scan metadata.
 - `index_realization.kind = "none"` means no durable logical index space has
@@ -278,17 +287,17 @@ This proposal should preserve Fricon's existing data-type distinctions:
 - complex scalar columns
 - trace columns
 
-V1 may extend or refine the datatype vocabulary when a distinction has direct
-storage or rendering consequences, for example:
+V1 may extend or refine the Fricon datatype vocabulary when a distinction has
+direct storage or rendering consequences, for example:
 
 - timestamp-like scalar columns, if user-provided timestamps need first-class
   rendering or formatting
 - categorical scalar columns, if categorical handling differs from plain string
   or numeric values
 
-System timestamps should use an explicit Fricon-owned system field such as
-`__ds_time_ns` when needed. A normal user timestamp column should just be a
-typed payload column.
+System timestamps should use `__ds_recorded_at` with the Fricon `timestamp_us`
+business dtype when needed. A normal user timestamp column should just be a
+typed payload column. The manifest should not expose Arrow timestamp internals.
 
 ### Column Metadata And Chart Hints
 
@@ -355,8 +364,8 @@ usable for chart axes with column metadata such as `chart_axis=True`.
 
 Logical indices should have three realization modes:
 
-- `implicit`: derive indices from `__ds_point_id`, scan shape, and traversal
-- `sidecar`: store append-only index chunks mapping `__ds_point_id` to logical
+- `implicit`: derive indices from `__ds_record_id`, scan shape, and traversal
+- `sidecar`: store append-only index chunks mapping `__ds_record_id` to logical
   index values
 - `embedded`: reserve for rare future cases where indices are part of the main
   payload schema
@@ -377,7 +386,7 @@ resumes, adaptive scans, or ragged groups, the writer can persist a sidecar
 index table. The sidecar schema should be compact:
 
 ```text
-__ds_point_id: uint64
+__ds_record_id: uint64
 <axis_id>: int64
 ...
 ```
@@ -394,7 +403,7 @@ mutable summaries that are easy to let drift.
 Recommended v1 fields:
 
 - `append_only: true`
-- `point_id_column`
+- `record_id_column`
 - `index_realization`
 - `duplicate_resolution_default`
 
@@ -410,7 +419,7 @@ Recommended v1 behavior:
 
 - live refresh grouping may use in-memory write-session state
 - chart projections after reopen should depend on persisted facts:
-  `__ds_point_id`, manifest scan axes, and optional sidecar logical indices
+  `__ds_record_id`, manifest scan axes, and optional sidecar logical indices
 - adjacency-based grouping remains valid only for contiguous legacy scans
 - non-contiguous scans that must be reproducible after reopen should persist
   logical indices in the sidecar, not live-only frame markers
@@ -602,7 +611,7 @@ For bare writes:
 Each row writes:
 
 - user fields
-- `__ds_point_id`, materialized automatically
+- `__ds_record_id`, materialized automatically
 - optional logical index entries through a sidecar when append-order inference
   is insufficient
 
@@ -666,11 +675,11 @@ Duplicate logical positions are allowed and expected.
 
 Recommended v1 rule:
 
-- default duplicate policy: `latest_by_point_id`
+- default duplicate policy: `latest_by_record_id`
 
 Do not add status-aware duplicate policies in v1. Dataset payloads are
 append-only facts; when the same logical scan point is written more than once,
-the default projection should use the later `__ds_point_id`. If a future
+the default projection should use the later `__ds_record_id`. If a future
 workflow needs invalidation or execution-quality state, it should be designed
 with the run or measurement layer rather than added as an under-specified
 dataset column.
@@ -720,7 +729,7 @@ for example restarts with different minimizer lengths, it should persist a
 sidecar logical index table:
 
 ```text
-__ds_point_id | restart | step
+__ds_record_id | restart | step
 0             | 0       | 0
 1             | 0       | 1
 2             | 0       | 2
@@ -737,7 +746,7 @@ The clean v1 should include:
 
 - chunked append-only Arrow payloads
 - `dataset_manifest.json`
-- `__ds_point_id`
+- `__ds_record_id`
 - a minimal manifest for bare writes with column metadata, realization, and
   compatibility settings
 - optional typed `columns=` creation metadata
@@ -817,10 +826,10 @@ Desired behavior:
 Recommended internal behavior:
 
 1. The first row determines the user column set and data types.
-2. Fricon materializes `__ds_point_id` automatically.
+2. Fricon materializes `__ds_record_id` automatically.
 3. Fricon writes a minimal manifest with:
     - observed payload column metadata
-    - `__ds_point_id` as the point-id system field
+    - `__ds_record_id` as the record-id system field
     - no scan plan
     - no durable logical index realization
     - compatibility mode enabled
@@ -1051,7 +1060,7 @@ The architecture is considered successful when:
   index columns in the main payload
 - shuffled scans with sidecar logical indices render to the correct grid cells
 - retries and resumes preserve all fact rows while default projections use the
-  latest row by `__ds_point_id`
+  latest row by `__ds_record_id`
 - live views for active writes can use in-memory grouping without requiring
   durable `sweep_id` or `frame_id` payload columns
 - minimizer-style unknown-length index axes can be sliced by index coordinate

--- a/dev-docs/dataset-semantic-implementation-plan.md
+++ b/dev-docs/dataset-semantic-implementation-plan.md
@@ -13,6 +13,8 @@ sidecar, API, and UI behavior.
 
 - Start with the smallest durable manifest that every new dataset can own.
 - Keep payload storage append-only and continue using chunked Arrow IPC files.
+- Store plain Arrow physical schemas. Do not write Fricon Arrow extension types
+  for new semantic datasets; the manifest owns Fricon-specific meaning.
 - Keep Arrow schema in the create stream payload; use create metadata only for
   catalog metadata and optional semantic creation metadata.
 - Treat manifest JSON as a Rust serde-maintained format, not a user-authored
@@ -33,13 +35,23 @@ The initial manifest implementation should include:
 - Optional `scan_plan`, `live_defaults`, and `view_defaults` fields with serde
   defaults and `skip_serializing_if`.
 - Serde-friendly tagged enums for durable values:
-    - Fricon dataset datatype, for example `{ "kind": "float64" }` for a
-      primitive scalar and `{ "kind": "timestamp_us" }` for a business dtype
+    - Fricon dataset datatype. Examples: `{ "kind": "float64" }`,
+      `{ "kind": "complex128" }`, `{ "kind": "timestamp_us" }`, and a trace
+      value with `kind = "trace"`, `layout = "variable_step"`,
+      `axis = { "kind": "float64" }`, and `value = { "kind": "float64" }`.
     - system column kind, for example `{ "kind": "record_id" }`
     - index realization, starting with `{ "kind": "none" }`
     - duplicate policy, starting with `{ "kind": "latest_by_record_id" }`
 - A `dataset_manifest.json` layout helper colocated with storage layout naming.
 - Atomic manifest writes through a temporary file in the dataset directory.
+- A constrained dtype model that replaces the current broad
+  `DatasetDataType::Scalar(ScalarKind::Numeric)` style for semantic datasets
+  with Arrow-aligned primitive variants plus structured business variants such
+  as `Complex128` and `Trace { layout, axis, value }`.
+- Dedicated trace axis and trace value dtype enums. Trace axes should support
+  numeric dtypes beyond `float64` over time, while trace values should be
+  limited to scalar value dtypes such as numeric primitives and `Complex128`.
+  Nested traces should not be representable in the Rust dtype model.
 
 Validation must check:
 
@@ -47,12 +59,22 @@ Validation must check:
 - `columns` contains the configured `record_id_column`.
 - `__ds_record_id` is a `uint64` system `record_id` column in minimal
   manifests.
+- each manifest dtype is compatible with the actual plain Arrow physical field.
+- trace dtype invariants are enforced both by Rust types and validation:
+  `axis` is numeric, `value` is a scalar trace value, and nested traces are
+  rejected.
 - user-visible columns do not use the reserved `__ds_` prefix.
 - `duplicate_resolution_default` is `latest_by_record_id` in v1.
 - `index_realization.kind = "none"` does not claim sidecar state.
 
 Do not use `deny_unknown_fields` in the durable manifest structs. Rejecting
 future manifests should be an explicit version/validation decision.
+
+Because the project has not reached production use, remove `fricon.complex` and
+`fricon.trace` Arrow extension metadata as part of the semantic storage cleanup
+instead of preserving it as a long-term compatibility contract. If old local
+fixtures need to keep opening during the transition, infer their semantics from
+plain Arrow field shapes.
 
 ## Phase 2: Ingest And Storage Integration
 
@@ -72,6 +94,11 @@ Implementation details:
   begin.
 - Assign `__ds_record_id` monotonically from zero in append order.
 - Include `__ds_record_id` in read schemas for semantic datasets.
+- Write complex and trace payloads with plain Arrow physical layouts:
+  `struct<real: float64, imag: float64>` for `complex128`, `list<T>` for simple
+  traces, `struct<x0: axis, step: axis, y: list<value>>` for fixed-step traces,
+  and `struct<x: list<axis>, y: list<value>>` for variable-step traces. Do not
+  attach Fricon Arrow extension metadata.
 - Keep `__ds_recorded_at` optional. If added later, represent it as Fricon's
   `timestamp_us` business dtype and map that internally to Arrow timestamp
   storage.
@@ -101,6 +128,10 @@ The resolved model should expose:
 - data columns with dtype, label, unit, hidden state, and chart-axis candidate
   metadata.
 - system columns such as `__ds_record_id`.
+- physical Arrow dtype and semantic dataset dtype separately enough that
+  consumers can distinguish chartable numeric scalars, complex values, traces,
+  timestamps, and non-chartable payloads without inspecting Arrow extension
+  metadata.
 - logical index realization: `none`, `implicit`, or later `sidecar`.
 - duplicate resolution policy.
 - compatibility-derived index columns when no durable scan/index metadata
@@ -215,6 +246,9 @@ Rust:
   unsupported version, and invalid realization combinations.
 - ingest tests proving bare writes create `dataset_manifest.json`, append
   `__ds_record_id`, and reject user `__ds_` columns.
+- schema tests proving new complex and trace fields are written as plain Arrow
+  physical layouts without `fricon.complex` or `fricon.trace` extension
+  metadata.
 - reader tests for manifest loading, compatibility fallback, resolved
   interpretation, duplicate policy, implicit indices, sidecar indices, and
   ragged grids.
@@ -250,8 +284,10 @@ Quality gates:
 
 Preferred PR sequence:
 
-1. Manifest serde model, IO helpers, validation, and tests.
-2. Ingest integration for minimal manifests and `__ds_record_id`.
+1. Manifest serde model, constrained dtype model, IO helpers, validation, and
+   tests.
+2. Plain Arrow storage cleanup, ingest integration for minimal manifests, and
+   `__ds_record_id`.
 3. Reader interpretation layer and compatibility fallback.
 4. Portability updates for manifests.
 5. Optional `columns=` creation metadata.

--- a/dev-docs/dataset-semantic-implementation-plan.md
+++ b/dev-docs/dataset-semantic-implementation-plan.md
@@ -1,0 +1,261 @@
+# Dataset Semantics Implementation Plan
+
+## Status
+
+Proposed.
+
+This plan implements the direction in
+`dev-docs/dataset-semantic-architecture-proposal.md`. The goal is to land the
+minimal durable architecture first, then incrementally add richer scan,
+sidecar, API, and UI behavior.
+
+## Implementation Principles
+
+- Start with the smallest durable manifest that every new dataset can own.
+- Keep payload storage append-only and continue using chunked Arrow IPC files.
+- Keep Arrow schema in the create stream payload; use create metadata only for
+  catalog metadata and optional semantic creation metadata.
+- Treat manifest JSON as a Rust serde-maintained format, not a user-authored
+  config file.
+- Keep validation separate from serde deserialization.
+- Keep compatibility inference available while consumers migrate off
+  `DatasetReader::index_columns()`.
+
+## Phase 1: Manifest Foundation
+
+Add a new `crates/fricon/src/dataset/semantics/` slice that owns manifest
+types, file IO, validation, and minimal-manifest construction.
+
+The initial manifest implementation should include:
+
+- `DatasetManifest` with required `manifest_version`, `columns`,
+  `realization`, and `compatibility` fields.
+- Optional `scan_plan`, `live_defaults`, and `view_defaults` fields with serde
+  defaults and `skip_serializing_if`.
+- Serde-friendly tagged enums for durable values:
+    - dataset datatype, for example `{ "kind": "float64" }`
+    - system column kind, for example `{ "kind": "point_id" }`
+    - index realization, starting with `{ "kind": "none" }`
+    - duplicate policy, starting with `{ "kind": "latest_by_point_id" }`
+- A `dataset_manifest.json` layout helper colocated with storage layout naming.
+- Atomic manifest writes through a temporary file in the dataset directory.
+
+Validation must check:
+
+- `manifest_version` is supported.
+- `columns` contains the configured `point_id_column`.
+- `__ds_point_id` is a `uint64` system `point_id` column in minimal manifests.
+- user-visible columns do not use the reserved `__ds_` prefix.
+- `duplicate_resolution_default` is `latest_by_point_id` in v1.
+- `index_realization.kind = "none"` does not claim sidecar state.
+
+Do not use `deny_unknown_fields` in the durable manifest structs. Rejecting
+future manifests should be an explicit version/validation decision.
+
+## Phase 2: Ingest And Storage Integration
+
+Make every new dataset write a manifest and materialize `__ds_point_id`.
+
+Bare write behavior:
+
+1. Python or Rust client creates a dataset as it does today.
+2. First payload row still freezes the user payload schema in minimal mode.
+3. Ingest augments the stored Arrow schema and every row with `__ds_point_id`.
+4. Ingest writes `dataset_manifest.json` before finalizing the first chunk.
+5. Finalized datasets always have both payload chunks and a manifest.
+
+Implementation details:
+
+- Reject user columns whose names start with `__ds_` before storage writes
+  begin.
+- Assign `__ds_point_id` monotonically from zero in append order.
+- Include `__ds_point_id` in read schemas for semantic datasets.
+- Preserve existing abort behavior: rows successfully written before abort stay
+  on disk and the manifest remains valid for those rows.
+- Keep sidecar logical-index files out of this phase.
+
+Portability must be updated in this phase or the same change series:
+
+- export archives include `dataset_manifest.json`.
+- import staging preserves `dataset_manifest.json`.
+- import preview remains based on SQLite metadata, not manifest details.
+
+Decide whether `WORKSPACE_VERSION` must bump before merge. If mandatory
+manifests make old workspaces incompatible with new read paths, bump the
+workspace version and document the migration behavior. If all old datasets still
+read through compatibility inference, do not bump solely for writing new
+manifests.
+
+## Phase 3: Resolved Interpretation
+
+Add `crates/fricon/src/dataset/interpret/` to resolve dataset facts into a
+stable consumer model.
+
+The resolved model should expose:
+
+- data columns with dtype, label, unit, hidden state, and chart-axis candidate
+  metadata.
+- system columns such as `__ds_point_id`.
+- logical index realization: `none`, `implicit`, or later `sidecar`.
+- duplicate resolution policy.
+- compatibility-derived index columns when no durable scan/index metadata
+  exists.
+
+Reader behavior:
+
+- Add reader entry points for raw manifest and resolved interpretation.
+- Keep `DatasetReader::index_columns()` temporarily as a compatibility adapter
+  backed by resolved interpretation where possible.
+- For old datasets with no manifest, synthesize an in-memory minimal
+  interpretation from schema plus legacy inference.
+- Chart/grid code must use interpretation-layer duplicate handling rather than
+  reimplementing duplicate selection.
+
+Acceptance for this phase:
+
+- existing datasets without manifests still open.
+- new minimal-manifest datasets open without first-two-row inference being the
+  canonical path.
+- existing chart behavior remains equivalent for current fixture datasets.
+
+## Phase 4: Scan Plans And Logical Index Sidecars
+
+Add explicit scan support after minimal manifests and resolved interpretation
+are stable.
+
+Scan plan support:
+
+- Add optional `scan_plan` manifest structs for axes, traversal, partial scans,
+  and index realization.
+- Support unknown-length integer axes for minimizer-style workflows.
+- Support static axis coordinate lists in the manifest.
+- Do not require one-to-one mapping between scan axes and payload columns.
+- Do not add a separate durable derived-coordinate model; materialized payload
+  columns can be marked as chart-axis candidates.
+
+Sidecar support:
+
+- Add append-only `index_chunk_*.arrow` files only when explicit logical
+  indices are provided.
+- Sidecar schema is `__ds_point_id: uint64` plus one `int64` column per logical
+  axis.
+- Sidecar chunks follow payload chunk naming and atomic write discipline.
+- `index_realization.kind = "sidecar"` records the sidecar naming pattern and
+  logical axis order.
+
+Reader/query behavior:
+
+- `reader.indexes()` resolves implicit indices from append order and scan
+  traversal, or reads sidecar indices when present.
+- `reader.select(index={...})` filters by logical index coordinates.
+- ragged grids are represented as observed sparse index pairs, not forced into
+  rectangular planned shapes.
+
+## Phase 5: Public API And Transport
+
+Expose progressive Python and Rust client APIs once the backend can persist and
+read the corresponding semantics.
+
+Python API:
+
+- Extend `DatasetManager.create()` with optional keyword-only `columns=None`
+  and `scan=None`.
+- Keep `write(**kwargs)` unchanged.
+- Extend `write_dict(values, *, logical_indices=None)` for framework-owned
+  explicit logical indices.
+- Add typed helper stubs for `Column`, `IndexAxis`, `ColumnSpec`, and
+  `ScanAxisSpec` in `crates/fricon-py/python/fricon/_core.pyi`.
+- Runtime may accept plain mappings, but documented examples should prefer
+  typed helpers where they improve completion.
+
+Transport:
+
+- Keep Arrow schema in stream payload bytes.
+- Extend `CreateMetadata` only with optional semantic creation metadata needed
+  by `columns=` and `scan=`.
+- Bump `IPC_PROTOCOL_VERSION` in the same change that changes protobuf
+  request/response contracts.
+- Regenerate affected protobuf bindings and TypeScript bindings as part of that
+  change.
+
+## Phase 6: UI, Charts, And Live Views
+
+Move UI and chart code from inferred `isIndex` toward resolved interpretation.
+
+Dataset detail contract:
+
+- Add interpretation fields such as `isLogicalIndex`, `isChartAxisCandidate`,
+  `label`, `unit`, and resolved scan axes.
+- Keep `isIndex` temporarily as a compatibility projection.
+- Update generated frontend bindings after the Tauri DTO changes.
+
+Chart behavior:
+
+- Chart selection defaults should prefer resolved scan/index metadata.
+- Heatmap transforms should consume resolved logical indices and duplicate
+  policy.
+- Ragged heatmaps should render from observed sparse index pairs.
+- Live views may use active write-session grouping for refresh timing without
+  persisting `sweep_id` or `frame_id`.
+
+Once chart paths no longer depend on `isIndex`, remove direct use of
+`DatasetReader::index_columns()` from UI/chart code.
+
+## Testing Plan
+
+Rust:
+
+- manifest serde round trips for minimal manifests and optional sections.
+- manifest validation failures for missing point id, reserved user prefixes,
+  unsupported version, and invalid realization combinations.
+- ingest tests proving bare writes create `dataset_manifest.json`, append
+  `__ds_point_id`, and reject user `__ds_` columns.
+- reader tests for manifest loading, compatibility fallback, resolved
+  interpretation, duplicate policy, implicit indices, sidecar indices, and
+  ragged grids.
+- portability tests proving manifests and sidecar chunks round trip through
+  export/import.
+
+Python:
+
+- existing `write(**kwargs)` behavior still works.
+- optional `columns=` can declare dtype/unit/label/chart-axis hints.
+- optional `scan=` can declare static axes and `IndexAxis`.
+- `write_dict(..., logical_indices=...)` persists sidecar-backed indices when
+  sidecar support lands.
+
+Frontend/UI:
+
+- API normalization tests for new dataset detail fields.
+- chart model tests proving defaults come from resolved interpretation rather
+  than `isIndex`.
+- browser tests for opening minimal-manifest datasets and explicit 2D scan
+  datasets.
+
+Quality gates:
+
+- Rust-focused phases: `cargo nextest run --workspace` or a targeted nextest
+  subset while iterating.
+- Python API phases: `uv run maturin develop` before `uv run pytest` when
+  bindings change.
+- Frontend phases: `pnpm run check`, plus targeted `pnpm run test:unit` or
+  `pnpm run test:browser` for chart/UI changes.
+
+## Implementation Order And Cut Points
+
+Preferred PR sequence:
+
+1. Manifest serde model, IO helpers, validation, and tests.
+2. Ingest integration for minimal manifests and `__ds_point_id`.
+3. Reader interpretation layer and compatibility fallback.
+4. Portability updates for manifests.
+5. Optional `columns=` creation metadata.
+6. Optional `scan=` and implicit index realization.
+7. Sidecar logical index storage and `write_dict(..., logical_indices=...)`.
+8. UI/detail DTO expansion and frontend binding updates.
+9. Chart transform migration to resolved interpretation.
+10. Cleanup of legacy `isIndex` as the canonical chart contract.
+
+Each cut point should preserve current simple dataset creation and reading.
+Avoid landing UI-breaking DTO changes before generated bindings and frontend
+normalization are updated in the same PR.

--- a/dev-docs/dataset-semantic-implementation-plan.md
+++ b/dev-docs/dataset-semantic-implementation-plan.md
@@ -33,20 +33,22 @@ The initial manifest implementation should include:
 - Optional `scan_plan`, `live_defaults`, and `view_defaults` fields with serde
   defaults and `skip_serializing_if`.
 - Serde-friendly tagged enums for durable values:
-    - dataset datatype, for example `{ "kind": "float64" }`
-    - system column kind, for example `{ "kind": "point_id" }`
+    - Fricon dataset datatype, for example `{ "kind": "float64" }` for a
+      primitive scalar and `{ "kind": "timestamp_us" }` for a business dtype
+    - system column kind, for example `{ "kind": "record_id" }`
     - index realization, starting with `{ "kind": "none" }`
-    - duplicate policy, starting with `{ "kind": "latest_by_point_id" }`
+    - duplicate policy, starting with `{ "kind": "latest_by_record_id" }`
 - A `dataset_manifest.json` layout helper colocated with storage layout naming.
 - Atomic manifest writes through a temporary file in the dataset directory.
 
 Validation must check:
 
 - `manifest_version` is supported.
-- `columns` contains the configured `point_id_column`.
-- `__ds_point_id` is a `uint64` system `point_id` column in minimal manifests.
+- `columns` contains the configured `record_id_column`.
+- `__ds_record_id` is a `uint64` system `record_id` column in minimal
+  manifests.
 - user-visible columns do not use the reserved `__ds_` prefix.
-- `duplicate_resolution_default` is `latest_by_point_id` in v1.
+- `duplicate_resolution_default` is `latest_by_record_id` in v1.
 - `index_realization.kind = "none"` does not claim sidecar state.
 
 Do not use `deny_unknown_fields` in the durable manifest structs. Rejecting
@@ -54,13 +56,13 @@ future manifests should be an explicit version/validation decision.
 
 ## Phase 2: Ingest And Storage Integration
 
-Make every new dataset write a manifest and materialize `__ds_point_id`.
+Make every new dataset write a manifest and materialize `__ds_record_id`.
 
 Bare write behavior:
 
 1. Python or Rust client creates a dataset as it does today.
 2. First payload row still freezes the user payload schema in minimal mode.
-3. Ingest augments the stored Arrow schema and every row with `__ds_point_id`.
+3. Ingest augments the stored Arrow schema and every row with `__ds_record_id`.
 4. Ingest writes `dataset_manifest.json` before finalizing the first chunk.
 5. Finalized datasets always have both payload chunks and a manifest.
 
@@ -68,8 +70,11 @@ Implementation details:
 
 - Reject user columns whose names start with `__ds_` before storage writes
   begin.
-- Assign `__ds_point_id` monotonically from zero in append order.
-- Include `__ds_point_id` in read schemas for semantic datasets.
+- Assign `__ds_record_id` monotonically from zero in append order.
+- Include `__ds_record_id` in read schemas for semantic datasets.
+- Keep `__ds_recorded_at` optional. If added later, represent it as Fricon's
+  `timestamp_us` business dtype and map that internally to Arrow timestamp
+  storage.
 - Preserve existing abort behavior: rows successfully written before abort stay
   on disk and the manifest remains valid for those rows.
 - Keep sidecar logical-index files out of this phase.
@@ -95,7 +100,7 @@ The resolved model should expose:
 
 - data columns with dtype, label, unit, hidden state, and chart-axis candidate
   metadata.
-- system columns such as `__ds_point_id`.
+- system columns such as `__ds_record_id`.
 - logical index realization: `none`, `implicit`, or later `sidecar`.
 - duplicate resolution policy.
 - compatibility-derived index columns when no durable scan/index metadata
@@ -137,8 +142,8 @@ Sidecar support:
 
 - Add append-only `index_chunk_*.arrow` files only when explicit logical
   indices are provided.
-- Sidecar schema is `__ds_point_id: uint64` plus one `int64` column per logical
-  axis.
+- Sidecar schema is `__ds_record_id: uint64` plus one `int64` column per
+  logical axis.
 - Sidecar chunks follow payload chunk naming and atomic write discipline.
 - `index_realization.kind = "sidecar"` records the sidecar naming pattern and
   logical axis order.
@@ -206,10 +211,10 @@ Once chart paths no longer depend on `isIndex`, remove direct use of
 Rust:
 
 - manifest serde round trips for minimal manifests and optional sections.
-- manifest validation failures for missing point id, reserved user prefixes,
+- manifest validation failures for missing record id, reserved user prefixes,
   unsupported version, and invalid realization combinations.
 - ingest tests proving bare writes create `dataset_manifest.json`, append
-  `__ds_point_id`, and reject user `__ds_` columns.
+  `__ds_record_id`, and reject user `__ds_` columns.
 - reader tests for manifest loading, compatibility fallback, resolved
   interpretation, duplicate policy, implicit indices, sidecar indices, and
   ragged grids.
@@ -246,7 +251,7 @@ Quality gates:
 Preferred PR sequence:
 
 1. Manifest serde model, IO helpers, validation, and tests.
-2. Ingest integration for minimal manifests and `__ds_point_id`.
+2. Ingest integration for minimal manifests and `__ds_record_id`.
 3. Reader interpretation layer and compatibility fallback.
 4. Portability updates for manifests.
 5. Optional `columns=` creation metadata.


### PR DESCRIPTION
## Summary
- Add a proposal describing the dataset semantic architecture direction
- Add an implementation plan to break the work into concrete steps
- Focus the docs on a solo-maintainer workflow with clear sequencing and low coordination overhead

## Testing
- Not run (not requested)