### PR TITLE
docs: reorganize public and developer documentation

### DIFF
--- a/.agents/skills/diesel-migration/SKILL.md
+++ b/.agents/skills/diesel-migration/SKILL.md
@@ -9,18 +9,27 @@ description: Use Diesel CLI to create, update, and validate SQLite schema migrat
 
 Use this skill for Fricon database schema work that should be driven by Diesel CLI rather than manual edits. Keep migrations reversible, treat `schema.rs` as generated output, and update only the persistence-side Rust code that owns the affected tables.
 
+## Path Resolution
+
+- Skill-local reference files use paths relative to this skill directory.
+- Repository files and commands use paths relative to the repository root
+  (`<project_root>`).
+
 ## Fricon Rules
 
 - Run Diesel CLI from `crates/fricon`.
 - Interpret repository paths relative to `<project_root>`.
-- Treat `src/database/schema.rs` as generated. Do not hand-edit it.
+- Treat `<project_root>/crates/fricon/src/database/schema.rs` as generated.
+  Do not hand-edit it.
 - Keep schema and Diesel model changes inside database/adapter code. Do not pull Diesel or schema modules into feature service code.
 - Migrations are embedded via `embed_migrations!()`, so checked-in SQL under `crates/fricon/migrations` is the source of truth shipped in the app.
 - Prefer adding a new migration for committed history. Only rewrite an in-progress migration when it is still local and safe to redo.
 
 ## Workflow
 
-1. Read `references/fricon-database.md` for the project-specific paths, commands, and verification checklist.
+1. Read `references/fricon-database.md` for project-specific paths and
+   commands, then apply the database schema section in
+   `<project_root>/dev-docs/maintenance-checklist.md`.
 2. Inspect the existing owning slice under `crates/fricon/src/database` before designing schema changes.
 3. Create a migration with Diesel CLI:
 
@@ -29,7 +38,8 @@ cd <project_root>/crates/fricon
 diesel migration generate <descriptive_name>
 ```
 
-4. Edit the generated `up.sql` and `down.sql`.
+4. Edit the generated migration files `up.sql` and `down.sql` inside the new
+   directory under `<project_root>/crates/fricon/migrations/`.
 5. Apply the migration with Diesel CLI so `schema.rs` regenerates from `diesel.toml`:
 
 ```bash
@@ -47,21 +57,10 @@ diesel migration redo
 7. Update the affected Diesel models, query code, and tests under the owning database slice.
 8. Run validation commands from the repo root.
 
-## Migration Design Checklist
-
-- Choose a descriptive migration name that states the schema intent.
-- Make `down.sql` a real rollback, not a placeholder.
-- For SQLite changes that are awkward to reverse, prefer explicit table-rebuild/copy/drop/rename SQL over fragile shortcuts.
-- Preserve existing data when changing live tables unless the task explicitly permits destructive resets.
-- Add or update indexes and constraints in the same migration when they are part of the schema contract.
-- Review the generated `schema.rs` diff to confirm the SQL produced the expected Rust table definitions.
-
 ## Validation
 
-- Run at least `cargo check -p fricon`.
-- Run targeted Rust tests for the affected database slice when present.
-- If Python-visible behavior changed, rebuild bindings with `uv run maturin develop` before Python tests.
-- If the migration setup or local database is missing, initialize the repo dev database before debugging migration failures.
+Use the database schema checklist in
+`<project_root>/dev-docs/maintenance-checklist.md`.
 
 ## When To Be Careful
 

--- a/.agents/skills/diesel-migration/references/fricon-database.md
+++ b/.agents/skills/diesel-migration/references/fricon-database.md
@@ -11,7 +11,9 @@
 
 ## Expected CLI Context
 
-Interpret repository paths relative to `<project_root>`. Run Diesel CLI from `<project_root>/crates/fricon` so it picks up `diesel.toml` and writes `src/database/schema.rs`.
+Interpret repository paths relative to `<project_root>`. Run Diesel CLI from
+`<project_root>/crates/fricon` so it picks up crate-local `diesel.toml` and
+writes crate-local `src/database/schema.rs`.
 
 Typical flow:
 
@@ -44,17 +46,14 @@ cargo install diesel_cli --no-default-features --features sqlite
 ## Fricon-Specific Notes
 
 - `crates/fricon/src/database/core.rs` embeds migrations with `embed_migrations!()`. The SQL files are shipped with the app build.
-- `crates/fricon/diesel.toml` configures `print_schema.file = "src/database/schema.rs"`, so schema regeneration is part of the Diesel CLI flow.
+- `crates/fricon/diesel.toml` configures
+  `print_schema.file = "src/database/schema.rs"` relative to
+  `<project_root>/crates/fricon`, so schema regeneration is part of the Diesel
+  CLI flow.
 - The current persistence code lives under `crates/fricon/src/database`. Keep new columns and tables wired into that layer, not service/business modules.
 - Existing migrations are timestamped directories with `up.sql` and `down.sql`. Follow the same layout.
 
-## Verification Checklist
+## Verification
 
-After changing migrations:
-
-1. Inspect the migration SQL diff for reversibility and data safety.
-2. Inspect the generated `crates/fricon/src/database/schema.rs` diff.
-3. Update affected Diesel structs, inserts/changesets, and query code.
-4. Run `cargo check -p fricon`.
-5. Run targeted tests for the touched database slice. Prefer `cargo nextest` when practical.
-6. Rebuild Python bindings before Python tests if the schema change affects exported behavior.
+Use the database schema checklist in
+`<project_root>/dev-docs/maintenance-checklist.md`.

