### PR TITLE
fix: update documentation for current usage and maintenance

### DIFF
--- a/.changeset/docs-correct-usage-guidance.md
+++ b/.changeset/docs-correct-usage-guidance.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Correct usage and maintenance documentation
+
+Fix public setup and GUI launch guidance, make the quickstart examples easier
+to copy, and align maintainer documentation with current storage, release, and
+preflight behavior.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Fricon is a data collection automation framework designed for managing datasets 
 
 ### Installation
 
-**For Python users (recommended):**
+**For Python users on supported wheel platforms:**
 
 ```bash
 pip install fricon
 ```
+
+Current PyPI builds may not cover every platform. If `pip install fricon`
+cannot find a compatible wheel for your system, build from source.
 
 **For development or building from source:**
 
@@ -49,7 +52,7 @@ fricon init path/to/workspace
 Launch the desktop UI:
 
 ```bash
-fricon gui path/to/workspace
+fricon-gui path/to/workspace
 ```
 
 Or connect from Python to a workspace with a running server:

--- a/crates/fricon/README.md
+++ b/crates/fricon/README.md
@@ -4,4 +4,4 @@ Data collection automation framework:
 
 - **Workspace Management**: Initialize and manage data workspaces
 - **Dataset Operations**: Create, store, and query datasets using Apache Arrow format
-- **Client-Server Architecture**: gRPC-based communication
+- **Client-Server Architecture**: local IPC/gRPC communication

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -25,14 +25,15 @@ every canonical document.
 
 ## Agent Starting Points By Change Type
 
-| Change type                                | Start here                               | Then read                                                                                         | Usually avoid                                                          |
-| ------------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| SQLite schema visible through Python       | `database-schema-changes.md`             | `maintenance-checklist.md`, `release-and-versioning.md`, Diesel skill                             | Dataset semantic proposal files unless semantics are changing          |
-| Desktop UI action with Rust Tauri command  | `desktop-ui-feature-playbook.md`         | `architecture-guidelines.md`, `testing-strategy.md`, `release-and-versioning.md`, UI AGENTS files | React/shadcn skills unless touching those APIs                         |
-| Workspace format or metadata compatibility | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Architecture background unless boundary design is unclear              |
-| Rust IPC/gRPC contract compatibility       | `maintenance-checklist.md`               | `pr-preflight-checklist.md`, `release-and-versioning.md`                                          | Public docs unless behavior is user-visible                            |
-| Public dataset docs update                 | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only                                 | Implementation plan details unless landed behavior is being documented |
-| Product route or issue planning            | `roadmap.md`                             | `project-intent.md`, proposal or implementation-plan files for affected areas                     | Treating roadmap future concepts as current implementation facts       |
+| Change type                                 | Start here                               | Then read                                                                                         | Usually avoid                                                          |
+| ------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| SQLite schema visible through Python        | `database-schema-changes.md`             | `maintenance-checklist.md`, `release-and-versioning.md`, Diesel skill                             | Dataset semantic proposal files unless semantics are changing          |
+| Desktop UI action with Rust Tauri command   | `desktop-ui-feature-playbook.md`         | `architecture-guidelines.md`, `testing-strategy.md`, `release-and-versioning.md`, UI AGENTS files | React/shadcn skills unless touching those APIs                         |
+| Workspace format or metadata compatibility  | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Architecture background unless boundary design is unclear              |
+| Dataset archive import/export compatibility | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Public docs unless behavior is user-visible                            |
+| Rust IPC/gRPC contract compatibility        | `maintenance-checklist.md`               | `pr-preflight-checklist.md`, `release-and-versioning.md`                                          | Public docs unless behavior is user-visible                            |
+| Public dataset docs update                  | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only                                 | Implementation plan details unless landed behavior is being documented |
+| Product route or issue planning             | `roadmap.md`                             | `project-intent.md`, proposal or implementation-plan files for affected areas                     | Treating roadmap future concepts as current implementation facts       |
 
 ## Canonical Guidance
 

--- a/dev-docs/architecture-ai-notes.md
+++ b/dev-docs/architecture-ai-notes.md
@@ -114,9 +114,10 @@ Guidance:
 
 ## Event Design
 
-Current issue identified:
+Earlier issue identified:
 
-- `AppEvent` currently mixes feature-level notifications and app/UI-shell requests.
+- App-level events can drift into mixing feature-level notifications and
+  app/UI-shell requests.
 
 Recommended distinction:
 

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -26,6 +26,7 @@ workspace/
   fricon.sqlite3
   fricon.socket
   data/
+    .graveyard/
     <uid[0:2]>/
       <uid>/
         data_chunk_0.arrow
