### PR TITLE
docs: add roadmap alignment and issue planning skills

### DIFF
--- a/.agents/skills/issue-planning/SKILL.md
+++ b/.agents/skills/issue-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-planning
-description: Convert Fricon roadmap items, product requirements, or milestone ideas into small GitHub issues or task plans suitable for solo development and low-conflict parallel Codex threads. Use when the user asks to create an issue plan, decompose roadmap work, align roadmap with issues/tasks, prepare parallel PR tasks, or create GitHub issues from product direction.
+description: Convert already-aligned Fricon roadmap items or milestones into small GitHub-ready issues or task plans for low-conflict Codex work. Use only when the user explicitly asks to create an issue plan, decompose roadmap work into tasks, align roadmap with issues/tasks, prepare parallel PR tasks, or create GitHub issues. Do not trigger for product brainstorming, roadmap editing, ordinary implementation, or PR preflight.
 ---
 
 # Issue Planning
@@ -10,6 +10,14 @@ description: Convert Fricon roadmap items, product requirements, or milestone id
 Act as the missing lightweight project-manager layer for a solo Fricon
 maintainer. Turn roadmap direction into small, reviewable, low-conflict tasks
 without starting implementation.
+
+## Trigger Boundaries
+
+Use this skill only after the product direction is already clear enough to plan
+tasks. If the user is still deciding what the product should do or where an
+idea belongs in the roadmap, use `roadmap-alignment` first. If the user asks to
+implement issue `#xxx`, do not use this skill unless they also ask to re-plan
+or split that issue.
 
 ## Path Resolution
 
@@ -39,7 +47,8 @@ When planning a UI-heavy milestone, also read:
 ## Workflow
 
 1. Confirm the planning target: roadmap area, milestone, product idea, or issue
-   theme. If the target is ambiguous, make a conservative default and state it.
+   theme. If the target is not aligned with `roadmap.md` yet, stop and use
+   `roadmap-alignment` first.
 2. Identify dependencies and whether any ADR or design note is needed before
    implementation.
 3. Split work into issues that are each suitable for one focused pull request.

--- a/.agents/skills/issue-planning/SKILL.md
+++ b/.agents/skills/issue-planning/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: issue-planning
+description: Convert Fricon roadmap items, product requirements, or milestone ideas into small GitHub issues or task plans suitable for solo development and low-conflict parallel Codex threads. Use when the user asks to create an issue plan, decompose roadmap work, align roadmap with issues/tasks, prepare parallel PR tasks, or create GitHub issues from product direction.
+---
+
+# Issue Planning
+
+## Objective
+
+Act as the missing lightweight project-manager layer for a solo Fricon
+maintainer. Turn roadmap direction into small, reviewable, low-conflict tasks
+without starting implementation.
+
+## Path Resolution
+
+Repository paths are relative to the repository root (`<project_root>`).
+
+## Required Context
+
+Read these first:
+
+- `<project_root>/dev-docs/project-intent.md`
+- `<project_root>/dev-docs/roadmap.md`
+- `<project_root>/dev-docs/README.md`
+- `<project_root>/dev-docs/pr-preflight-checklist.md`
+- `<project_root>/dev-docs/maintenance-checklist.md`
+
+When planning dataset semantics work, also read:
+
+- `<project_root>/dev-docs/current-storage-notes.md`
+- `<project_root>/dev-docs/dataset-semantic-architecture-proposal.md`
+- `<project_root>/dev-docs/dataset-semantic-implementation-plan.md`
+
+When planning a UI-heavy milestone, also read:
+
+- `<project_root>/dev-docs/desktop-ui-feature-playbook.md`
+- `<project_root>/dev-docs/testing-strategy.md`
+
+## Workflow
+
+1. Confirm the planning target: roadmap area, milestone, product idea, or issue
+   theme. If the target is ambiguous, make a conservative default and state it.
+2. Identify dependencies and whether any ADR or design note is needed before
+   implementation.
+3. Split work into issues that are each suitable for one focused pull request.
+4. Prefer dependency order that preserves the current route:
+   dataset semantics -> inspection/Python usability -> run records/parameters
+   -> provenance -> workflows/scheduler -> AI automation -> device integration.
+5. Mark each issue as one of:
+   - `backend`
+   - `Python API`
+   - `desktop UI`
+   - `docs`
+   - `tests`
+   - `cross-boundary`
+   - `ADR/design`
+6. For each issue, list:
+   - goal
+   - scope
+   - out of scope
+   - likely touched files or modules
+   - dependencies or blockers
+   - parallelization risk: `low`, `medium`, or `high`
+   - validation commands or checklist sections
+   - expected PR shape
+7. Keep issues small. Split when an issue crosses unrelated feature slices,
+   requires both design and implementation, or would block several parallel
+   Codex threads.
+8. If the user asks to create GitHub issues, use the GitHub connector when
+   available. Otherwise produce a markdown issue plan that can be reviewed
+   before creation.
+
+## Parallel Work Guidance
+
+- Low-risk parallel issues should touch distinct files or feature slices.
+- High-conflict files include central docs, generated bindings, database schema,
+  migration files, IPC/gRPC contracts, and shared frontend app shells.
+- Cross-boundary changes need explicit checklist references and should usually
+  be sequenced before dependent UI or Python API issues.
+- If two tasks need the same high-conflict file, make one a blocking foundation
+  issue or split out a shared preparatory issue.
+
+## Issue Template
+
+```markdown
+## Goal
+
+## Scope
+
+## Out Of Scope
+
+## Likely Files Or Modules
+
+## Dependencies
+
+## Parallelization Risk
+
+## Validation
+
+## PR Shape
+```
+
+## Output Contract
+
+Return:
+
+- milestone or planning theme
+- ordered issue list
+- dependency notes
+- parallelization recommendations
+- ADR/design tasks that should happen before implementation
+- issues created, if GitHub issue creation was requested and completed

