### PR TITLE
chore: remove automatic worktree bootstrap rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,8 @@
 
 ## Repo-Wide Rules
 
-- On a fresh clone or `git worktree`, run `python3 scripts/bootstrap-checkout.py`
-  before edits or checks. Use `python3 scripts/setup-dev.py` only when you need
-  the dev workspace created through `fricon init`.
+- Use `python3 scripts/setup-dev.py` only when you need the dev workspace
+  created through `fricon init`.
 - Keep setup lazy: run `uv sync`, `uv run maturin develop`, `pnpm install`, and
   broader builds only when the task actually needs them.
 - Users interact with this repo through the Python API, CLI, and desktop UI. Internal Rust APIs between crates have no stability guarantees and may be aggressively refactored or broken when it improves the architecture.


### PR DESCRIPTION
## Summary
- Remove the repo-wide instruction that forces `bootstrap-checkout.py` on fresh clones or worktrees
- Keep the lazy `setup-dev.py` guidance for cases where the dev workspace is actually needed

## Testing
- Not run (not requested)