@@ -44,6 +45,8 @@ Notes:
 - `fricon.socket` is runtime IPC state, not durable data.
 - Dataset directories are currently sharded by the first two characters of the
   dataset UID.
+- `data/.graveyard/` stores deleted dataset payload directories before they are
+  permanently removed.
 
 ## Dataset Payload Storage
 
@@ -70,7 +73,7 @@ Current Python dataset writes are buffered on the client and flushed
 automatically when either:
 
 - 16 rows have accumulated, or
-- 1 second has elapsed since the first buffered row.
+- 200 ms have elapsed since the first buffered row.
 
 Calling `finish()`, `abort()`, or dropping the writer flushes pending rows
 before finalizing the dataset stream.

--- a/dev-docs/maintenance-checklist.md
+++ b/dev-docs/maintenance-checklist.md
@@ -20,13 +20,14 @@ compatibility decision is required, record the decision in the change.
 
 Classify the boundary before deciding which checklist applies:
 
-| Changed surface                                                                                                    | Use                              |
-| ------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
-| `.fricon_workspace.json`, workspace directory layout, durable workspace metadata, or workspace migration semantics | Workspace format changes         |
-| Dataset payload files, chunking, durable dataset-side metadata, or dataset payload schema rules                    | Dataset payload layout changes   |
-| SQLite tables, Diesel migrations, generated Diesel schema, or database row models                                  | Database schema changes          |
-| `crates/fricon/proto/**`, `crates/fricon/src/transport/**`, IPC/gRPC request or response semantics                 | Rust IPC / gRPC contract changes |
-| Tauri command/event DTOs, Specta exports, generated frontend bindings, or frontend-only adapter DTOs               | Tauri / frontend binding changes |
+| Changed surface                                                                                                    | Use                                   |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `.fricon_workspace.json`, workspace directory layout, durable workspace metadata, or workspace migration semantics | Workspace format changes              |
+| Dataset payload files, chunking, durable dataset-side metadata, or dataset payload schema rules                    | Dataset payload layout changes        |
+| Dataset archive metadata, archive entry allowlist, import/export semantics, or archive version                     | Dataset archive import/export changes |
+| SQLite tables, Diesel migrations, generated Diesel schema, or database row models                                  | Database schema changes               |
+| `crates/fricon/proto/**`, `crates/fricon/src/transport/**`, IPC/gRPC request or response semantics                 | Rust IPC / gRPC contract changes      |
+| Tauri command/event DTOs, Specta exports, generated frontend bindings, or frontend-only adapter DTOs               | Tauri / frontend binding changes      |
 
 ## Workspace Format Changes
 
@@ -70,6 +71,32 @@ payload files.
 - Update public docs only for stable user-facing behavior.
 - Add or update tests for old and new payload expectations when compatibility
   matters.
+
+## Dataset Archive Import/Export Changes
+
+Use this when changing exported dataset archive metadata, archive entry names,
+archive entry allowlists, import conflict behavior, replacement behavior, or
+archive version compatibility.
+
+- Update archive read/write code in `crates/fricon/src/dataset/portability.rs`
+  together with database import/export callers.
+- Decide whether the archive version must change.
+- Update extraction allowlists when new archive entry types are introduced.
+- Update `dev-docs/current-storage-notes.md` if current import/export storage
+  behavior changes.
+- Update public docs only when user-visible import/export behavior changes.
+- Add or update import/export tests for backward compatibility, conflict
+  handling, and rollback behavior where applicable.
+
+Decision guide:
+
+| Change                                                                               | Archive version decision                        |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| Add optional metadata that older import code may ignore                              | Usually no bump; add default-handling tests     |
+| Add required metadata needed to interpret an archive                                 | Bump                                            |
+| Remove, rename, or change the meaning of archive metadata                            | Bump                                            |
+| Add new required archive entries or change entry naming semantics                    | Bump                                            |
+| Expand the extraction allowlist for optional entries that current readers can ignore | Usually no bump; add allowlist and import tests |
 
 ## Database Schema Changes
 

--- a/dev-docs/pr-preflight-checklist.md
+++ b/dev-docs/pr-preflight-checklist.md
@@ -33,7 +33,9 @@ Use the result to choose changed areas:
   files, docs describing workspace layout
 - Rust IPC/gRPC compatibility: `crates/fricon/proto/**`,
   `crates/fricon/src/client.rs`, `crates/fricon/src/transport/**`
-- Docs-only: `docs/**`, `dev-docs/**`, and Markdown-only changes
+- Release notes: `.changeset/**`
+- Docs-only: `docs/**`, `dev-docs/**`, and Markdown-only changes outside
+  `.changeset/`
 
 ## Quick Profile
 