--- a/.agents/skills/issue-planning/agents/openai.yaml
+++ b/.agents/skills/issue-planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Planning"
+  short_description: "Turn Fricon roadmap work into small low-conflict issues"
+  default_prompt: "Use $issue-planning to turn this roadmap item into small GitHub-ready issues with dependencies and validation."

--- a/.agents/skills/roadmap-alignment/SKILL.md
+++ b/.agents/skills/roadmap-alignment/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: roadmap-alignment
+description: Align Fricon product ideas, requirement discussions, and proposed docs changes with the current product route, roadmap, existing proposals, and current implementation state. Use when the user asks to discuss product requirements, decide whether an idea belongs in now/next/later/non-goals, update roadmap or project-intent docs, or check whether a future concept conflicts with current dataset semantics work.
+---
+
+# Roadmap Alignment
+
+## Objective
+
+Help a solo maintainer turn product ideas into clear project direction without
+confusing future concepts with current behavior.
+
+## Path Resolution
+
+Repository paths are relative to the repository root (`<project_root>`).
+
+## Required Context
+
+Read these first:
+
+- `<project_root>/dev-docs/project-intent.md`
+- `<project_root>/dev-docs/roadmap.md`
+- `<project_root>/dev-docs/README.md`
+
+When the idea touches current dataset behavior, storage, or semantics, also
+read:
+
+- `<project_root>/docs/concepts.md`
+- `<project_root>/docs/dataset.md`
+- `<project_root>/dev-docs/current-storage-notes.md`
+- `<project_root>/dev-docs/dataset-semantic-architecture-proposal.md`
+- `<project_root>/dev-docs/dataset-semantic-implementation-plan.md`
+
+For cross-boundary implementation implications, check:
+
+- `<project_root>/dev-docs/maintenance-checklist.md`
+- `<project_root>/dev-docs/pr-preflight-checklist.md`
+- `<project_root>/dev-docs/adr/README.md`
+
+## Workflow
+
+1. Identify whether the user wants discussion only, documentation edits, issue
+   planning, or implementation. Do not implement product ideas during roadmap
+   alignment unless explicitly asked.
+2. Restate the idea in Fricon terms: user value, affected product pillar, and
+   likely user surface.
+3. Classify the idea:
+   - `current behavior`
+   - `now`
+   - `next`
+   - `after dataset semantics`
+   - `future concept`
+   - `explicit non-goal`
+   - `ADR needed before implementation`
+4. Check for conflicts with the dataset-first, Python-led, local-first route.
+5. Check whether the idea depends on current dataset semantics proposal work.
+6. If docs should change, update the smallest appropriate files:
+   - `project-intent.md` for durable product direction and design principles
+   - `roadmap.md` for sequencing, future concepts, or core model pressure
+   - `README.md` only for index/navigation changes
+   - ADRs only for settled, durable, cross-cutting decisions
+7. Keep future concepts clearly marked as future. Do not write proposal content
+   as current behavior until implementation and current docs have caught up.
+
+## Classification Guidance
+
+- Dataset semantics, resolved interpretation, and chart meaning belong before
+  higher-level experiment/workflow/AI automation work.
+- Parameter, workflow, device, provenance, and AI concepts should not be hidden
+  inside dataset names, incidental metadata, or chart heuristics.
+- Workflow definitions are above experiment runs.
+- AI integration is a cross-cutting automation layer with review and audit
+  boundaries for mutating actions.
+- Device management remains later unless a concrete workflow requires minimal
+  device identity or configuration snapshots.
+
+## Output Contract
+
+For discussion-only requests, return:
+
+- classification
+- why it belongs there
+- current docs or proposals it relates to
+- open questions
+- recommended next action
+
+For documentation-edit requests, return:
+
+- files changed
+- what changed
+- whether any idea remains future-only or ADR-needed
+- whether tests were skipped because the change is docs-only

--- a/.agents/skills/roadmap-alignment/SKILL.md
+++ b/.agents/skills/roadmap-alignment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-alignment
-description: Align Fricon product ideas, requirement discussions, and proposed docs changes with the current product route, roadmap, existing proposals, and current implementation state. Use when the user asks to discuss product requirements, decide whether an idea belongs in now/next/later/non-goals, update roadmap or project-intent docs, or check whether a future concept conflicts with current dataset semantics work.
+description: Align Fricon product ideas with the existing product route and docs. Use only when the user explicitly asks to discuss product requirements, align an idea with the roadmap, classify an idea as now/next/later/non-goal/ADR-needed, or update `dev-docs/project-intent.md` or `dev-docs/roadmap.md`. Do not trigger for ordinary implementation, bug fixing, PR preflight, or GitHub issue decomposition.
 ---
 
 # Roadmap Alignment
@@ -9,6 +9,14 @@ description: Align Fricon product ideas, requirement discussions, and proposed d
 
 Help a solo maintainer turn product ideas into clear project direction without
 confusing future concepts with current behavior.
+
+## Trigger Boundaries
+
+Use this skill only for product-direction alignment and roadmap/project-intent
+documentation. If the user asks to decompose work into tasks, create GitHub
+issues, or plan parallel PRs, use `issue-planning` instead. If the user asks to
+implement an existing issue or code change, do not use this skill unless the
+issue explicitly requires roadmap or product-intent alignment.
 
 ## Path Resolution
 
@@ -39,9 +47,10 @@ For cross-boundary implementation implications, check:
 
 ## Workflow
 
-1. Identify whether the user wants discussion only, documentation edits, issue
-   planning, or implementation. Do not implement product ideas during roadmap
-   alignment unless explicitly asked.
+1. Identify whether the user wants discussion only or documentation edits. If
+   the user wants issue decomposition, hand off to `issue-planning`. If the
+   user wants implementation, proceed with normal coding workflow unless
+   product alignment is explicitly requested.
 2. Restate the idea in Fricon terms: user value, affected product pillar, and
    likely user surface.
 3. Classify the idea:

--- a/.agents/skills/roadmap-alignment/agents/openai.yaml
+++ b/.agents/skills/roadmap-alignment/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roadmap Alignment"
+  short_description: "Align product ideas with Fricon roadmap and current state"
+  default_prompt: "Use $roadmap-alignment to classify this product idea against the current Fricon roadmap and update docs if appropriate."

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -32,6 +32,7 @@ every canonical document.
 | Workspace format or metadata compatibility | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Architecture background unless boundary design is unclear              |
 | Rust IPC/gRPC contract compatibility       | `maintenance-checklist.md`               | `pr-preflight-checklist.md`, `release-and-versioning.md`                                          | Public docs unless behavior is user-visible                            |
 | Public dataset docs update                 | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only                                 | Implementation plan details unless landed behavior is being documented |
+| Product route or issue planning            | `roadmap.md`                             | `project-intent.md`, proposal or implementation-plan files for affected areas                     | Treating roadmap future concepts as current implementation facts       |
 
 ## Canonical Guidance
 
@@ -40,8 +41,8 @@ skills, prompts, or contributor notes.
 
 - `project-intent.md` - product direction, target users, non-goals, and AI
   guardrails
-- `roadmap.md` - AI-oriented product route, sequencing, and decision pressure
-  map
+- `roadmap.md` - AI-oriented product route, sequencing, relationship to current
+  state, and decision pressure map
 - `maintenance-checklist.md` - coordinated update checklist for cross-boundary
   changes
 - `pr-preflight-checklist.md` - local and pre-PR validation matrix

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -40,8 +40,8 @@ skills, prompts, or contributor notes.
 
 - `project-intent.md` - product direction, target users, non-goals, and AI
   guardrails
-- `roadmap.md` - lightweight AI-oriented project direction and decision
-  pressure map
+- `roadmap.md` - AI-oriented product route, sequencing, and decision pressure
+  map
 - `maintenance-checklist.md` - coordinated update checklist for cross-boundary
   changes
 - `pr-preflight-checklist.md` - local and pre-PR validation matrix

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -15,9 +15,10 @@ not public user docs. Public user-facing docs live in `docs/`.
 Start here when orienting a new human or AI contributor:
 
 1. `project-intent.md`
-2. `maintenance-checklist.md`
-3. `pr-preflight-checklist.md`
-4. The topic-specific note for the area being changed
+2. `roadmap.md`
+3. `maintenance-checklist.md`
+4. `pr-preflight-checklist.md`
+5. The topic-specific note for the area being changed
 
 For narrow tasks, prefer the task-specific starting points below over reading
 every canonical document.
@@ -39,6 +40,8 @@ skills, prompts, or contributor notes.
 
 - `project-intent.md` - product direction, target users, non-goals, and AI
   guardrails
+- `roadmap.md` - lightweight AI-oriented project direction and decision
+  pressure map
 - `maintenance-checklist.md` - coordinated update checklist for cross-boundary
   changes
 - `pr-preflight-checklist.md` - local and pre-PR validation matrix
@@ -68,6 +71,8 @@ checklist, policy, or guideline.
 
 - `architecture-ai-notes.md` - architecture discussion and AI-assisted
   maintainability guidance
+- `adr/` - durable architecture decision records for settled cross-cutting
+  decisions
 
 ## Proposals And Plans
 
@@ -86,3 +91,7 @@ implementation facts unless the implementation has already landed.
   guidance in `dev-docs/`.
 - When a proposal becomes current behavior, update or split the proposal so
   current facts live in a current implementation note.
+- Keep `roadmap.md` short and directional; move detailed execution steps into
+  focused implementation plans.
+- Add ADRs selectively for durable decisions, not for routine local
+  implementation choices.

--- a/dev-docs/adr/0001-record-architecture-decisions.md
+++ b/dev-docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,45 @@
+# ADR 0001: Record Architecture Decisions
+
+## Status
+
+Accepted
+
+## Context
+
+Fricon has several design choices that affect Rust crates, Python bindings,
+desktop UI behavior, workspace storage, and compatibility policy. Existing
+developer docs already separate current implementation notes, proposals,
+maintenance checklists, and AI-assisted architecture guidance.
+
+As the project grows, durable decisions need a stable home so future human and
+AI contributors do not have to infer settled direction from old proposals,
+discussion notes, or implementation details.
+
+## Decision
+
+The project will keep architecture decision records under `dev-docs/adr/`.
+
+ADRs should be used selectively for durable, cross-cutting decisions. They
+should not replace implementation plans, current implementation notes, or
+release guidance.
+
+## Consequences
+
+Future durable decisions can be linked from roadmap, architecture, maintenance,
+and implementation documents without duplicating full rationale.
+
+Contributors should avoid treating every local code choice as an ADR-worthy
+decision. The ADR directory should stay small enough to remain useful as an
+orientation tool.
+
+When an ADR becomes outdated, add a new ADR that supersedes it instead of
+silently rewriting history.
+
+## Alternatives Considered
+
+Keeping all rationale in topic-specific notes would avoid another directory,
+but it would make durable decisions harder to discover once proposals and
+implementation plans accumulate.
+
+Using issues or pull requests as the only decision log would preserve history,
+but it would be too scattered for low-context contributors and AI agents.

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -1,0 +1,78 @@
+# Architecture Decision Records
+
+## Status
+
+Index and rules for durable architecture decision records.
+
+## Purpose
+
+Use ADRs to preserve important decisions after the project has chosen a
+direction. ADRs should explain why a decision was made, what alternatives were
+considered, and what consequences future work must respect.
+
+ADRs are not task plans, meeting notes, or design brainstorms. Use
+`dev-docs/roadmap.md` for coarse direction and focused proposal or
+implementation-plan files for unresolved work.
+
+## When To Add An ADR
+
+Add an ADR when a decision is:
+
+- durable enough to guide future changes
+- cross-cutting across crates, APIs, storage, IPC, or UI/runtime boundaries
+- likely to be rediscovered by future human or AI contributors
+- important enough that reversing it would require coordinated migration work
+
+Do not add an ADR for:
+
+- routine implementation details
+- temporary workarounds
+- narrow refactors contained in one feature slice
+- proposals that are still exploratory
+
+## Naming
+
+Use a monotonically increasing four-digit prefix:
+
+```text
+0001-record-architecture-decisions.md
+0002-example-decision-title.md
+```
+
+Use lowercase kebab-case after the number.
+
+## ADR Format
+
+Each ADR should use this structure:
+
+```markdown
+# ADR 0000: Decision Title
+
+## Status
+
+Accepted | Superseded by ADR 0000 | Deprecated
+
+## Context
+
+What problem, constraint, or recurring question forced the decision?
+
+## Decision
+
+What has the project decided?
+
+## Consequences
+
+What becomes easier, harder, required, or intentionally unsupported?
+
+## Alternatives Considered
+
+What plausible options were rejected, and why?
+```
+
+Keep ADRs concise. Link to deeper design notes or implementation plans instead
+of copying their full contents.
+
+## Index
+
+- `0001-record-architecture-decisions.md` - establishes when and how this
+  project records ADRs

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -197,6 +197,7 @@ Use this when changing public docs, developer docs, or repo guidance.
 - Run:
 
 ```bash
+pnpm run format:check
 uv run --group docs mkdocs build -s -v
 ```
 