--- a/.agents/skills/pr-preflight-checklist/SKILL.md
+++ b/.agents/skills/pr-preflight-checklist/SKILL.md
@@ -9,13 +9,19 @@ description: Run a pre-pull-request quality gate for the fricon monorepo (Rust, 
 
 Reduce PR back-and-forth by running the smallest complete check set before pushing.
 
+## Path Resolution
+
+Unless explicitly stated otherwise, paths and commands in this skill are
+relative to the repository root (`<project_root>`), not to this skill directory.
+
 ## Workflow
 
 1. Identify changed scope using `git diff --name-only`.
 2. Choose profile:
    - `quick` for normal local development loops (default)
    - `strict` once before opening/updating a PR
-3. Map changed files to checks using `references/checklist-matrix.md`.
+3. Map changed files to checks using the repository-root file
+   `<project_root>/dev-docs/pr-preflight-checklist.md`.
 4. Run selected checks in fail-fast order:
    - run format and static checks first
    - for frontend changes, prefer `pnpm run check` as the default combined gate
@@ -24,52 +30,31 @@ Reduce PR back-and-forth by running the smallest complete check set before pushi
    - for targeted frontend reruns, pass file filters to `test:unit` or `test:browser` instead of the batch `test` script
    - build/test next
    - strict-only checks last (dependency/license checks included)
-5. If the PR includes user-facing behavior changes, release-note-worthy fixes, or an intended version bump, add a Knope changeset file under `.changeset/`.
-   - AI agents should write the file directly instead of using the interactive `knope document-change` CLI.
-   - Human contributors may use `knope document-change` or write the file manually.
-6. If Rust IPC signatures changed, run:
-   - `pnpm --filter fricon-ui run gen:bindings`
-   - `git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts`
-7. If workspace structure or workspace metadata semantics changed, also:
-   - verify whether `WORKSPACE_VERSION` must change
-   - verify docs/rules that describe workspace structure and migration duties
-8. If Rust IPC/gRPC compatibility semantics changed, also:
-   - verify whether `IPC_PROTOCOL_VERSION` must change
-   - verify the explicit IPC protocol version/handshake logic changed with the protocol
-9. Re-run failed checks after fixes, then run the selected profile once end-to-end.
-10. Report results with explicit pass/fail status and any remaining risk.
+5. For release notes, generated bindings, workspace format changes, database
+   migrations, or IPC/gRPC compatibility changes, apply the relevant section in
+   the repository-root file `<project_root>/dev-docs/maintenance-checklist.md`.
+6. Re-run failed checks after fixes, then run the selected profile once end-to-end.
+7. Report results with explicit pass/fail status and any remaining risk.
 
 ## Repository Rules To Enforce
 
 - Prefer `pnpm` and `uv` for package management commands.
 - Run `uv run maturin develop` before `uv run pytest` for Python binding tests.
 - Treat `cargo clippy --all-targets --all-features -- -D warnings` as the required Rust lint gate for preflight, not a warnings-only advisory pass.
-- Never hand-edit `crates/fricon-ui/frontend/src/shared/lib/bindings.ts`; regenerate it.
+- Never hand-edit the repository-root generated file
+  `<project_root>/crates/fricon-ui/frontend/src/shared/lib/bindings.ts`;
+  regenerate it.
 - Treat `pnpm run check` as the default frontend gate and ensure frontend slice-boundary validation is covered by it or by `pnpm run depcruise:frontend` when commands are split.
 - Treat `pnpm run test` as a batch command only; choose `test:unit` or `test:browser` for targeted reruns.
-- AI agents should create Knope changeset files directly under `.changeset/` instead of using the interactive `knope document-change` command.
-- Do not place templates, README files, or other helper Markdown files inside `.changeset/`; Knope treats them as real changesets. `.changeset/.gitkeep` is acceptable.
-- Workspace structure changes are not complete until migration logic, the `WORKSPACE_VERSION` decision, and docs/rules are updated together.
-- IPC/gRPC contract changes are not complete until the explicit IPC protocol compatibility rule, the `IPC_PROTOCOL_VERSION` decision, and generated bindings/docs are updated together.
-
-## Knope Changeset Template
-
-When an AI agent needs to create a Knope changeset, write a Markdown file directly in `.changeset/` using this template:
-
-```md
----
-default: patch
----
-
-# Short user-facing title
-
-Describe the user-visible change in release-note language.
-```
-
-Guidance:
-
-- Use `major`, `minor`, and `patch` with standard semantic-versioning intent; Knope will handle `0.x` version behavior automatically.
-- Prefer concise, user-facing wording over implementation detail.
+- AI agents should create Knope changeset files directly under the
+  repository-root `.changeset/` directory instead of using the interactive
+  `knope document-change` command.
+- Do not place templates, README files, or other helper Markdown files inside
+  the repository-root `.changeset/` directory; Knope treats them as real
+  changesets. `.changeset/.gitkeep` is acceptable.
+- Workspace, IPC/gRPC, database, generated binding, and release-note
+  maintenance rules live in the repository-root file
+  `<project_root>/dev-docs/maintenance-checklist.md`.
 
 ## Optional Alternatives
 
@@ -89,4 +74,7 @@ Return a concise preflight summary with:
 
 ## Reference
 
-- `references/checklist-matrix.md`
+Repository-root files:
+
+- `<project_root>/dev-docs/pr-preflight-checklist.md`
+- `<project_root>/dev-docs/maintenance-checklist.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,10 @@
 - Frontend is under `crates/fricon-ui/frontend`.
 - `examples/` contains runnable examples.
 - `scripts/` contains development helpers.
-- `docs/` contains documentation sources.
+- `docs/` contains public user-facing documentation sources.
+- `dev-docs/` contains internal developer notes, implementation details,
+  architecture notes, and maintenance guidance that should not be published as
+  user-facing docs.
 
 ## Repo-Wide Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@
   created through `fricon init`.
 - Keep setup lazy: run `uv sync`, `uv run maturin develop`, `pnpm install`, and
   broader builds only when the task actually needs them.
+- Use `dev-docs/maintenance-checklist.md` as the canonical source for
+  coordinated maintenance checklists, and use
+  `dev-docs/pr-preflight-checklist.md` as the canonical pre-PR check matrix.
 - Users interact with this repo through the Python API, CLI, and desktop UI. Internal Rust APIs between crates have no stability guarantees and may be aggressively refactored or broken when it improves the architecture.
 - Use non-`mod.rs` layout for Rust modules (`foo.rs` plus optional `foo/*.rs` submodules).
 - Rust use nightly rustfmt: `cargo +nightly fmt`.
@@ -32,15 +35,8 @@
   passing file filters through the batch `test` script.
   Desktop smoke is CI-validated on Windows only; Tauri does not provide desktop
   WebDriver support on macOS.
-- When changing workspace on-disk structure or `.fricon_workspace.json`, update
-  `crates/fricon/src/workspace.rs` migration steps, decide whether
-  `WORKSPACE_VERSION` must change, and update developer-facing documentation
-  describing the format and maintenance duties.
-- When changing Rust IPC/gRPC request or response contracts under
-  `crates/fricon/proto` or `crates/fricon/src/transport`, update the explicit
-  IPC protocol compatibility logic, decide whether `IPC_PROTOCOL_VERSION` must
-  change, regenerate affected bindings, and document any new maintenance steps
-  or constraints.
+- For workspace format changes and Rust IPC/gRPC contract changes, follow the
+  relevant sections in `dev-docs/maintenance-checklist.md`.
 - Follow the existing vertical slice boundaries and add code within the owning domain/feature. Keep boundaries and data ownership clear, and avoid cross-feature or cross-layer shortcuts.
 - Keep internal structure lightweight: prefer straightforward local implementations, feature-local duplication, and explicit types over premature shared abstractions or generic extension points.
 - Add traits only for real boundaries or capabilities with multiple plausible implementations, not as a default pattern for mocking.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,11 +169,10 @@ Docs:
 - Run relevant linters and tests before opening a PR.
 - For frontend work, start with `pnpm run check`, then run narrower commands only if you need to investigate a specific failure.
 
-PR checklist (recommended):
-
-- Follow code style and pass linters
-- Include tests or a clear rationale if none
-- Update docs if behavior changes
+Before opening a PR, use the canonical preflight matrix in
+`dev-docs/pr-preflight-checklist.md`. For coordinated maintenance items such as
+workspace format, IPC/gRPC, database schema, generated bindings, or release-note
+changes, use `dev-docs/maintenance-checklist.md`.
 
 ## Release workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,8 @@ Docs:
 
 - Branch from `main`: feature/bugfix branches named clearly.
 - Use conventional commits: `type(scope): description` (feat, fix, docs, style, refactor, test, chore).
-- For release notes and version bumps, prefer `knope document-change` and commit the generated file under `.changeset/`.
+- For release notes and version bumps, follow
+  `dev-docs/release-and-versioning.md`.
 - Add tests for new features when possible.
 - Run relevant linters and tests before opening a PR.
 - For frontend work, start with `pnpm run check`, then run narrower commands only if you need to investigate a specific failure.
@@ -176,11 +177,9 @@ changes, use `dev-docs/maintenance-checklist.md`.
 
 ## Release workflow
 
-- Releases are managed by `knope`, not `release-plz`.
-- The repository ships one unified release version and one canonical Git tag: `v<version>`.
-- A push to `main` refreshes a rolling release preview PR from the `release` branch.
-- Merging that PR creates the GitHub release and tag; publishing remains PyPI-only.
-- Release notes and version bumps can come from either Knope change files or conventional commits. Use change files when you want explicit release notes or a release rule that should not rely on commit parsing.
+Releases are managed by Knope. See `dev-docs/release-and-versioning.md` for
+the canonical release model, changeset policy, version bump guidance, and
+compatibility decision rules.
 
 ## Reporting issues & getting help
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ ws = Workspace.connect(workspace_path)
 writer = ws.dataset_manager.create("my_dataset", description="My test dataset")
 
 # Write data - schema is inferred from the first row
-# Writes are micro-batched automatically every second or when 16 rows accumulate
-# MVP currently supports float and complex types only
+# Writes are buffered automatically
+# Current scalar writes support float, int-as-float, and complex values
 writer.write(id=1, value=42.0, measurement=3.14 + 2j)
 writer.write(id=2, value=84.0, measurement=1.618 - 1j)
 writer.close()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Data collection automation framework.
 
 [GitHub Pages](https://kahojyun.github.io/fricon/)
 
+For implementation guidance, maintainer checklists, and AI-agent starting
+points, see [dev-docs/README.md](dev-docs/README.md).
+
 ## Overview
 
 Fricon is a data collection automation framework designed for managing datasets in scientific and research workflows. It provides:

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,0 +1,69 @@
+# Developer Docs
+
+## Status
+
+Directory index for developer documentation.
+
+## Purpose
+
+`dev-docs/` contains maintainer-facing documentation for implementation,
+architecture, release, testing, and AI-assisted development. These files are
+not public user docs. Public user-facing docs live in `docs/`.
+
+## Reading Order
+
+Start here when orienting a new human or AI contributor:
+
+1. `project-intent.md`
+2. `maintenance-checklist.md`
+3. `pr-preflight-checklist.md`
+4. The topic-specific note for the area being changed
+
+## Canonical Guidance
+
+These files are active project policy. Prefer them over duplicated guidance in
+skills, prompts, or contributor notes.
+
+- `project-intent.md` - product direction, target users, non-goals, and AI
+  guardrails
+- `maintenance-checklist.md` - coordinated update checklist for cross-boundary
+  changes
+- `pr-preflight-checklist.md` - local and pre-PR validation matrix
+- `release-and-versioning.md` - release model, changeset policy, and version
+  bump guidance
+- `testing-strategy.md` - test runner split and test placement rules
+- `internal-doc-comments.md` - Rustdoc/comment style for maintainable internal
+  code
+
+## Current Implementation Notes
+
+These files describe the current implementation. Update them when the
+implementation changes.
+
+- `current-storage-notes.md` - current workspace and dataset storage details
+
+## Architecture Notes
+
+These files are advisory unless they explicitly point to a canonical checklist
+or policy.
+
+- `architecture-ai-notes.md` - architecture discussion and AI-assisted
+  maintainability guidance
+
+## Proposals And Plans
+
+These files describe proposed future direction. Do not treat them as current
+implementation facts unless the implementation has already landed.
+
+- `dataset-semantic-architecture-proposal.md`
+- `dataset-semantic-implementation-plan.md`
+
+## Maintenance Rules
+
+- Keep checklist-style canonical guidance in `dev-docs/` and link to it from
+  skills, `AGENTS.md`, and `CONTRIBUTING.md`.
+- Keep `docs/` focused on user workflows and stable user-facing concepts.
+- Keep internal storage, protocol, migration, architecture, and AI-agent
+  guidance in `dev-docs/`.
+- When a proposal becomes current behavior, update or split the proposal so
+  current facts live in a current implementation note.

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -19,6 +19,19 @@ Start here when orienting a new human or AI contributor:
 3. `pr-preflight-checklist.md`
 4. The topic-specific note for the area being changed
 
+For narrow tasks, prefer the task-specific starting points below over reading
+every canonical document.
+
+## Agent Starting Points By Change Type
+
+| Change type | Start here | Then read | Usually avoid |
+| --- | --- | --- | --- |
+| SQLite schema visible through Python | `database-schema-changes.md` | `maintenance-checklist.md`, `release-and-versioning.md`, Diesel skill | Dataset semantic proposal files unless semantics are changing |
+| Desktop UI action with Rust Tauri command | `desktop-ui-feature-playbook.md` | `architecture-guidelines.md`, `testing-strategy.md`, `release-and-versioning.md`, UI AGENTS files | React/shadcn skills unless touching those APIs |
+| Workspace format or metadata compatibility | `maintenance-checklist.md` | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md` | Architecture background unless boundary design is unclear |
+| Rust IPC/gRPC contract compatibility | `maintenance-checklist.md` | `pr-preflight-checklist.md`, `release-and-versioning.md` | Public docs unless behavior is user-visible |
+| Public dataset docs update | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only | Implementation plan details unless landed behavior is being documented |
+
 ## Canonical Guidance
 
 These files are active project policy. Prefer them over duplicated guidance in
@@ -33,6 +46,10 @@ skills, prompts, or contributor notes.
   bump guidance
 - `architecture-guidelines.md` - current implementation architecture rules and
   boundary guidance
+- `desktop-ui-feature-playbook.md` - low-context path for Rust Tauri plus
+  frontend feature work
+- `database-schema-changes.md` - low-context path for Diesel changes,
+  especially DB-to-Python changes
 - `testing-strategy.md` - test runner split and test placement rules
 - `internal-doc-comments.md` - Rustdoc/comment style for maintainable internal
   code

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -24,13 +24,13 @@ every canonical document.
 
 ## Agent Starting Points By Change Type
 
-| Change type | Start here | Then read | Usually avoid |
-| --- | --- | --- | --- |
-| SQLite schema visible through Python | `database-schema-changes.md` | `maintenance-checklist.md`, `release-and-versioning.md`, Diesel skill | Dataset semantic proposal files unless semantics are changing |
-| Desktop UI action with Rust Tauri command | `desktop-ui-feature-playbook.md` | `architecture-guidelines.md`, `testing-strategy.md`, `release-and-versioning.md`, UI AGENTS files | React/shadcn skills unless touching those APIs |
-| Workspace format or metadata compatibility | `maintenance-checklist.md` | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md` | Architecture background unless boundary design is unclear |
-| Rust IPC/gRPC contract compatibility | `maintenance-checklist.md` | `pr-preflight-checklist.md`, `release-and-versioning.md` | Public docs unless behavior is user-visible |
-| Public dataset docs update | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only | Implementation plan details unless landed behavior is being documented |
+| Change type                                | Start here                               | Then read                                                                                         | Usually avoid                                                          |
+| ------------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| SQLite schema visible through Python       | `database-schema-changes.md`             | `maintenance-checklist.md`, `release-and-versioning.md`, Diesel skill                             | Dataset semantic proposal files unless semantics are changing          |
+| Desktop UI action with Rust Tauri command  | `desktop-ui-feature-playbook.md`         | `architecture-guidelines.md`, `testing-strategy.md`, `release-and-versioning.md`, UI AGENTS files | React/shadcn skills unless touching those APIs                         |
+| Workspace format or metadata compatibility | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Architecture background unless boundary design is unclear              |
+| Rust IPC/gRPC contract compatibility       | `maintenance-checklist.md`               | `pr-preflight-checklist.md`, `release-and-versioning.md`                                          | Public docs unless behavior is user-visible                            |
+| Public dataset docs update                 | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only                                 | Implementation plan details unless landed behavior is being documented |
 
 ## Canonical Guidance
 

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -31,6 +31,8 @@ skills, prompts, or contributor notes.
 - `pr-preflight-checklist.md` - local and pre-PR validation matrix
 - `release-and-versioning.md` - release model, changeset policy, and version
   bump guidance
+- `architecture-guidelines.md` - current implementation architecture rules and
+  boundary guidance
 - `testing-strategy.md` - test runner split and test placement rules
 - `internal-doc-comments.md` - Rustdoc/comment style for maintainable internal
   code
@@ -44,8 +46,8 @@ implementation changes.
 
 ## Architecture Notes
 
-These files are advisory unless they explicitly point to a canonical checklist
-or policy.
+These files are advisory background unless they explicitly point to a canonical
+checklist, policy, or guideline.
 
 - `architecture-ai-notes.md` - architecture discussion and AI-assisted
   maintainability guidance

--- a/dev-docs/architecture-ai-notes.md
+++ b/dev-docs/architecture-ai-notes.md
@@ -2,12 +2,17 @@
 
 ## Status
 
-Advisory architecture note. Use canonical checklist and policy files for
+Advisory background discussion. Use `dev-docs/architecture-guidelines.md` for
+current architecture rules and `dev-docs/maintenance-checklist.md` for
 actionable maintenance requirements.
 
 ## Scope
 
 This note summarizes the architectural conclusions from a review and comparison of `fricon` and `crates.io`, with a focus on long-term maintainability in an AI-heavy development workflow.
+
+This file preserves rationale and historical context. Do not treat it as the
+short canonical rule set for new work; use `dev-docs/architecture-guidelines.md`
+first.
 
 ## High-Level Takeaways
 

--- a/dev-docs/architecture-ai-notes.md
+++ b/dev-docs/architecture-ai-notes.md
@@ -225,15 +225,5 @@ and they should be maintained separately.
   workspace is recognizable and that IPC is reachable. They should not take
   over the job of workspace migration.
 
-When changing workspace structure or workspace metadata semantics:
-
-- update the stepwise migration logic
-- decide whether `WORKSPACE_VERSION` must change
-- update developer-facing maintenance docs and repo rules together
-
-When changing IPC/gRPC request or response contracts:
-
-- update the explicit IPC protocol compatibility logic in the client and server
-- decide whether `IPC_PROTOCOL_VERSION` must change
-- update generated bindings and the maintainer-facing docs/rules that describe
-  the protocol change workflow
+For the actionable change checklists, use
+`dev-docs/maintenance-checklist.md`.

--- a/dev-docs/architecture-ai-notes.md
+++ b/dev-docs/architecture-ai-notes.md
@@ -1,5 +1,10 @@
 # Architecture Notes From AI/Repo Discussion
 
+## Status
+
+Advisory architecture note. Use canonical checklist and policy files for
+actionable maintenance requirements.
+
 ## Scope
 
 This note summarizes the architectural conclusions from a review and comparison of `fricon` and `crates.io`, with a focus on long-term maintainability in an AI-heavy development workflow.

--- a/dev-docs/architecture-guidelines.md
+++ b/dev-docs/architecture-guidelines.md
@@ -1,0 +1,162 @@
+# Architecture Guidelines
+
+## Status
+
+Canonical architecture guidance for current Fricon implementation work.
+
+## Purpose
+
+This note captures the current architecture rules agents and maintainers should
+apply while editing Fricon. Historical discussion and rationale live in
+`dev-docs/architecture-ai-notes.md`.
+
+## Product Shape
+
+Fricon is a local-first, single-user scientific experiment measurement
+management system. Users interact through the Python API, CLI, and desktop UI.
+Internal Rust APIs between crates are not stable user contracts and may be
+refactored when it improves architecture.
+
+Do not introduce multi-user, SaaS, account, role, or distributed-system
+architecture unless the product direction explicitly changes.
+
+## Feature Slices
+
+Prefer feature-local vertical slices.
+
+A feature may contain:
+
+- core/domain types
+- service or workflow orchestration
+- thin local adapters for persistence, transport, runtime, or filesystem edges
+
+Do not require every feature to have identical layers. Add boundaries where
+workflow complexity crosses real infrastructure edges; keep simple CRUD-heavy
+features lightweight.
+
+Preferred dependency direction inside a feature:
+
+```text
+composition/app -> services + adapters
+services -> core types + feature-defined ports
+adapters -> core types + infrastructure
+```
+
+## Infrastructure Boundaries
+
+Core and service code should not directly depend on:
+
+- Diesel schema modules
+- Diesel query APIs
+- transport request/response types
+- runtime-specific UI or Tauri types
+- filesystem layout details, except through owning storage adapters
+
+Adapter modules own those dependencies. The point of the boundary is local
+reasoning and cross-resource orchestration, not future database swapping.
+
+## Persistence
+
+Use repository or persistence-port abstractions when a workflow coordinates
+database state with files, sessions, runtime state, or events.
+
+Avoid generic repository wrappers that only mirror ORM CRUD operations. For
+simple database-heavy features, a thin feature-local adapter is usually enough.
+
+Keep Diesel-specific code concentrated in persistence/database modules.
+
+## App And Transport
+
+The `app` layer acts as the composition root:
+
+- create infrastructure objects
+- instantiate adapters and services
+- inject dependencies
+- expose stable handles to inbound adapters
+
+gRPC and IPC handlers are inbound adapters. They should parse transport input,
+validate transport-level shape, call services, and map errors to transport
+statuses. They should not directly query Diesel or own business orchestration.
+
+## Runtime Dependencies
+
+Tokio is acceptable in app-level orchestration, transport glue, background
+tasks, and runtime coordination.
+
+Avoid exposing Tokio synchronization types as the primary API of feature core
+modules unless stream or concurrency semantics are part of the business
+contract.
+
+## Events
+
+Keep these concepts separate:
+
+- feature events, such as dataset created or updated
+- app or shell commands, such as show main window
+- transport or UI event shapes, such as Tauri/frontend DTOs
+
+Feature code may publish fire-and-forget notifications through a small
+publisher trait when needed. App and adapter code should own logging, metrics,
+delivery failures, and transport-specific conversion.
+
+## Desktop UI Slices
+
+`fricon-ui` is organized as vertical feature slices across Rust and React.
+
+Rust dependency flow:
+
+```text
+desktop_runtime -> tauri_api -> features/<feature>/tauri -> features/<feature>/workflow -> fricon
+```
+
+Frontend dependency flow:
+
+```text
+app/routes -> features/<feature> -> feature-local api -> shared/lib/tauri.ts -> generated bindings
+```
+
+Rules:
+
+- Rust `src/tauri_api.rs` owns global Tauri/Specta binding export and command
+  or event aggregation.
+- Rust `src/features/<feature>/tauri.rs` files are Tauri adapters only. They
+  own commands, events, exported DTOs, and native dialogs.
+- Rust `src/features/<feature>/workflow.rs` files own feature orchestration and
+  should not depend on Tauri types.
+- Pure Rust data shaping helpers stay inside the owning feature slice.
+- Frontend features own their own `api/`, `ui/`, `model`, and `hooks` modules.
+- Files under `frontend/src/features/**` use relative imports only.
+- `frontend/src/app/**` and `frontend/src/routes/**` import features only
+  through public barrels such as `@/features/<feature>`.
+- `frontend/src/shared/lib/tauri.ts` stays generic; feature-specific
+  normalization and query/event wiring belong in each feature's `api/` folder.
+
+## Compatibility Boundaries
+
+Workspace compatibility and IPC compatibility are separate concerns.
+
+- Workspace compatibility is controlled by `.fricon_workspace.json`,
+  `WORKSPACE_VERSION`, and migration steps in `crates/fricon/src/workspace.rs`.
+- IPC compatibility is controlled by the protocol handshake exposed by the
+  `Version` RPC and `IPC_PROTOCOL_VERSION`.
+- UI probes should only verify that a workspace is recognizable and IPC is
+  reachable; they should not replace workspace migration.
+
+For actionable maintenance steps, use `dev-docs/maintenance-checklist.md`.
+
+## Anti-Decay Checks
+
+Healthy changes usually have these properties:
+
+- Most code changes stay within one feature slice.
+- Services read like business steps instead of persistence scripts.
+- Diesel-specific code stays in adapter/persistence modules.
+- Feature APIs use domain/application terms instead of infrastructure terms.
+
+Watch for these drift signals:
+
+- services importing Diesel or schema modules directly
+- feature boundaries becoming inconsistent across modules
+- shared helpers appearing before behavior is stable across multiple features
+- repository traits becoming generic wrappers with no domain meaning
+- events mixing feature semantics with UI shell control

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -63,13 +63,7 @@ a documented performance contract.
 
 ## Maintenance Notes
 
-When changing workspace on-disk structure or `.fricon_workspace.json`, update:
-
-- `crates/fricon/src/workspace.rs` migration steps
-- `WORKSPACE_VERSION`, if the change breaks old workspace assumptions
-- this note, if the current layout or compatibility behavior changes
-
-When changing dataset payload layout, update this note and decide whether the
-workspace compatibility version or migration path must change.
+For workspace format and dataset payload layout changes, use the canonical
+checklists in `dev-docs/maintenance-checklist.md`.
 
 [Arrow IPC]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -1,5 +1,10 @@
 # Current Workspace And Dataset Storage Notes
 
+## Status
+
+Current implementation note. Update this when workspace or dataset storage
+layout changes.
+
 ## Purpose
 
 This note captures current implementation details that should not be presented

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -12,6 +12,10 @@ as stable user-facing documentation. Public docs should describe workspaces and
 datasets through the CLI, Python API, and desktop UI rather than through the
 on-disk layout.
 
+Dataset semantics proposal documents describe future direction, not current
+storage facts. Use this file as the current source of truth until those
+proposals are implemented and this note is updated.
+
 ## Workspace Layout
 
 At the time of writing, a workspace contains:

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -55,6 +55,15 @@ The physical storage layout is an implementation detail. User-facing docs may
 mention Arrow-compatible tables, but should avoid promising exact file names,
 chunking behavior, or directory structure.
 
+## Dataset Metadata Ownership
+
+Current dataset catalog metadata lives in SQLite. This includes dataset name,
+description, favorite state, status, timestamps, and tags as represented by
+`DatasetRecord` / `DatasetMetadata`.
+
+Dataset payload facts live in Arrow chunk files. Future semantic manifest files
+described by the dataset semantic proposal docs are not current behavior.
+
 ## Write Buffering
 
 Current Python dataset writes are buffered on the client and flushed

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -1,0 +1,75 @@
+# Current Workspace And Dataset Storage Notes
+
+## Purpose
+
+This note captures current implementation details that should not be presented
+as stable user-facing documentation. Public docs should describe workspaces and
+datasets through the CLI, Python API, and desktop UI rather than through the
+on-disk layout.
+
+## Workspace Layout
+
+At the time of writing, a workspace contains:
+
+```tree
+workspace/
+  .fricon_workspace.json
+  fricon.sqlite3
+  fricon.socket
+  data/
+    <uid[0:2]>/
+      <uid>/
+        data_chunk_0.arrow
+        data_chunk_1.arrow
+  backup/
+  log/
+```
+
+Notes:
+
+- `.fricon_workspace.json` stores the workspace format version as an internal
+  integer compatibility counter.
+- Opening an older workspace may trigger a stepwise migration before the
+  workspace is usable.
+- `fricon.sqlite3` stores workspace catalog metadata.
+- `fricon.socket` is runtime IPC state, not durable data.
+- Dataset directories are currently sharded by the first two characters of the
+  dataset UID.
+
+## Dataset Payload Storage
+
+Current dataset payloads are chunked [Arrow IPC][] files under the dataset
+directory. A dataset is modeled as one logical Arrow table split across
+`data_chunk_<n>.arrow` files as needed.
+
+The physical storage layout is an implementation detail. User-facing docs may
+mention Arrow-compatible tables, but should avoid promising exact file names,
+chunking behavior, or directory structure.
+
+## Write Buffering
+
+Current Python dataset writes are buffered on the client and flushed
+automatically when either:
+
+- 16 rows have accumulated, or
+- 1 second has elapsed since the first buffered row.
+
+Calling `finish()`, `abort()`, or dropping the writer flushes pending rows
+before finalizing the dataset stream.
+
+The public contract is that writes are buffered and finalization flushes pending
+rows. The exact thresholds are implementation details unless they become part of
+a documented performance contract.
+
+## Maintenance Notes
+
+When changing workspace on-disk structure or `.fricon_workspace.json`, update:
+
+- `crates/fricon/src/workspace.rs` migration steps
+- `WORKSPACE_VERSION`, if the change breaks old workspace assumptions
+- this note, if the current layout or compatibility behavior changes
+
+When changing dataset payload layout, update this note and decide whether the
+workspace compatibility version or migration path must change.
+
+[Arrow IPC]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc

--- a/dev-docs/database-schema-changes.md
+++ b/dev-docs/database-schema-changes.md
@@ -1,0 +1,122 @@
+# Database Schema Changes
+
+## Status
+
+Canonical playbook for SQLite/Diesel schema changes, especially changes exposed
+through the Python API.
+
+## Purpose
+
+Use this when adding or changing SQLite schema, Diesel models, dataset catalog
+metadata, or database-backed behavior that becomes visible through Rust,
+Python, CLI, or desktop UI surfaces.
+
+## Read First
+
+- `dev-docs/maintenance-checklist.md` - database and Python API checklists
+- `.agents/skills/diesel-migration/SKILL.md` - Diesel CLI workflow
+- `.agents/skills/diesel-migration/references/fricon-database.md` - Diesel
+  paths and CLI context
+- `dev-docs/architecture-guidelines.md` - persistence boundary rules
+- `dev-docs/release-and-versioning.md` - changeset policy
+
+Use the `pyo3-guide` skill only after code inspection shows PyO3 binding or
+stub changes are needed.
+
+## Current Dataset Metadata Ownership
+
+Today, dataset catalog metadata such as name, description, favorite state,
+status timestamps, and tags is stored in SQLite and mapped into
+`DatasetRecord` / `DatasetMetadata`.
+
+Dataset payload facts live in Arrow chunk files under the dataset directory.
+Future semantic manifest files described by dataset semantic proposal docs are
+not current behavior.
+
+Ordinary Diesel migrations are database compatibility changes. They do not
+require a `WORKSPACE_VERSION` decision unless they also change workspace
+metadata files, workspace layout, or workspace migration semantics.
+
+## Cross-Boundary Flow
+
+For a database field visible through Python, update the layers in this order:
+
+1. Create or update a Diesel migration under `crates/fricon/migrations`.
+2. Regenerate and inspect `crates/fricon/src/database/schema.rs`.
+3. Update Diesel row structs, inserts, changesets, query code, and conversions
+   under `crates/fricon/src/database`.
+4. Update domain/application types under `crates/fricon/src/dataset/**`, such
+   as `DatasetRecord`, `DatasetMetadata`, `DatasetUpdate`, service methods, and
+   repository ports.
+5. Update transport/protobuf code if the field crosses gRPC/IPC boundaries.
+6. Update Python bindings under `crates/fricon-py/src/`.
+7. Update Python stubs under `crates/fricon-py/python/fricon/_core.pyi`.
+8. Update Python tests under `crates/fricon-py/tests/`.
+9. Update public docs only when user-visible behavior changes.
+10. Add a changeset when the change is user-visible.
+
+Example: adding a nullable dataset catalog field such as `operator_name` and
+exposing it through Python usually touches a Diesel migration, generated
+`schema.rs`, dataset catalog row structs and conversions, domain metadata
+types, Python getters or update methods, `_core.pyi`, Python tests, and public
+docs if users are expected to rely on the new field. It does not require a
+`WORKSPACE_VERSION` bump unless workspace metadata files or layout semantics
+also change.
+
+Python-visible catalog metadata does not automatically imply a protobuf or IPC
+change. Update transport contracts only when the field must travel through a
+client/server request or response used by Rust, Python, or desktop callers.
+
+## Diesel Commands
+
+Run Diesel CLI from the crate directory:
+
+```bash
+cd <project_root>/crates/fricon
+diesel migration generate <descriptive_name>
+diesel migration run
+```
+
+During local iteration on an unshared migration:
+
+```bash
+cd <project_root>/crates/fricon
+diesel migration redo
+```
+
+## Validation
+
+Use targeted checks during local iteration:
+
+Minimum local loop for a plain SQLite/catalog change:
+
+```bash
+cargo check -p fricon
+cargo nextest run -p fricon
+```
+
+Add Python checks when the change is visible through Python:
+
+```bash
+uv run maturin develop
+uv run pytest
+uv run basedpyright
+uv run stubtest fricon._core
+```
+
+If docs changed:
+
+```bash
+uv run --group docs mkdocs build -s -v
+```
+
+Before PR readiness, use `dev-docs/pr-preflight-checklist.md`.
+
+## Common Pitfalls
+
+- Do not hand-edit `crates/fricon/src/database/schema.rs`.
+- Do not leak Diesel schema modules into service/business code.
+- Do not confuse SQLite catalog metadata with Arrow payload metadata or future
+  semantic manifests.
+- Do not rewrite a committed migration; add a follow-up migration instead.
+- Do not skip `_core.pyi` when Python-visible signatures or attributes change.

--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -4,6 +4,10 @@
 
 Proposed.
 
+This is not current behavior. Do not implement or document behavior from this
+proposal without checking current code, `dev-docs/current-storage-notes.md`, and
+the relevant checklist in `dev-docs/maintenance-checklist.md`.
+
 This note revises the earlier append-only dataset idea for the actual Fricon
 codebase and assumes the product is still pre-adoption, so breaking internal
 changes are acceptable when they produce a cleaner long-term architecture.

--- a/dev-docs/dataset-semantic-implementation-plan.md
+++ b/dev-docs/dataset-semantic-implementation-plan.md
@@ -4,6 +4,11 @@
 
 Proposed.
 
+This is not current behavior. Do not execute this plan mechanically without
+checking current code, `dev-docs/current-storage-notes.md`, and the relevant
+checklists in `dev-docs/maintenance-checklist.md` and
+`dev-docs/pr-preflight-checklist.md`.
+
 This plan implements the direction in
 `dev-docs/dataset-semantic-architecture-proposal.md`. The goal is to land the
 minimal durable architecture first, then incrementally add richer scan,

--- a/dev-docs/desktop-ui-feature-playbook.md
+++ b/dev-docs/desktop-ui-feature-playbook.md
@@ -1,0 +1,119 @@
+# Desktop UI Feature Playbook
+
+## Status
+
+Canonical playbook for changes that cross Rust Tauri commands/events and the
+React frontend.
+
+## Purpose
+
+Use this when adding or changing desktop UI behavior that needs Rust-side Tauri
+commands, events, exported DTOs, generated frontend bindings, or frontend
+feature behavior.
+
+## Read First
+
+- `dev-docs/architecture-guidelines.md` - desktop UI slice boundaries
+- `dev-docs/maintenance-checklist.md` - Tauri/frontend binding checklist
+- `dev-docs/testing-strategy.md` - frontend test placement
+- `dev-docs/release-and-versioning.md` - changeset policy for user-visible UI
+  changes
+- `crates/fricon-ui/AGENTS.md` - Rust UI crate constraints
+- `crates/fricon-ui/frontend/AGENTS.md` - frontend slice and generated file
+  rules
+
+Do not read dataset semantic proposal files for ordinary UI action work unless
+the feature directly changes dataset semantics.
+
+## Ordered Flow
+
+1. Identify the owning feature slice under `crates/fricon-ui/src/features/` and
+   `crates/fricon-ui/frontend/src/features/`.
+2. Put Rust Tauri command, event, exported DTO, native dialog, and API-error
+   mapping changes in `crates/fricon-ui/src/features/<feature>/tauri.rs`.
+3. Put Rust orchestration below the Tauri adapter, usually in feature-local
+   modules such as `workflow.rs` only when real orchestration exists.
+4. Register or export commands/events through `crates/fricon-ui/src/tauri_api.rs`
+   when the global command/event set changes.
+5. Update Tauri capabilities or config only when the concrete command or
+   platform feature requires it. Ordinary Specta/Tauri commands usually need
+   command registration and generated bindings only. Native dialog,
+   filesystem, shell, window, or other platform permissions may require
+   updates under:
+   - `crates/fricon-ui/capabilities/`
+   - `crates/fricon-ui/tauri.conf.json`
+6. Regenerate frontend bindings from the repo root:
+
+```bash
+pnpm --filter fricon-ui run gen:bindings
+```
+
+7. Verify generated bindings are current:
+
+```bash
+git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts
+```
+
+8. Keep the generic Tauri bridge in
+   `crates/fricon-ui/frontend/src/shared/lib/tauri.ts` minimal.
+9. Put wire-to-domain normalization, command wrappers, event subscriptions, and
+   query invalidation in the frontend feature's `api/` folder.
+10. Put reusable state transitions or table/action logic in `model/` or `hooks/`.
+11. Put user-facing UI in `ui/`.
+12. Export feature public surface through the feature barrel when app/routes
+    need it.
+13. Add or update tests.
+14. Add a changeset when the desktop behavior is user-visible.
+
+## Worked Example
+
+For a dataset row or table action backed by a Rust command:
+
+1. Put the command DTO and Tauri adapter in
+   `crates/fricon-ui/src/features/datasets/tauri.rs`.
+2. Register the command in `crates/fricon-ui/src/tauri_api.rs`.
+3. Regenerate bindings with `pnpm --filter fricon-ui run gen:bindings`.
+4. Add the frontend command wrapper and query invalidation under
+   `crates/fricon-ui/frontend/src/features/datasets/api/`.
+5. Put reusable action state in `model/` or `hooks/` only if more than the UI
+   component needs it.
+6. Add the visible row action in
+   `crates/fricon-ui/frontend/src/features/datasets/ui/DatasetTableRowActions.tsx`
+   or the nearest existing table-action component.
+7. Add focused tests beside the changed API/model/ui code.
+
+## Test Placement
+
+- API normalization and query/event helpers: unit tests under `api/`.
+- Reducers and table/action state transitions: unit tests under `model/`.
+- Hooks that do not need real layout/focus/browser behavior: unit tests under
+  `hooks/`.
+- Menus, dialogs, focus, keyboard behavior, table interactions, and
+  query-driven screens: browser-mode tests under `ui/` with
+  `*.browser.test.*`.
+- Desktop smoke tests: only for app launch, runtime, packaging, or WebView
+  integration risk. Do not use smoke tests for broad component coverage.
+
+## Validation
+
+For local loops, prefer targeted checks:
+
+```bash
+cargo check -p fricon-ui
+pnpm run check
+pnpm run test:unit -- <path-or-pattern>
+pnpm run test:browser -- <path-or-pattern>
+```
+
+Before PR readiness, use `dev-docs/pr-preflight-checklist.md`.
+
+## Common Pitfalls
+
+- Do not hand-edit generated `bindings.ts`.
+- Do not import generated bindings outside `src/shared/lib/tauri.ts` and
+  feature-local `api/*` modules.
+- Do not let feature `workflow.rs` depend on Tauri types.
+- Do not add `useMemo`, `useCallback`, or `React.memo` by default; React
+  Compiler is enabled.
+- Do not add shared UI components under `src/shared/ui/`; that folder is for
+  shadcn primitives and thin local patches.

--- a/dev-docs/desktop-ui-feature-playbook.md
+++ b/dev-docs/desktop-ui-feature-playbook.md
@@ -40,8 +40,8 @@ the feature directly changes dataset semantics.
    command registration and generated bindings only. Native dialog,
    filesystem, shell, window, or other platform permissions may require
    updates under:
-   - `crates/fricon-ui/capabilities/`
-   - `crates/fricon-ui/tauri.conf.json`
+    - `crates/fricon-ui/capabilities/`
+    - `crates/fricon-ui/tauri.conf.json`
 6. Regenerate frontend bindings from the repo root:
 
 ```bash

--- a/dev-docs/internal-doc-comments.md
+++ b/dev-docs/internal-doc-comments.md
@@ -1,5 +1,9 @@
 # Internal Rust Doc Comment Guideline
 
+## Status
+
+Canonical style guide for internal Rust documentation.
+
 ## Goal
 
 Higher-signal comments in boundary-heavy and workflow-heavy code, while keeping

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -140,25 +140,7 @@ uv run --group docs mkdocs build -s -v
 Use this when a change is user-facing, release-note-worthy, or intentionally
 changes versioned behavior.
 
-- Add a Knope changeset file under `.changeset/`.
-- AI agents should write changeset files directly rather than using the
-  interactive `knope document-change` CLI.
-- Human contributors may use `knope document-change` or write the file
-  manually.
-- Do not place templates, README files, or other helper Markdown files inside
-  `.changeset/`; Knope treats them as real changesets.
-
-Template:
-
-```md
----
-default: patch
----
-
-# Short user-facing title
-
-Describe the user-visible change in release-note language.
-```
-
-Use `major`, `minor`, and `patch` with standard semantic-versioning intent;
-Knope handles `0.x` version behavior.
+- Apply the policy in `dev-docs/release-and-versioning.md`.
+- Add a Knope changeset file under `.changeset/` when that policy requires one.
+- Record any required compatibility decision, such as `WORKSPACE_VERSION` or
+  `IPC_PROTOCOL_VERSION`, in the implementation change.

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -1,5 +1,9 @@
 # Maintenance Checklist
 
+## Status
+
+Canonical maintenance checklist.
+
 ## Purpose
 
 This is the canonical maintenance checklist for coordinated repository changes.

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -1,0 +1,164 @@
+# Maintenance Checklist
+
+## Purpose
+
+This is the canonical maintenance checklist for coordinated repository changes.
+Other docs, skills, and agent rules should link here instead of duplicating
+these rules.
+
+## General Rule
+
+When a change crosses a user-facing boundary, update the implementation,
+tests, generated artifacts, and documentation together. If a version or
+compatibility decision is required, record the decision in the change.
+
+## Workspace Format Changes
+
+Use this when changing workspace on-disk structure, `.fricon_workspace.json`,
+workspace metadata semantics, or workspace migration behavior.
+
+- Update stepwise migration logic in `crates/fricon/src/workspace.rs`.
+- Decide whether `WORKSPACE_VERSION` must change.
+- Update `dev-docs/current-storage-notes.md` when the current layout or
+  compatibility behavior changes.
+- Update user-facing docs only when user-visible workspace behavior changes.
+- Add or update Rust tests that cover migration or compatibility behavior.
+
+## Dataset Payload Layout Changes
+
+Use this when changing dataset file layout, chunking behavior, dataset
+directory naming, payload schema rules, or durable metadata stored beside
+payload files.
+
+- Decide whether the workspace migration path or `WORKSPACE_VERSION` must
+  change.
+- Update dataset read/write code and any affected recovery paths together.
+- Update `dev-docs/current-storage-notes.md`.
+- Update public docs only for stable user-facing behavior.
+- Add or update tests for old and new payload expectations when compatibility
+  matters.
+
+## Database Schema Changes
+
+Use this when changing SQLite tables, columns, indexes, constraints, Diesel
+migrations, generated Diesel schema, or database model types.
+
+- Create or update a Diesel migration under `crates/fricon/migrations`.
+- Make `down.sql` a real rollback, not a placeholder.
+- Preserve existing data unless the task explicitly permits destructive resets.
+- Regenerate and inspect `crates/fricon/src/database/schema.rs`.
+- Update affected Diesel structs, inserts/changesets, queries, and tests.
+- Keep Diesel and schema types inside database/adapter code.
+- Run at least `cargo check -p fricon`.
+- Run targeted Rust tests for the affected database slice when present.
+- Rebuild Python bindings before Python tests if exported behavior changed.
+
+## Rust IPC / gRPC Contract Changes
+
+Use this when changing protobuf files, transport request or response shapes,
+client/server IPC behavior, or protocol compatibility semantics.
+
+- Update the relevant files under `crates/fricon/proto/**` or
+  `crates/fricon/src/transport/**`.
+- Update explicit IPC protocol compatibility logic in both client and server
+  where applicable.
+- Decide whether `IPC_PROTOCOL_VERSION` must change.
+- Regenerate affected bindings.
+- Update Rust, Python, or frontend callers affected by the contract change.
+- Update maintainer-facing docs when the protocol workflow or compatibility
+  rule changes.
+- Add or update compatibility and transport tests.
+
+## Tauri / Frontend Binding Changes
+
+Use this when changing Rust commands, events, DTOs, or exported Specta/Tauri
+types consumed by the frontend.
+
+- Update the owning Rust feature adapter, usually
+  `crates/fricon-ui/src/features/<feature>/tauri.rs`.
+- Regenerate frontend bindings:
+
+```bash
+pnpm --filter fricon-ui run gen:bindings
+```
+
+- Verify generated bindings are current:
+
+```bash
+git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts
+```
+
+- Update frontend API adapters, query hooks, events, and tests.
+- Do not hand-edit generated binding files.
+
+## Python API Changes
+
+Use this when changing Python-visible classes, methods, errors, type stubs, or
+binding behavior.
+
+- Update Rust PyO3 bindings and Python package files together.
+- Update `.pyi` stubs when exported signatures or types change.
+- Run `uv run maturin develop` before Python tests when Rust bindings may be
+  stale.
+- Update Python integration tests.
+- Update public docs when user-facing API behavior changes.
+- Add a release note changeset when the change is user-visible.
+
+## Frontend Route Or UI Contract Changes
+
+Use this when changing frontend routes, route tree generation, shared UI
+contracts, or user-visible screen behavior.
+
+- Update the owning feature slice first.
+- Keep feature-specific API normalization inside the feature's `api/` folder.
+- Regenerate or verify generated route files when router files change:
+
+```bash
+git diff --exit-code crates/fricon-ui/frontend/src/routeTree.gen.ts
+```
+
+- Run `pnpm run check` as the default frontend gate.
+- Use `pnpm run test:unit` or `pnpm run test:browser` for targeted reruns.
+
+## Documentation Changes
+
+Use this when changing public docs, developer docs, or repo guidance.
+
+- Keep `docs/` user-facing.
+- Put implementation details, architecture notes, and maintenance rules in
+  `dev-docs/`.
+- When introducing a checklist, put the canonical version in `dev-docs/` and
+  link to it elsewhere.
+- Run:
+
+```bash
+uv run --group docs mkdocs build -s -v
+```
+
+## Release Notes
+
+Use this when a change is user-facing, release-note-worthy, or intentionally
+changes versioned behavior.
+
+- Add a Knope changeset file under `.changeset/`.
+- AI agents should write changeset files directly rather than using the
+  interactive `knope document-change` CLI.
+- Human contributors may use `knope document-change` or write the file
+  manually.
+- Do not place templates, README files, or other helper Markdown files inside
+  `.changeset/`; Knope treats them as real changesets.
+
+Template:
+
+```md
+---
+default: patch
+---
+
+# Short user-facing title
+
+Describe the user-visible change in release-note language.
+```
+
+Use `major`, `minor`, and `patch` with standard semantic-versioning intent;
+Knope handles `0.x` version behavior.

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -16,6 +16,18 @@ When a change crosses a user-facing boundary, update the implementation,
 tests, generated artifacts, and documentation together. If a version or
 compatibility decision is required, record the decision in the change.
 
+## Which Compatibility Surface Is Changing?
+
+Classify the boundary before deciding which checklist applies:
+
+| Changed surface | Use |
+| --- | --- |
+| `.fricon_workspace.json`, workspace directory layout, durable workspace metadata, or workspace migration semantics | Workspace format changes |
+| Dataset payload files, chunking, durable dataset-side metadata, or dataset payload schema rules | Dataset payload layout changes |
+| SQLite tables, Diesel migrations, generated Diesel schema, or database row models | Database schema changes |
+| `crates/fricon/proto/**`, `crates/fricon/src/transport/**`, IPC/gRPC request or response semantics | Rust IPC / gRPC contract changes |
+| Tauri command/event DTOs, Specta exports, generated frontend bindings, or frontend-only adapter DTOs | Tauri / frontend binding changes |
+
 ## Workspace Format Changes
 
 Use this when changing workspace on-disk structure, `.fricon_workspace.json`,
@@ -27,6 +39,23 @@ workspace metadata semantics, or workspace migration behavior.
   compatibility behavior changes.
 - Update user-facing docs only when user-visible workspace behavior changes.
 - Add or update Rust tests that cover migration or compatibility behavior.
+
+Decision guide:
+
+| Change | `WORKSPACE_VERSION` decision |
+| --- | --- |
+| Add optional workspace metadata with a default and old workspaces still open without migration | Usually no bump; document the default and add a compatibility test |
+| Add required workspace metadata or change metadata meaning so old workspaces need transformation | Bump and add a migration step |
+| Rename, remove, or move workspace metadata | Bump and add a migration step |
+| Change workspace directory layout or durable file placement | Bump unless the old layout remains fully supported |
+| SQLite-only Diesel migration with no `.fricon_workspace.json` or layout change | No workspace version bump; Diesel migration handles database compatibility |
+
+Examples:
+
+- Add optional `created_by` metadata with a default and old workspaces still
+  open: usually no bump.
+- Add required `workspace_uuid` metadata needed to open or interpret old
+  workspaces: bump and add a migration step.
 
 ## Dataset Payload Layout Changes
 
@@ -46,6 +75,9 @@ payload files.
 
 Use this when changing SQLite tables, columns, indexes, constraints, Diesel
 migrations, generated Diesel schema, or database model types.
+
+For database fields exposed through Python, use
+`dev-docs/database-schema-changes.md`.
 
 - Create or update a Diesel migration under `crates/fricon/migrations`.
 - Make `down.sql` a real rollback, not a placeholder.
@@ -73,10 +105,36 @@ client/server IPC behavior, or protocol compatibility semantics.
   rule changes.
 - Add or update compatibility and transport tests.
 
+Decision guide:
+
+| Change | `IPC_PROTOCOL_VERSION` decision |
+| --- | --- |
+| Add a backward-compatible optional response field and all current clients can ignore it | Usually no bump; add tests for old/default handling where practical |
+| Add a required request field or require clients to send new data | Bump |
+| Remove, rename, renumber, or change the meaning/type of a protobuf field | Bump |
+| Change protocol handshake, stream sequencing, status semantics, or error meaning | Bump |
+| Internal Rust struct refactor with no wire/protobuf/semantic contract change | No bump |
+| Tauri/Specta-only command shape change not used by Rust IPC/gRPC | No IPC protocol bump; follow the Tauri/frontend binding checklist |
+
+Examples:
+
+- Add an optional protobuf response field that existing clients can ignore:
+  usually no bump.
+- Rename a response field or change an error/status meaning: bump.
+
+Generated protobuf Rust code is produced by `crates/fricon/build.rs` during
+Cargo builds from `crates/fricon/proto/**`. There is no checked-in protobuf
+Rust output to edit. Run Rust checks/builds to regenerate in `OUT_DIR`, and
+regenerate Tauri frontend bindings separately if the desktop frontend consumes
+the changed shape.
+
 ## Tauri / Frontend Binding Changes
 
 Use this when changing Rust commands, events, DTOs, or exported Specta/Tauri
 types consumed by the frontend.
+
+For cross-boundary desktop UI work, use
+`dev-docs/desktop-ui-feature-playbook.md`.
 
 - Update the owning Rust feature adapter, usually
   `crates/fricon-ui/src/features/<feature>/tauri.rs`.
@@ -94,6 +152,8 @@ git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts
 
 - Update frontend API adapters, query hooks, events, and tests.
 - Do not hand-edit generated binding files.
+- Apply `dev-docs/release-and-versioning.md` when the UI behavior is
+  user-visible.
 
 ## Python API Changes
 
@@ -101,7 +161,8 @@ Use this when changing Python-visible classes, methods, errors, type stubs, or
 binding behavior.
 
 - Update Rust PyO3 bindings and Python package files together.
-- Update `.pyi` stubs when exported signatures or types change.
+- Update `.pyi` stubs when exported signatures or types change, especially
+  `crates/fricon-py/python/fricon/_core.pyi`.
 - Run `uv run maturin develop` before Python tests when Rust bindings may be
   stale.
 - Update Python integration tests.

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -20,13 +20,13 @@ compatibility decision is required, record the decision in the change.
 
 Classify the boundary before deciding which checklist applies:
 
-| Changed surface | Use |
-| --- | --- |
-| `.fricon_workspace.json`, workspace directory layout, durable workspace metadata, or workspace migration semantics | Workspace format changes |
-| Dataset payload files, chunking, durable dataset-side metadata, or dataset payload schema rules | Dataset payload layout changes |
-| SQLite tables, Diesel migrations, generated Diesel schema, or database row models | Database schema changes |
-| `crates/fricon/proto/**`, `crates/fricon/src/transport/**`, IPC/gRPC request or response semantics | Rust IPC / gRPC contract changes |
-| Tauri command/event DTOs, Specta exports, generated frontend bindings, or frontend-only adapter DTOs | Tauri / frontend binding changes |
+| Changed surface                                                                                                    | Use                              |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| `.fricon_workspace.json`, workspace directory layout, durable workspace metadata, or workspace migration semantics | Workspace format changes         |
+| Dataset payload files, chunking, durable dataset-side metadata, or dataset payload schema rules                    | Dataset payload layout changes   |
+| SQLite tables, Diesel migrations, generated Diesel schema, or database row models                                  | Database schema changes          |
+| `crates/fricon/proto/**`, `crates/fricon/src/transport/**`, IPC/gRPC request or response semantics                 | Rust IPC / gRPC contract changes |
+| Tauri command/event DTOs, Specta exports, generated frontend bindings, or frontend-only adapter DTOs               | Tauri / frontend binding changes |
 
 ## Workspace Format Changes
 
@@ -42,13 +42,13 @@ workspace metadata semantics, or workspace migration behavior.
 
 Decision guide:
 
-| Change | `WORKSPACE_VERSION` decision |
-| --- | --- |
-| Add optional workspace metadata with a default and old workspaces still open without migration | Usually no bump; document the default and add a compatibility test |
-| Add required workspace metadata or change metadata meaning so old workspaces need transformation | Bump and add a migration step |
-| Rename, remove, or move workspace metadata | Bump and add a migration step |
-| Change workspace directory layout or durable file placement | Bump unless the old layout remains fully supported |
-| SQLite-only Diesel migration with no `.fricon_workspace.json` or layout change | No workspace version bump; Diesel migration handles database compatibility |
+| Change                                                                                           | `WORKSPACE_VERSION` decision                                               |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Add optional workspace metadata with a default and old workspaces still open without migration   | Usually no bump; document the default and add a compatibility test         |
+| Add required workspace metadata or change metadata meaning so old workspaces need transformation | Bump and add a migration step                                              |
+| Rename, remove, or move workspace metadata                                                       | Bump and add a migration step                                              |
+| Change workspace directory layout or durable file placement                                      | Bump unless the old layout remains fully supported                         |
+| SQLite-only Diesel migration with no `.fricon_workspace.json` or layout change                   | No workspace version bump; Diesel migration handles database compatibility |
 
 Examples:
 
@@ -107,14 +107,14 @@ client/server IPC behavior, or protocol compatibility semantics.
 
 Decision guide:
 
-| Change | `IPC_PROTOCOL_VERSION` decision |
-| --- | --- |
+| Change                                                                                  | `IPC_PROTOCOL_VERSION` decision                                     |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | Add a backward-compatible optional response field and all current clients can ignore it | Usually no bump; add tests for old/default handling where practical |
-| Add a required request field or require clients to send new data | Bump |
-| Remove, rename, renumber, or change the meaning/type of a protobuf field | Bump |
-| Change protocol handshake, stream sequencing, status semantics, or error meaning | Bump |
-| Internal Rust struct refactor with no wire/protobuf/semantic contract change | No bump |
-| Tauri/Specta-only command shape change not used by Rust IPC/gRPC | No IPC protocol bump; follow the Tauri/frontend binding checklist |
+| Add a required request field or require clients to send new data                        | Bump                                                                |
+| Remove, rename, renumber, or change the meaning/type of a protobuf field                | Bump                                                                |
+| Change protocol handshake, stream sequencing, status semantics, or error meaning        | Bump                                                                |
+| Internal Rust struct refactor with no wire/protobuf/semantic contract change            | No bump                                                             |
+| Tauri/Specta-only command shape change not used by Rust IPC/gRPC                        | No IPC protocol bump; follow the Tauri/frontend binding checklist   |
 
 Examples:
 

--- a/dev-docs/pr-preflight-checklist.md
+++ b/dev-docs/pr-preflight-checklist.md
@@ -1,5 +1,9 @@
 # PR Preflight Checklist
 
+## Status
+
+Canonical pre-PR validation matrix.
+
 ## Purpose
 
 This is the canonical pre-PR check matrix for local development and PR

--- a/dev-docs/pr-preflight-checklist.md
+++ b/dev-docs/pr-preflight-checklist.md
@@ -45,13 +45,13 @@ Run only for changed areas.
 cargo +nightly fmt --all --check
 cargo check
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test --workspace
+cargo nextest run
 ```
 
 Optional alternative:
 
 ```bash
-cargo nextest run
+cargo test --workspace
 ```
 
 ### Python
@@ -124,14 +124,14 @@ cargo +nightly fmt --all --check
 cargo check
 cargo build --workspace --locked
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test --workspace
+cargo nextest run
 cargo deny --workspace --all-features check
 ```
 
 Optional alternative for Rust tests:
 
 ```bash
-cargo nextest run
+cargo test --workspace
 ```
 
 ### Python

--- a/dev-docs/pr-preflight-checklist.md
+++ b/dev-docs/pr-preflight-checklist.md
@@ -1,30 +1,42 @@
-# Preflight Matrix
+# PR Preflight Checklist
+
+## Purpose
+
+This is the canonical pre-PR check matrix for local development and PR
+readiness. Skills, agent rules, and contributing docs should link here instead
+of duplicating command lists.
 
 Use one profile per run:
-- `quick` for local development loops (default)
-- `strict` once before opening/updating a PR
+
+- `quick` for local development loops
+- `strict` once before opening or updating a PR
 
 ## Scope Detection
 
 Check changed files first:
+
 ```bash
 git diff --name-only
 ```
 
-Use the result to choose areas:
-- Rust core/CLI (`crates/fricon`, shared Rust CLI, non-frontend Rust)
-- Python bindings (`crates/fricon-py`, Python tests, `pyproject.toml`)
-- Frontend (`crates/fricon-ui/frontend`, root JS/TS config)
-- Tauri IPC signatures (Rust command/event changes used by UI)
-- Workspace structure / migration compatibility (`crates/fricon/src/workspace.rs`, workspace metadata files, docs describing workspace layout)
-- Rust IPC/gRPC protocol compatibility (`crates/fricon/proto/**`, `crates/fricon/src/client.rs`, `crates/fricon/src/transport/**`)
-- Docs-only (`docs/**`, markdown files)
+Use the result to choose changed areas:
 
-## Quick Profile (default)
+- Rust core/CLI: `crates/fricon`, shared Rust CLI, non-frontend Rust
+- Python bindings: `crates/fricon-py`, Python tests, `pyproject.toml`
+- Frontend: `crates/fricon-ui/frontend`, root JS/TS config
+- Tauri IPC signatures: Rust command/event changes used by UI
+- Workspace compatibility: `crates/fricon/src/workspace.rs`, workspace metadata
+  files, docs describing workspace layout
+- Rust IPC/gRPC compatibility: `crates/fricon/proto/**`,
+  `crates/fricon/src/client.rs`, `crates/fricon/src/transport/**`
+- Docs-only: `docs/**`, `dev-docs/**`, and Markdown-only changes
+
+## Quick Profile
 
 Run only for changed areas.
 
 ### Rust
+
 ```bash
 cargo +nightly fmt --all --check
 cargo check
@@ -33,11 +45,13 @@ cargo test --workspace
 ```
 
 Optional alternative:
+
 ```bash
 cargo nextest run
 ```
 
 ### Python
+
 ```bash
 uv run ruff format --check
 uv run maturin develop
@@ -46,6 +60,7 @@ uv run pytest
 ```
 
 ### Frontend
+
 ```bash
 pnpm run check
 pnpm run format:check
@@ -53,6 +68,7 @@ pnpm run test
 ```
 
 Optional split for diagnosis or narrow reruns:
+
 ```bash
 pnpm run format:check
 pnpm run type-check
@@ -64,39 +80,41 @@ pnpm run test:unit -- <path-or-pattern>
 pnpm run test:browser -- <path-or-pattern>
 ```
 
-### Tauri IPC changed
+### Tauri IPC Changed
+
 ```bash
 pnpm --filter fricon-ui run gen:bindings
 git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts
 ```
 
-### Workspace structure / migration compatibility changed
-Use the normal Rust test gate for coverage, and also verify:
+### Workspace Compatibility Changed
 
-- whether `WORKSPACE_VERSION` must change
-- the docs and repo rules that describe workspace structure and migration duties
+Use the normal Rust test gate for coverage, then apply the workspace checklist
+in `dev-docs/maintenance-checklist.md`.
 
-### Rust IPC/gRPC protocol compatibility changed
-Use the normal Rust test gate for coverage, and also verify:
+### Rust IPC / gRPC Compatibility Changed
 
-- whether `IPC_PROTOCOL_VERSION` must change
-- the explicit IPC protocol version/handshake logic changed with the protocol contract
+Use the normal Rust test gate for coverage, then apply the IPC/gRPC checklist in
+`dev-docs/maintenance-checklist.md`.
 
-### Route tree guard (when frontend router files changed)
+### Frontend Router Files Changed
+
 ```bash
 git diff --exit-code crates/fricon-ui/frontend/src/routeTree.gen.ts
 ```
 
-### Docs-only
+### Docs-Only
+
 ```bash
 uv run --group docs mkdocs build -s -v
 ```
 
-## Strict Profile (PR gate)
+## Strict Profile
 
-Run once before opening/updating PR.
+Run once before opening or updating a PR.
 
 ### Rust
+
 ```bash
 cargo +nightly fmt --all --check
 cargo check
@@ -107,11 +125,13 @@ cargo deny --workspace --all-features check
 ```
 
 Optional alternative for Rust tests:
+
 ```bash
 cargo nextest run
 ```
 
 ### Python
+
 ```bash
 uv run ruff format --check
 uv run maturin develop
@@ -122,6 +142,7 @@ uv run stubtest fricon._core
 ```
 
 ### Frontend
+
 ```bash
 pnpm run check
 pnpm run format:check
@@ -131,6 +152,7 @@ git diff --exit-code crates/fricon-ui/frontend/src/routeTree.gen.ts
 ```
 
 Optional split for diagnosis or narrow reruns:
+
 ```bash
 pnpm run format:check
 pnpm run type-check
@@ -142,37 +164,47 @@ pnpm run test:unit -- <path-or-pattern>
 pnpm run test:browser -- <path-or-pattern>
 ```
 
-### Tauri IPC changed
+### Tauri IPC Changed
+
 ```bash
 pnpm --filter fricon-ui run gen:bindings
 git diff --exit-code crates/fricon-ui/frontend/src/shared/lib/bindings.ts
 ```
 
-### Workspace structure / migration compatibility changed
-Use the normal Rust test gate for coverage, and also verify:
+### Workspace Compatibility Changed
 
-- whether `WORKSPACE_VERSION` must change
-- the docs and repo rules that describe workspace structure and migration duties
+Use the normal Rust test gate for coverage, then apply the workspace checklist
+in `dev-docs/maintenance-checklist.md`.
 
-### Rust IPC/gRPC protocol compatibility changed
-Use the normal Rust test gate for coverage, and also verify:
+### Rust IPC / gRPC Compatibility Changed
 
-- whether `IPC_PROTOCOL_VERSION` must change
-- the explicit IPC protocol version/handshake logic changed with the protocol contract
+Use the normal Rust test gate for coverage, then apply the IPC/gRPC checklist in
+`dev-docs/maintenance-checklist.md`.
 
 ### Docs
+
 ```bash
 uv run --group docs mkdocs build -s -v
 ```
 
 ## Environment Notes
 
-- Local development does not need CI-style `uv sync --locked --group ci` by default.
+- Local development does not need CI-style `uv sync --locked --group ci` by
+  default.
 - If required tools are missing locally, run once:
+
 ```bash
 uv sync --all-groups
 ```
 
 ## Final Gate
 
-Do not mark PR ready if selected checks fail.
+Do not mark a PR ready if selected checks fail.
+
+Report:
+
+- changed area classification
+- commands executed
+- pass/fail result per command
+- blocking failures and next fix step
+- final readiness: `ready` or `not ready`

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -1,0 +1,125 @@
+# Project Intent
+
+## Purpose
+
+Fricon aims to become an easy-to-use scientific experiment measurement
+management system.
+
+The project should help researchers record, organize, inspect, and eventually
+execute scientific measurement workflows on their own computers without requiring
+them to operate a multi-user service or a complex lab information system.
+
+## Target Users
+
+The primary target users are researchers who have entry-level Python data
+analysis ability.
+
+Assumptions:
+
+- They can install Python packages and run Python scripts or notebooks.
+- They are comfortable with basic tabular or array-like data concepts.
+- They may not be software engineers.
+- They should not need to understand Fricon's internal Rust, IPC, database, or
+  file-layout implementation details.
+
+## Long-Term Product Direction
+
+Fricon is expected to provide:
+
+- data recording
+- experiment execution
+- parameter management
+- device management
+- local experiment workspace management
+- a desktop UI for browsing, managing, and inspecting collected data
+- Python APIs for scripting and automation
+
+The product should make common scientific measurement workflows easier while
+remaining scriptable for users who already use Python in their research.
+
+## Runtime Model
+
+Fricon is local-first. The main supported runtime model is:
+
+- data lives on the user's local computer
+- the desktop UI and Python API operate against a local workspace
+- the local server process coordinates workspace operations
+
+A remote client may be considered in the future, but it should build on the
+local-first model rather than forcing the project into a hosted service shape.
+
+## Non-Goals
+
+Fricon does not currently aim to support:
+
+- multi-user collaboration
+- server-hosted SaaS operation
+- account management, teams, roles, or permissions
+- centralized lab administration
+- distributed database semantics
+- web-first deployment as the primary experience
+
+These may become integration concerns someday, but they should not drive the
+core architecture now.
+
+## Design Principles
+
+### Keep The User Model Simple
+
+Users should think in terms of workspaces, datasets, experiments, parameters,
+and devices. Internal concepts such as SQLite tables, Arrow chunk files, IPC
+protocol versions, and Rust module boundaries belong in developer notes, not in
+public user documentation.
+
+### Prefer Local Reliability Over Distributed Flexibility
+
+Because the product is local-first and single-user, prioritize predictable local
+state, understandable recovery paths, and clear workspace compatibility over
+distributed coordination patterns.
+
+### Keep Python Ergonomic
+
+The Python API is a primary user surface. It should support straightforward
+data collection scripts without forcing users to predefine every low-level
+schema detail.
+
+### Make Advanced Workflows Explicit
+
+Experiment execution, parameter management, and device management should become
+explicit product concepts as they mature. Avoid hiding those semantics inside
+dataset naming conventions or incidental metadata.
+
+### Keep Architecture Proportional
+
+Use explicit boundaries where workflows cross storage, runtime, IPC, device, or
+UI concerns. Avoid general-purpose abstractions that only prepare for future
+possibilities without simplifying current product work.
+
+## AI-Assisted Development Guidance
+
+This document is a constraint for AI-assisted changes:
+
+- Do not expand the project toward multi-user SaaS unless explicitly requested.
+- Do not expose internal storage or protocol details in `docs/`.
+- Keep user-facing docs focused on workflows and stable product concepts.
+- Put implementation details, architectural notes, and maintenance rules in
+  `dev-docs/`.
+- Prefer feature-local changes that preserve clear ownership.
+- Treat Python API and desktop UI behavior as user-facing contracts.
+- Treat internal Rust module boundaries as changeable when doing so improves
+  the architecture.
+
+## Open Product Questions
+
+These questions are intentionally unresolved:
+
+- What experiment execution model should Fricon support first: script-driven,
+  UI-driven, or a hybrid?
+- How should parameters be represented: flat key-value sets, typed schemas,
+  sweep definitions, or versioned experiment configurations?
+- What level of device abstraction is useful without overbuilding a hardware
+  framework?
+- Which data formats and array shapes should be first-class beyond the current
+  dataset model?
+- What remote-client use cases are worth supporting without introducing
+  multi-user product complexity?

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -1,5 +1,9 @@
 # Project Intent
 
+## Status
+
+Canonical project direction and AI-assisted development guardrails.
+
 ## Purpose
 
 Fricon aims to become an easy-to-use scientific experiment measurement

--- a/dev-docs/release-and-versioning.md
+++ b/dev-docs/release-and-versioning.md
@@ -1,5 +1,9 @@
 # Release And Versioning
 
+## Status
+
+Canonical release and versioning policy.
+
 ## Purpose
 
 This note is the canonical release and versioning policy for Fricon. Use it to

--- a/dev-docs/release-and-versioning.md
+++ b/dev-docs/release-and-versioning.md
@@ -1,0 +1,110 @@
+# Release And Versioning
+
+## Purpose
+
+This note is the canonical release and versioning policy for Fricon. Use it to
+decide when a change needs release notes, how to describe the change, and which
+versioning decisions must be made before merge.
+
+For implementation-side coordination, use `dev-docs/maintenance-checklist.md`.
+
+## Current Release Model
+
+- Releases are managed by Knope.
+- The repository has one unified project version.
+- The canonical Git tag format is `v<version>`.
+- Release preparation happens through the `release` branch and a prepared
+  release PR.
+- Merging the prepared release PR creates the GitHub release and tag.
+- Publishing is currently PyPI-only.
+- Versioned files are defined in `knope.toml`.
+
+## Changeset Policy
+
+Add a Knope changeset under `.changeset/` when a change is user-visible,
+release-note-worthy, or intentionally changes versioned behavior.
+
+Examples that usually need a changeset:
+
+- new Python API capability
+- changed Python API behavior
+- new CLI or desktop UI capability
+- changed dataset or workspace behavior visible to users
+- user-visible bug fix
+- compatibility change that users may need to know about
+
+Examples that usually do not need a changeset:
+
+- internal Rust-only refactor with no user-visible behavior change
+- test-only change
+- developer-doc-only maintenance note
+- CI or tooling cleanup with no release impact
+- changes to internal docs under `dev-docs/` that do not describe released
+  behavior
+
+When in doubt, prefer a concise patch changeset if a user could observe the
+change after upgrading.
+
+## Version Bump Guidance
+
+Use normal semantic-versioning intent:
+
+- `patch`: bug fixes, user-facing documentation corrections, small behavior
+  fixes, and compatible polish
+- `minor`: new user-facing Python, CLI, desktop UI, dataset, or workspace
+  capability
+- `major`: future stable-compatibility breaks once the project has stable
+  compatibility promises
+
+Knope handles `0.x` version behavior. Choose the release intent; do not
+manually edit versioned files for normal changes.
+
+## Changeset Format
+
+AI agents should write changeset files directly rather than using the
+interactive `knope document-change` CLI. Human contributors may use
+`knope document-change` or write the file manually.
+
+Use this template:
+
+```md
+---
+default: patch
+---
+
+# Short user-facing title
+
+Describe the user-visible change in release-note language.
+```
+
+Rules:
+
+- Use `major`, `minor`, or `patch` instead of `patch` when the intended bump is
+  not patch.
+- Prefer user-facing language over implementation details.
+- Do not place templates, README files, or helper Markdown files inside
+  `.changeset/`; Knope treats Markdown files there as real changesets.
+- `.changeset/.gitkeep` is acceptable.
+
+## Compatibility Decisions
+
+Some implementation changes require a version or compatibility decision even if
+they do not directly edit release files:
+
+- Workspace format changes require a `WORKSPACE_VERSION` decision.
+- Rust IPC/gRPC contract changes require an `IPC_PROTOCOL_VERSION` decision.
+- Python API behavior changes require updated stubs/tests and usually a
+  changeset.
+- Desktop UI or CLI behavior changes usually require user-facing release notes.
+
+Use `dev-docs/maintenance-checklist.md` for the full coordinated checklist for
+these changes.
+
+## Release Workflow Summary
+
+- A push to `main` refreshes the rolling release preview PR from the `release`
+  branch.
+- The release preparation workflow depends on the prepared release commit
+  subject `chore: prepare release <version>`.
+- Merging the prepared release PR creates the GitHub release and tag.
+- Publishing remains PyPI-only unless the release workflow is changed.

--- a/dev-docs/testing-strategy.md
+++ b/dev-docs/testing-strategy.md
@@ -1,5 +1,9 @@
 # Testing Strategy
 
+## Status
+
+Canonical testing strategy.
+
 ## Purpose
 
 This note defines the steady-state automated testing strategy for `fricon`.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,25 +9,8 @@ the data files and metadata. You can create a workspace using the CLI:
 fricon init path/to/workspace
 ```
 
-Currently a workspace contains the following files:
-
-```tree
-workspace/
-  .fricon_workspace.json
-  fricon.sqlite3
-  fricon.socket
-  data/
-    <uid[0:2]>/
-      <uid>/
-        data_chunk_0.arrow
-        data_chunk_1.arrow (optional, written when first exceeds chunk size)
-  backup/
-  log/
-```
-
-`.fricon_workspace.json` stores the workspace format version as an internal
-integer compatibility counter. Opening an older workspace may trigger a
-stepwise migration before the workspace is usable.
+A workspace should be treated as Fricon-managed storage. Use the CLI, Python
+API, or desktop UI to read and modify it.
 
 ## Fricon Server
 

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -61,18 +61,23 @@ thresholds are implementation details.
 
 `fricon` currently supports a focused set of data types optimized for scientific measurements and signal processing. The following table lists the supported types:
 
-| Python type        | Dataset data type | Description                                  |
-| ------------------ | ----------------- | -------------------------------------------- |
-| [`float`][]        | `Float64`         | 64-bit floating point numbers                |
-| [`complex`][]      | `Complex128`      | 128-bit complex numbers (real + imaginary)   |
-| [`fricon.Trace`][] | `Trace`           | Time series data with various x-axis formats |
+| Python type              | Dataset data type | Description                                  |
+| ------------------------ | ----------------- | -------------------------------------------- |
+| [`float`][]              | `Float64`         | 64-bit floating point numbers                |
+| [`int`][]                | `Float64`         | Converted to 64-bit floating point numbers   |
+| [`complex`][]            | `Complex128`      | 128-bit complex numbers (real + imaginary)   |
+| [`fricon.Trace`][]       | `Trace`           | Time series data with explicit x-axis values |
+| list, NumPy, Arrow array | `Trace`           | Simple trace with implicit integer x indices |
 
-> **Note**: The current release intentionally limits scalar type support to float and complex values.
+> **Note**: The current release intentionally stores scalar columns as float or complex values.
 
 ### Supported trace variants
 
 Trace data supports three different formats depending on how the x-axis (independent variable) is stored:
 
-- **SimpleList**: Only y-values are stored, x-values are implicit indices (0, 1, 2, ...)
-- **FixedStep**: Regular spacing with x₀ (starting point) and step size
-- **VariableStep**: Arbitrary x-values stored alongside y-values
+- **SimpleList**: pass a list, NumPy array, or Arrow array as the column value;
+  only y-values are stored, and x-values are implicit indices (0, 1, 2, ...).
+- **FixedStep**: use `fricon.Trace.fixed_step(x0, step, y)` for regular
+  spacing with x0 and step size.
+- **VariableStep**: use `fricon.Trace.variable_step(x, y)` for arbitrary
+  x-values stored alongside y-values.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,7 +1,8 @@
 # Dataset
 
-`fricon` uses [Arrow IPC format] to store datasets. A basic knowledge of Arrow
-data structures can be helpful to understand how `fricon` works.
+`fricon` datasets are table-shaped data collections. A basic knowledge of Arrow
+data structures can be helpful because the Python API accepts Arrow-compatible
+values and exposes Arrow-style tables.
 
 ## [Apache Arrow](https://arrow.apache.org/docs/index.html)
 
@@ -23,24 +24,22 @@ classes in the python binding of Arrow:
 - [`pyarrow.Table`][]: A helper type to unify representations of single and
   collection of record batches with the same schema.
 
-## How are datasets stored?
+## How datasets work
 
-A dataset is exactly one Arrow table stored in [Arrow IPC format]. When a dataset
-is created, the schema of the table is automatically inferred from the first row
-of data written. This allows for flexible data collection without requiring
-manual schema definition.
+Each dataset contains one table. When a dataset is created, the table schema is
+automatically inferred from the first row of data written. This allows for
+flexible data collection without requiring manual schema definition.
 
 ## Write batching
 
-Dataset writes are buffered on the client and flushed automatically when either
-16 rows have accumulated or 1 second has elapsed since the first buffered row.
-This keeps the write API row-oriented while reducing transport overhead for
-larger ingests. Calling `finish()`, `abort()`, or dropping the writer will flush
-any pending rows before the dataset stream is finalized.
+Dataset writes are buffered automatically. This keeps the write API row-oriented
+while reducing transport overhead for larger ingests. Calling `finish()`,
+`abort()`, or dropping the writer flushes any pending rows before the dataset
+stream is finalized.
 
 ## Type inference
 
-`fricon` MVP currently supports a focused set of data types optimized for scientific measurements and signal processing. The following table lists the supported types:
+`fricon` currently supports a focused set of data types optimized for scientific measurements and signal processing. The following table lists the supported types:
 
 | Python type        | Dataset data type | Description                                  |
 | ------------------ | ----------------- | -------------------------------------------- |
@@ -48,7 +47,7 @@ any pending rows before the dataset stream is finalized.
 | [`complex`][]      | `Complex128`      | 128-bit complex numbers (real + imaginary)   |
 | [`fricon.Trace`][] | `Trace`           | Time series data with various x-axis formats |
 
-> **Note**: The MVP version intentionally limits type support to float and complex types for simplicity. Additional types (bool, int, str) will be supported in future releases.
+> **Note**: The current release intentionally limits scalar type support to float and complex values.
 
 ### Supported trace variants
 
@@ -57,11 +56,3 @@ Trace data supports three different formats depending on how the x-axis (indepen
 - **SimpleList**: Only y-values are stored, x-values are implicit indices (0, 1, 2, ...)
 - **FixedStep**: Regular spacing with x₀ (starting point) and step size
 - **VariableStep**: Arbitrary x-values stored alongside y-values
-
-### Future extensions
-
-Additional data types (bool, int, str, timestamps) will be supported in future versions. The current focus on float, complex, and trace types ensures optimal performance and correctness for the most common scientific use cases.
-
-<!-- TODO: `pyarrow` and `polars` tips -->
-
-[Arrow IPC format]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -4,6 +4,27 @@
 data structures can be helpful because the Python API accepts Arrow-compatible
 values and exposes Arrow-style tables.
 
+## Public dataset contract
+
+Each dataset contains one table. The first written row defines the table schema.
+Later rows must use the same column names and compatible value types as that
+first row. Missing columns, extra columns, and different value kinds are not
+part of the supported write contract.
+
+Supported public write values are currently `float`, `int` values converted to
+`float`, `complex`, and trace values. `None` and nullable columns are not part
+of the current write contract.
+
+Call `finish()` or `close()` to complete a dataset successfully. A writer used
+as a context manager calls `close()` when the block exits normally. Calling
+`abort()`, raising from the context manager block, or dropping a writer before
+successful completion marks the dataset as aborted.
+
+Users do not currently declare dataset semantics, scan axes, or logical indices
+through the public API. The exact workspace file layout, internal metadata
+files, chunk file names, and write-buffer thresholds are implementation details
+rather than public storage contracts.
+
 ## [Apache Arrow](https://arrow.apache.org/docs/index.html)
 
 You may be familiar with [pandas](https://pandas.pydata.org/), which is a
@@ -26,16 +47,15 @@ classes in the python binding of Arrow:
 
 ## How datasets work
 
-Each dataset contains one table. When a dataset is created, the table schema is
-automatically inferred from the first row of data written. This allows for
-flexible data collection without requiring manual schema definition.
+When a dataset is created, the table schema is automatically inferred from the
+first row of data written. This allows for flexible data collection without
+requiring manual schema definition.
 
 ## Write batching
 
 Dataset writes are buffered automatically. This keeps the write API row-oriented
-while reducing transport overhead for larger ingests. Calling `finish()`,
-`abort()`, or dropping the writer flushes any pending rows before the dataset
-stream is finalized.
+while reducing transport overhead for larger ingests. The exact buffering
+thresholds are implementation details.
 
 ## Type inference
 


### PR DESCRIPTION
## Summary
- Split public user docs from internal maintainer docs and added a canonical `dev-docs/` index
- Moved checklist, release, architecture, and storage guidance into focused developer playbooks
- Updated skill and repo guidance to point at the new canonical docs and reduce path ambiguity
- Tightened public dataset docs to reflect the current contract and removed stale TODO-style content

## Testing
- `pnpm run format` and `pnpm run format:check` passed
- `uv run --group docs mkdocs build -s -v` passed
- `git diff --check` passed
- Documentation cleanup scans found no remaining `TODO`, `FIXME`, or `TBD` markers