@@ -114,6 +116,13 @@ pnpm run format:check
 uv run --group docs mkdocs build -s -v
 ```
 
+### Release Notes
+
+```bash
+pnpm run format:check
+knope --validate
+```
+
 ## Strict Profile
 
 Run once before opening or updating a PR.
@@ -124,8 +133,9 @@ Run once before opening or updating a PR.
 cargo +nightly fmt --all --check
 cargo check
 cargo build --workspace --locked
-cargo clippy --all-targets --all-features -- -D warnings
-cargo nextest run
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo nextest run --workspace --profile ci --locked
+cargo test --workspace --doc --locked
 cargo deny --workspace --all-features check
 ```
 

--- a/dev-docs/release-and-versioning.md
+++ b/dev-docs/release-and-versioning.md
@@ -106,8 +106,9 @@ these changes.
 
 ## Release Workflow Summary
 
-- A push to `main` refreshes the rolling release preview PR from the `release`
-  branch.
+- The release preparation workflow is started manually from `main` and refreshes
+  the prepared release PR from the `release` branch when Knope finds pending
+  release notes.
 - The release preparation workflow depends on the prepared release commit
   subject `chore: prepare release <version>`.
 - Merging the prepared release PR creates the GitHub release and tag.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -18,7 +18,7 @@ Fricon needs a _server process_ to manage the workspace. The desktop app can
 launch it for you:
 
 ```shell
-fricon gui path/to/workspace
+fricon-gui path/to/workspace
 ```
 
 Python scripts can connect to an already running workspace server:

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -15,10 +15,11 @@ Supported public write values are currently `float`, `int` values converted to
 `float`, `complex`, and trace values. `None` and nullable columns are not part
 of the current write contract.
 
-Call `finish()` or `close()` to complete a dataset successfully. A writer used
-as a context manager calls `close()` when the block exits normally. Calling
-`abort()`, raising from the context manager block, or dropping a writer before
-successful completion marks the dataset as aborted.
+After writing at least one row, call `finish()` or `close()` to complete a
+dataset successfully. A writer used as a context manager calls `close()` when
+the block exits normally. Calling `abort()`, raising from the context manager
+block, or dropping a writer before successful completion marks the dataset as
+aborted. Finishing an empty writer does not create a completed dataset.
 
 Users do not currently declare dataset semantics, scan axes, or logical indices
 through the public API. The exact workspace file layout, internal metadata

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,14 @@ Fricon is a framework for data collection automation.
 
 ## Usage
 
-Install via PyPI:
+Install via PyPI on supported wheel platforms:
 
 ```shell
 pip install fricon
 ```
+
+If PyPI does not provide a compatible wheel for your system, build from source
+using the repository setup instructions.
 
 Initialize workspace via CLI:
 
@@ -24,7 +27,7 @@ fricon init path/to/workspace
 Launch the desktop UI for a workspace:
 
 ```shell
-fricon gui path/to/workspace
+fricon-gui path/to/workspace
 ```
 
 Connect from Python to a workspace with a running server:
@@ -37,12 +40,41 @@ ws = Workspace.connect("path/to/workspace")
 
 Create and populate a dataset from Python:
 
-```python title="examples/simple/create.py"
---8<-- "examples/simple/create.py:create-example"
+```python
+from pathlib import Path
+
+from fricon import Trace, Workspace
+
+workspace_path = Path("path/to/workspace")
+ws = Workspace.connect(workspace_path)
+manager = ws.dataset_manager
+
+with manager.create("example_dataset") as writer:
+    writer.write(
+        i=1,
+        a=42.0,
+        b=[1.0, 2.0],
+        c=[1 + 2j, 3 + 4j],
+        d=Trace.fixed_step(0.1, 1.1, [1, 2, 3]),
+    )
+
+print(f"Id of the dataset: {writer.dataset.id}")
 ```
 
 Query and open a dataset from Python:
 
-```python title="examples/simple/open.py"
---8<-- "examples/simple/open.py:open-example"
+```python
+from pathlib import Path
+
+from fricon import Workspace
+
+workspace_path = Path("path/to/workspace")
+ws = Workspace.connect(workspace_path)
+manager = ws.dataset_manager
+datasets = manager.list_all()
+dataset_id = int(datasets.index[0])
+dataset = manager.open(dataset_id)
+table = dataset.to_arrow()
 ```
+
+Runnable script versions are available in `examples/simple/`.


### PR DESCRIPTION
## Summary
- Fix public install and launch guidance to match the current CLI and wheel availability
- Make the quickstart examples copy-pasteable and clarify dataset completion behavior
- Align maintainer docs with current storage, release, preflight, and archive compatibility rules

## Testing
- `pnpm run format:check`
- `uv run --group docs mkdocs build -s -v`
- `knope --validate`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