--- a/dev-docs/pr-preflight-checklist.md
+++ b/dev-docs/pr-preflight-checklist.md
@@ -110,6 +110,7 @@ git diff --exit-code crates/fricon-ui/frontend/src/routeTree.gen.ts
 ### Docs-Only
 
 ```bash
+pnpm run format:check
 uv run --group docs mkdocs build -s -v
 ```
 
@@ -188,6 +189,7 @@ Use the normal Rust test gate for coverage, then apply the IPC/gRPC checklist in
 ### Docs
 
 ```bash
+pnpm run format:check
 uv run --group docs mkdocs build -s -v
 ```
 

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -143,6 +143,14 @@ user model.
 When records need correction, prefer appended correction or event history over
 silent mutation of completed run facts.
 
+### Leave Room For Core Scientific Entities
+
+Some concepts may be implemented later but should influence early model
+boundaries because they are expensive to retrofit. Dataset, run, and parameter
+work should leave room for units and display metadata, sample or specimen
+identity, dataset lineage, parameter snapshots, workflow definitions, local
+automation approvals, and event or audit logs.
+
 ### Make Advanced Workflows Explicit
 
 Experiment execution, parameter management, and device management should become
@@ -201,6 +209,10 @@ These questions are intentionally unresolved:
   sweep definitions, or versioned experiment configurations?
 - How should parameter history and version comparison be represented in the
   Python API and desktop UI?
+- What unit and display metadata belongs on dataset columns, parameters, or
+  both?
+- How should sample or specimen identity be represented without overbuilding a
+  lab inventory system?
 - Which run facts should be immutable, and which should allow correction
   events?
 - How much dataset lineage is needed for measured, processed, simulation, and

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -39,6 +39,10 @@ Fricon is expected to provide:
 - Python APIs for scripting and automation
 - reproducibility support for experiment code, environments, parameters, and
   generated datasets
+- workflow definitions above individual experiments for repeated calibration,
+  optimization, and benchmark tasks
+- AI-assisted automation for repetitive scientific data-management work, with
+  explicit review and auditability for mutating actions
 
 The product should make common scientific measurement workflows easier while
 remaining scriptable for users who already use Python in their research.
@@ -61,6 +65,16 @@ Device management should remain a later foundation. Near-term design may keep
 room for device identity and configuration, but should avoid building a broad
 driver framework or hardware orchestration layer before real workflows require
 one.
+
+Workflow automation should be treated as a layer above individual experiments.
+It can eventually coordinate scheduled calibration, optimization, benchmark,
+and repeated measurement tasks, but should rely on clear run records, parameter
+snapshots, provenance, and human approval boundaries.
+
+AI-assisted workflows should be designed as assistive automation rather than
+silent authority. AI may help draft snippets, summaries, reports, metadata
+cleanup, parameter comparisons, and workflow proposals, but mutating workspace
+state should remain explicit, reviewable, and auditable.
 
 ## Runtime Model
 
@@ -113,6 +127,22 @@ For example, dataset detail views may eventually provide Python read snippets
 that reopen selected datasets through the public API without exposing internal
 storage paths.
 
+Quality-of-life features should make common scientific work faster without
+changing the user's mental model. Good candidates include preview/export
+snippets, saved views, aliases, notes, tags, quality flags, compare views, and
+template experiments.
+
+### Preserve Provenance
+
+Scientific workflows need enough traceability to explain where a result came
+from. Fricon should be able to connect runs, datasets, parameters, code
+versions, environments, device configuration, notes, imports, exports, and
+future workflow definitions without exposing internal storage details as the
+user model.
+
+When records need correction, prefer appended correction or event history over
+silent mutation of completed run facts.
+
 ### Make Advanced Workflows Explicit
 
 Experiment execution, parameter management, and device management should become
@@ -129,6 +159,17 @@ environment management. Git-backed code history, including a workspace-managed
 bare repository, and environment tools such as `uv` or `pixi` are plausible
 directions, but they should be designed as explicit product capabilities rather
 than hidden side effects of dataset writes.
+
+Workflow definitions may eventually orchestrate repeated experiment execution,
+scheduled calibration, parameter optimization, and benchmark runs. These
+capabilities should record workflow versions, triggers, inputs, outputs,
+approval checkpoints, failures, and manual overrides.
+
+AI model integration may eventually automate boring or repetitive work, but
+should not bypass product boundaries. AI-generated changes to data,
+parameters, code, workflow definitions, or execution plans should leave
+auditable records and require user approval unless the operation is explicitly
+designed as safe and reversible.
 
 ### Keep Architecture Proportional
 
@@ -160,10 +201,22 @@ These questions are intentionally unresolved:
   sweep definitions, or versioned experiment configurations?
 - How should parameter history and version comparison be represented in the
   Python API and desktop UI?
+- Which run facts should be immutable, and which should allow correction
+  events?
+- How much dataset lineage is needed for measured, processed, simulation, and
+  imported datasets?
 - How should experiment code history be captured without surprising users or
   turning Fricon into a general Git client?
 - What level of automatic `uv` or `pixi` environment management is useful
   without making experiment setup opaque?
+- What should a workflow definition contain beyond a Python entry point,
+  parameters, schedules, approval checkpoints, and expected outputs?
+- Which calibration, optimization, and benchmark tasks should be first-class
+  workflow types?
+- Which AI actions should be suggestion-only, which may mutate workspace state,
+  and what approval or audit metadata should each class require?
+- What AI model/provider/version and prompt-summary metadata is needed for
+  reproducibility without storing unnecessary sensitive context?
 - What level of device abstraction is useful without overbuilding a hardware
   framework?
 - Which data formats and array shapes should be first-class beyond the current

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -32,14 +32,35 @@ Fricon is expected to provide:
 
 - data recording
 - experiment execution
-- parameter management
+- parameter management, including future history and versioning workflows
 - device management
 - local experiment workspace management
 - a desktop UI for browsing, managing, and inspecting collected data
 - Python APIs for scripting and automation
+- reproducibility support for experiment code, environments, parameters, and
+  generated datasets
 
 The product should make common scientific measurement workflows easier while
 remaining scriptable for users who already use Python in their research.
+
+## Current Product Route
+
+The current route is dataset-first, Python-led, and local-first.
+
+Fricon should first become reliable for recording, organizing, and inspecting
+scientific measurement datasets. Dataset semantics should be explicit enough
+that later experiment, parameter, and device concepts do not have to be hidden
+inside dataset names, incidental metadata, or chart heuristics.
+
+Initial experiment support should lean on Python scripts as the execution
+entry point. The desktop UI should browse, inspect, and eventually assist those
+workflows, but should not become the primary experiment execution engine before
+the Python-led model is clear.
+
+Device management should remain a later foundation. Near-term design may keep
+room for device identity and configuration, but should avoid building a broad
+driver framework or hardware orchestration layer before real workflows require
+one.
 
 ## Runtime Model
 
@@ -87,11 +108,27 @@ The Python API is a primary user surface. It should support straightforward
 data collection scripts without forcing users to predefine every low-level
 schema detail.
 
+Desktop and documentation workflows should help users get back to Python code.
+For example, dataset detail views may eventually provide Python read snippets
+that reopen selected datasets through the public API without exposing internal
+storage paths.
+
 ### Make Advanced Workflows Explicit
 
 Experiment execution, parameter management, and device management should become
 explicit product concepts as they mature. Avoid hiding those semantics inside
 dataset naming conventions or incidental metadata.
+
+The first explicit experiment model should be Python-led: user scripts perform
+measurement work while Fricon records datasets, run metadata, and parameters.
+UI-led execution can be introduced later if the Python-led workflow proves too
+limited.
+
+Experiment reproducibility may eventually include automatic code history and
+environment management. Git-backed code history, including a workspace-managed
+bare repository, and environment tools such as `uv` or `pixi` are plausible
+directions, but they should be designed as explicit product capabilities rather
+than hidden side effects of dataset writes.
 
 ### Keep Architecture Proportional
 
@@ -108,6 +145,8 @@ This document is a constraint for AI-assisted changes:
 - Keep user-facing docs focused on workflows and stable product concepts.
 - Put implementation details, architectural notes, and maintenance rules in
   `dev-docs/`.
+- Preserve the dataset-first, Python-led product route unless a planning or ADR
+  document explicitly changes it.
 - Prefer feature-local changes that preserve clear ownership.
 - Treat Python API and desktop UI behavior as user-facing contracts.
 - Treat internal Rust module boundaries as changeable when doing so improves
@@ -117,10 +156,14 @@ This document is a constraint for AI-assisted changes:
 
 These questions are intentionally unresolved:
 
-- What experiment execution model should Fricon support first: script-driven,
-  UI-driven, or a hybrid?
 - How should parameters be represented: flat key-value sets, typed schemas,
   sweep definitions, or versioned experiment configurations?
+- How should parameter history and version comparison be represented in the
+  Python API and desktop UI?
+- How should experiment code history be captured without surprising users or
+  turning Fricon into a general Git client?
+- What level of automatic `uv` or `pixi` environment management is useful
+  without making experiment setup opaque?
 - What level of device abstraction is useful without overbuilding a hardware
   framework?
 - Which data formats and array shapes should be first-class beyond the current

--- a/dev-docs/roadmap.md
+++ b/dev-docs/roadmap.md
@@ -1,9 +1,10 @@
-# Lightweight Roadmap
+# Product Roadmap
 
 ## Status
 
-AI-oriented planning note. This file is intentionally lightweight and should not
-replace issues, pull requests, implementation plans, or release notes.
+AI-oriented product planning note. This file is intentionally lightweight and
+should not replace issues, pull requests, implementation plans, or release
+notes.
 
 ## Purpose
 
@@ -15,11 +16,40 @@ implementation facts.
 Keep this file short. If an item needs step-by-step execution details, put those
 details in a focused implementation plan and link it from here.
 
+## Product Route
+
+The current route is dataset-first, Python-led, and local-first.
+
+Fricon should first become reliable for recording, organizing, and inspecting
+scientific measurement datasets. Experiment, parameter, and device concepts
+should build on that foundation instead of forcing the dataset layer to absorb
+higher-level workflow meaning implicitly.
+
+Initial experiment support should lean on Python scripts as the execution
+entry point. The desktop UI should inspect, browse, and eventually assist those
+workflows, but it should not become the primary experiment execution engine
+before the Python-led model is clear.
+
+Device management remains a later foundation. Near-term work may preserve space
+for device identity and configuration, but should not build a broad driver or
+hardware orchestration framework.
+
+## Product Pillars
+
+- Workspace and dataset management
+- Dataset semantics and durable interpretation
+- Desktop dataset browsing, inspection, and charting
+- Python scripting API for data recording and automation
+- Python-led experiment and parameter workflows
+- Reproducibility support for experiment code and environments
+- Later device identity and configuration foundations
+
 ## Now
 
 Current work should favor:
 
 - stabilizing the local-first workspace and dataset experience
+- landing the minimal durable dataset semantic model
 - keeping Python API and desktop UI behavior coherent as user-facing contracts
 - preserving clear vertical slice boundaries across Rust, Python bindings, and
   the frontend
@@ -36,8 +66,9 @@ Start with:
 
 ## Next
 
-Near-term direction should clarify and land the dataset semantic model without
-turning proposals into assumed implementation facts before the code catches up.
+Near-term direction should clarify and land the dataset semantic model, then
+make the desktop UI consume resolved dataset interpretation instead of
+rediscovering chart meaning from row heuristics.
 
 Relevant notes:
 
@@ -46,18 +77,76 @@ Relevant notes:
 - `database-schema-changes.md`
 - `release-and-versioning.md`
 
+## After Dataset Semantics
+
+After the dataset foundation is durable, product work should move toward:
+
+- richer desktop inspection and charting workflows
+- dataset read snippets that help users reopen or reproduce analysis from
+  Python
+- Python-led experiment run records
+- parameter capture and display for recorded runs
+- a minimal model for connecting runs to datasets
+
+This phase should avoid turning experiment support into a desktop-first
+workflow engine too early. Python scripts should remain the first-class way to
+run scientific measurement code.
+
+## Future Product Concepts
+
+These ideas are promising, but not current implementation commitments. Convert
+them into focused design notes, issues, or ADRs before implementation if the
+details affect storage, API contracts, or user workflows.
+
+Parameter management may grow beyond static run metadata into:
+
+- parameter history views
+- plotting parameter values across runs or time
+- parameter versioning for experiment configurations
+- links between parameter versions, runs, and generated datasets
+
+Experiment code management may support local reproducibility features such as:
+
+- automatic history tracking for experiment code
+- Git-backed storage, possibly using a bare repository managed inside the
+  workspace
+- automatic environment capture or setup using tools such as `uv` or `pixi`
+- clear links between a run, the code version, the environment, parameters, and
+  produced datasets
+
+Dataset usability may include:
+
+- generated Python read snippets for each dataset
+- copyable examples for loading selected datasets by workspace-local ID or UID
+- snippets that match the public Python API instead of exposing internal
+  storage layout
+
 ## Later
 
 Longer-term product direction includes explicit concepts for:
 
-- experiment execution
-- parameter management
-- device management
-- richer desktop inspection workflows
-- Python scripting and automation around those concepts
+- UI-assisted experiment execution
+- richer parameter schemas and sweep definitions
+- parameter history and version comparison workflows
+- experiment code and environment history management
+- device identity and configuration
+- device integration points once real workflows justify them
 
 Keep these ideas aligned with `project-intent.md`. Do not let future remote,
 multi-user, or SaaS possibilities drive the current local-first architecture.
+
+## Issue Planning Guidance
+
+When generating GitHub issues from this roadmap:
+
+- split work by product pillar and owning code area
+- keep each issue small enough for one focused pull request
+- mark whether the issue is backend, Python API, desktop UI, docs, or
+  cross-boundary
+- list likely touched files or modules when known
+- list required validation commands from `pr-preflight-checklist.md`
+- create an ADR task before implementation when a durable cross-cutting
+  decision is still unresolved
 
 ## Explicit Non-Goals For Current Work
 
@@ -81,5 +170,6 @@ be rediscovered or relitigated later. Good ADR candidates include:
 - Python API contract decisions
 - desktop/runtime architecture decisions
 - experiment, parameter, or device model foundations
+- experiment code history and environment management foundations
 
 Use `dev-docs/adr/README.md` for ADR rules and format.

--- a/dev-docs/roadmap.md
+++ b/dev-docs/roadmap.md
@@ -1,0 +1,85 @@
+# Lightweight Roadmap
+
+## Status
+
+AI-oriented planning note. This file is intentionally lightweight and should not
+replace issues, pull requests, implementation plans, or release notes.
+
+## Purpose
+
+Use this roadmap to orient low-context human or AI contributors before choosing
+implementation work. It summarizes project direction at a coarse level and
+links to the documents that contain detailed policy, plans, or current
+implementation facts.
+
+Keep this file short. If an item needs step-by-step execution details, put those
+details in a focused implementation plan and link it from here.
+
+## Now
+
+Current work should favor:
+
+- stabilizing the local-first workspace and dataset experience
+- keeping Python API and desktop UI behavior coherent as user-facing contracts
+- preserving clear vertical slice boundaries across Rust, Python bindings, and
+  the frontend
+- keeping current implementation notes accurate when storage, IPC, or workspace
+  behavior changes
+
+Start with:
+
+- `project-intent.md`
+- `architecture-guidelines.md`
+- `current-storage-notes.md`
+- `maintenance-checklist.md`
+- `pr-preflight-checklist.md`
+
+## Next
+
+Near-term direction should clarify and land the dataset semantic model without
+turning proposals into assumed implementation facts before the code catches up.
+
+Relevant notes:
+
+- `dataset-semantic-architecture-proposal.md`
+- `dataset-semantic-implementation-plan.md`
+- `database-schema-changes.md`
+- `release-and-versioning.md`
+
+## Later
+
+Longer-term product direction includes explicit concepts for:
+
+- experiment execution
+- parameter management
+- device management
+- richer desktop inspection workflows
+- Python scripting and automation around those concepts
+
+Keep these ideas aligned with `project-intent.md`. Do not let future remote,
+multi-user, or SaaS possibilities drive the current local-first architecture.
+
+## Explicit Non-Goals For Current Work
+
+Do not treat these as active roadmap items unless the project direction changes
+explicitly:
+
+- multi-user collaboration
+- hosted SaaS operation
+- account, team, role, or permission systems
+- distributed database semantics
+- web-first deployment as the primary experience
+
+## Decision Pressure
+
+Create or update an ADR when a decision is durable, cross-cutting, and likely to
+be rediscovered or relitigated later. Good ADR candidates include:
+
+- workspace and storage format compatibility
+- dataset semantic model commitments
+- IPC or gRPC compatibility policy
+- Python API contract decisions
+- desktop/runtime architecture decisions
+- experiment, parameter, or device model foundations
+
+Use `dev-docs/adr/README.md` for ADR rules and format.

--- a/dev-docs/roadmap.md
+++ b/dev-docs/roadmap.md
@@ -34,6 +34,16 @@ Device management remains a later foundation. Near-term work may preserve space
 for device identity and configuration, but should not build a broad driver or
 hardware orchestration framework.
 
+Workflow definitions are a later layer above individual experiments. They may
+eventually coordinate repeated runs, scheduled calibration, optimization, and
+benchmark tasks, but should build on run records, parameter snapshots, and
+provenance first.
+
+AI integration is a cross-cutting automation layer. It should help with
+repetitive scientific data-management work, but actions that mutate data,
+parameters, code, workflow definitions, or execution plans should require clear
+user review and durable audit records.
+
 ## Product Pillars
 
 - Workspace and dataset management
@@ -42,6 +52,9 @@ hardware orchestration framework.
 - Python scripting API for data recording and automation
 - Python-led experiment and parameter workflows
 - Reproducibility support for experiment code and environments
+- Traceability across runs, datasets, parameters, code, and environments
+- Workflow definitions and scheduled automation
+- AI-assisted automation with explicit review and auditability
 - Later device identity and configuration foundations
 
 ## Now
@@ -84,9 +97,13 @@ After the dataset foundation is durable, product work should move toward:
 - richer desktop inspection and charting workflows
 - dataset read snippets that help users reopen or reproduce analysis from
   Python
+- dataset preview, export, and plotting snippets for common Python workflows
+- lightweight run notes, tags, favorites, and quality flags
 - Python-led experiment run records
-- parameter capture and display for recorded runs
+- parameter snapshots, diffs, and display for recorded runs
 - a minimal model for connecting runs to datasets
+- basic run provenance links between datasets, parameters, code, environment,
+  and notes
 
 This phase should avoid turning experiment support into a desktop-first
 workflow engine too early. Python scripts should remain the first-class way to
@@ -118,8 +135,67 @@ Dataset usability may include:
 
 - generated Python read snippets for each dataset
 - copyable examples for loading selected datasets by workspace-local ID or UID
+- preview snippets for pandas, pyarrow, plotting, CSV export, and Parquet export
 - snippets that match the public Python API instead of exposing internal
   storage layout
+- saved table and chart views
+- dataset aliases for important datasets
+- compare views for selected datasets or runs
+
+Scientific quality-of-life features may include:
+
+- run notes for manual observations and experimental context
+- quick tags, favorites, and filters for datasets, runs, and parameter sets
+- data quality flags such as good, suspect, failed, calibration, or test run
+- calibration records linked to runs, parameters, and device configuration
+- unit, label, precision, and display-scale metadata for parameters and dataset
+  columns
+- template experiments that copy parameter structure, code entry points, and
+  output dataset conventions from previous work
+
+Traceability and reproducibility may include:
+
+- a provenance graph from workflow to run, datasets, parameters, code version,
+  environment, device configuration, notes, imports, and exports
+- immutable run records with later corrections recorded as appended events
+- a workspace event timeline for dataset, run, parameter, import, export, and
+  automation events
+- parameter snapshots for each run and parameter diffs between runs
+- input lineage for derived datasets, including measured, processed,
+  simulation, and imported dataset categories
+- import provenance such as source path, file hash, import time, and conversion
+  options
+- export provenance such as exported content, time, format, and destination
+  summary
+- checksums for dataset chunks, exported bundles, code snapshots, and
+  environment lock files
+- human-readable audit summaries for selected runs or workspaces
+
+Workflow automation may include:
+
+- workflow definitions above individual experiments
+- reusable workflow templates
+- workflow versioning and workflow run history
+- scheduled or periodic workflows
+- automatic parameter calibration and optimization
+- periodic instrument or experiment benchmarks
+- benchmark history and trend plots
+- optimization objectives, constraints, chosen parameter changes, and rollback
+  context
+- human approval checkpoints for risky automation
+- failed automation attempts with logs and partial outputs
+
+AI-assisted automation may include:
+
+- metadata cleanup suggestions
+- generated read, plot, export, and report snippets
+- parameter comparison and anomaly-explanation assistance
+- tagging, note summarization, and draft report generation
+- calibration or benchmark interpretation suggestions
+- workflow drafts generated for user review before execution
+- audit records for AI-assisted changes, including model/provider/version when
+  practical and a task summary that avoids storing unnecessary sensitive prompt
+  content
 
 ## Later
 
@@ -129,6 +205,10 @@ Longer-term product direction includes explicit concepts for:
 - richer parameter schemas and sweep definitions
 - parameter history and version comparison workflows
 - experiment code and environment history management
+- run provenance and audit reporting
+- workflow definitions and scheduled automation
+- automatic calibration, optimization, and benchmark workflows
+- AI-assisted repetitive-work automation with human approval boundaries
 - device identity and configuration
 - device integration points once real workflows justify them
 
@@ -171,5 +251,8 @@ be rediscovered or relitigated later. Good ADR candidates include:
 - desktop/runtime architecture decisions
 - experiment, parameter, or device model foundations
 - experiment code history and environment management foundations
+- run provenance and immutability foundations
+- workflow definition and scheduler foundations
+- AI action, approval, and auditability foundations
 
 Use `dev-docs/adr/README.md` for ADR rules and format.

--- a/dev-docs/roadmap.md
+++ b/dev-docs/roadmap.md
@@ -16,6 +16,33 @@ implementation facts.
 Keep this file short. If an item needs step-by-step execution details, put those
 details in a focused implementation plan and link it from here.
 
+## Relationship To Current State
+
+Current implemented user-facing behavior is still centered on:
+
+- local workspaces
+- dataset creation, write, list, read, tag, favorite, and delete flows
+- Arrow-compatible table payloads with schema inferred from the first row
+- Python API, CLI, server process, and desktop dataset explorer surfaces
+
+Use `docs/concepts.md`, `docs/dataset.md`, and
+`dev-docs/current-storage-notes.md` as the source of truth for current behavior.
+This roadmap includes future product direction and should not be used as proof
+that experiment, parameter, workflow, device, provenance, AI automation, or
+semantic-manifest behavior has already landed.
+
+The existing dataset semantics proposal and implementation plan are the bridge
+between current dataset behavior and the next product phase:
+
+- `dataset-semantic-architecture-proposal.md` defines the proposed direction:
+  explicit dataset semantics, durable manifests, resolved interpretation, and
+  chart behavior that does not depend on row-order heuristics.
+- `dataset-semantic-implementation-plan.md` breaks that direction into phases.
+  Treat it as proposed execution guidance, not current implementation fact.
+
+When implementation lands, update the current implementation notes and public
+docs before treating proposal content as current behavior.
+
 ## Product Route
 
 The current route is dataset-first, Python-led, and local-first.
@@ -63,6 +90,8 @@ Current work should favor:
 
 - stabilizing the local-first workspace and dataset experience
 - landing the minimal durable dataset semantic model
+- keeping dataset semantics separate from higher-level run, workflow, parameter,
+  device, and AI concepts until those concepts have their own model boundaries
 - keeping Python API and desktop UI behavior coherent as user-facing contracts
 - preserving clear vertical slice boundaries across Rust, Python bindings, and
   the frontend
@@ -82,6 +111,11 @@ Start with:
 Near-term direction should clarify and land the dataset semantic model, then
 make the desktop UI consume resolved dataset interpretation instead of
 rediscovering chart meaning from row heuristics.
+
+Do this before building higher-level experiment, workflow, automation, or AI
+features. Those later features need explicit run and provenance models; they
+should not be smuggled into dataset naming conventions, incidental metadata, or
+chart-specific assumptions.
 
 Relevant notes:
 

--- a/dev-docs/roadmap.md
+++ b/dev-docs/roadmap.md
@@ -90,6 +90,30 @@ Relevant notes:
 - `database-schema-changes.md`
 - `release-and-versioning.md`
 
+## Core Model Pressure
+
+These future concepts have enough model impact that early dataset, run,
+parameter, and workspace work should leave room for them. They are not all
+near-term implementation scope, but ignoring them may cause avoidable schema,
+API, or UI rewrites later.
+
+- provenance graph across runs, datasets, parameters, code versions,
+  environments, device configuration, workflow definitions, imports, exports,
+  and notes
+- parameter snapshots and parameter-set versioning instead of only mutable
+  "current parameter" state
+- unit, label, precision, and display-scale metadata for both dataset columns
+  and parameters
+- sample or specimen identity for workflows where the measured object matters
+  as much as the device or parameter set
+- dataset kind and lineage, including measured, imported, processed, and
+  simulation datasets
+- workflow definition, workflow run, and experiment run as distinct concepts
+- local automation safety and approval boundaries for scheduler, optimizer, and
+  AI-assisted actions
+- event and audit log support for immutable records, corrections, manual
+  overrides, failed automation, and AI-assisted changes
+
 ## After Dataset Semantics
 
 After the dataset foundation is durable, product work should move toward:
@@ -145,6 +169,8 @@ Dataset usability may include:
 Scientific quality-of-life features may include:
 
 - run notes for manual observations and experimental context
+- sample or specimen records for experiments organized around a measured object,
+  batch, preparation, condition, or source
 - quick tags, favorites, and filters for datasets, runs, and parameter sets
 - data quality flags such as good, suspect, failed, calibration, or test run
 - calibration records linked to runs, parameters, and device configuration
@@ -163,6 +189,8 @@ Traceability and reproducibility may include:
 - parameter snapshots for each run and parameter diffs between runs
 - input lineage for derived datasets, including measured, processed,
   simulation, and imported dataset categories
+- sample or specimen provenance when runs and datasets are tied to physical
+  measured objects
 - import provenance such as source path, file hash, import time, and conversion
   options
 - export provenance such as exported content, time, format, and destination


### PR DESCRIPTION
## Summary
- Add two focused Codex skills for product-roadmap alignment and GitHub issue planning
- Expand `dev-docs` with a product roadmap, clearer current-state boundaries, and ADR guidance
- Tighten skill trigger boundaries so they hand off cleanly instead of overlapping with implementation work
- Update docs-only preflight guidance to include `pnpm run format:check` for Markdown changes

## Testing
- `pnpm run format:check` passed
- `uv run --group docs mkdocs build -s -v` passed
- No code tests were needed because this change is documentation and skill metadata only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
