### PR TITLE
feat: add dataset semantic manifest model

### DIFF
--- a/crates/fricon/src/dataset.rs
+++ b/crates/fricon/src/dataset.rs
@@ -5,6 +5,7 @@ pub mod model;
 pub mod portability;
 pub mod read;
 pub mod schema;
+pub mod semantics;
 pub mod storage;
 mod tag;
 

--- a/crates/fricon/src/dataset/semantics.rs
+++ b/crates/fricon/src/dataset/semantics.rs
@@ -1,0 +1,13 @@
+mod error;
+mod io;
+mod model;
+
+pub use self::{
+    error::{ManifestError, ManifestValidationError},
+    io::{read_manifest, read_manifest_optional, write_manifest},
+    model::{
+        Compatibility, DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault,
+        IndexRealization, MANIFEST_VERSION_V1, ManifestColumn, RECORD_ID_COLUMN, Realization,
+        SystemColumn, TraceAxisDType, TraceDType, TraceLayout, TraceValueDType,
+    },
+};

--- a/crates/fricon/src/dataset/semantics/error.rs
+++ b/crates/fricon/src/dataset/semantics/error.rs
@@ -1,0 +1,45 @@
+use std::io;
+
+use tempfile::PersistError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Persist(#[from] PersistError),
+    #[error(transparent)]
+    Validation(#[from] ManifestValidationError),
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ManifestValidationError {
+    #[error("Unsupported dataset semantic manifest version: {found}")]
+    UnsupportedVersion { found: u32 },
+    #[error("Dataset semantic manifest must contain at least one column")]
+    EmptyColumns,
+    #[error("Dataset semantic manifest is missing the record id column")]
+    MissingRecordIdColumn,
+    #[error("Record id column must be named {expected}, found {found}")]
+    InvalidRecordIdReference { expected: String, found: String },
+    #[error("Record id column must be a uint64 system record id column")]
+    InvalidRecordIdColumn,
+    #[error("User column uses the reserved __ds_ prefix: {name}")]
+    ReservedUserColumn { name: String },
+    #[error("System column {name} is not valid in v1 dataset semantic manifests")]
+    InvalidSystemColumn { name: String },
+    #[error("Dataset semantic manifest v1 requires append_only=true")]
+    AppendOnlyRequired,
+    #[error("Arrow schema is missing manifest column: {name}")]
+    MissingArrowColumn { name: String },
+    #[error("Arrow schema has a column not declared in the manifest: {name}")]
+    UnexpectedArrowColumn { name: String },
+    #[error("Arrow type mismatch for {name}: expected {expected}, found {found}")]
+    ArrowTypeMismatch {
+        name: String,
+        expected: String,
+        found: String,
+    },
+}

--- a/crates/fricon/src/dataset/semantics/io.rs
+++ b/crates/fricon/src/dataset/semantics/io.rs
@@ -1,0 +1,109 @@
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    path::{Path, PathBuf},
+};
+
+use tempfile::NamedTempFile;
+
+use crate::dataset::{
+    semantics::{DatasetSemanticManifest, ManifestError},
+    storage::layout::manifest_path,
+};
+
+pub fn read_manifest(
+    path_or_dataset_dir: impl AsRef<Path>,
+) -> Result<DatasetSemanticManifest, ManifestError> {
+    let path = resolve_manifest_path(path_or_dataset_dir.as_ref());
+    let file = File::open(path)?;
+    let manifest: DatasetSemanticManifest = serde_json::from_reader(BufReader::new(file))?;
+    manifest.validate()?;
+    Ok(manifest)
+}
+
+pub fn read_manifest_optional(
+    dataset_dir: impl AsRef<Path>,
+) -> Result<Option<DatasetSemanticManifest>, ManifestError> {
+    match File::open(manifest_path(dataset_dir.as_ref())) {
+        Ok(file) => {
+            let manifest: DatasetSemanticManifest = serde_json::from_reader(BufReader::new(file))?;
+            manifest.validate()?;
+            Ok(Some(manifest))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn write_manifest(
+    dataset_dir: impl AsRef<Path>,
+    manifest: &DatasetSemanticManifest,
+) -> Result<(), ManifestError> {
+    manifest.validate()?;
+    let path = manifest_path(dataset_dir.as_ref());
+    let mut file = NamedTempFile::new_in(
+        path.parent()
+            .expect("manifest path should always have a dataset directory parent"),
+    )?;
+    serde_json::to_writer_pretty(&mut file, manifest)?;
+    file.persist(path)?;
+    Ok(())
+}
+
+fn resolve_manifest_path(path_or_dataset_dir: &Path) -> PathBuf {
+    if path_or_dataset_dir.is_dir() {
+        manifest_path(path_or_dataset_dir)
+    } else {
+        path_or_dataset_dir.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::tempdir;
+
+    use crate::dataset::{
+        semantics::{
+            DatasetDType, DatasetSemanticManifest, ManifestColumn, read_manifest,
+            read_manifest_optional, write_manifest,
+        },
+        storage::layout::manifest_path,
+    };
+
+    fn manifest() -> DatasetSemanticManifest {
+        DatasetSemanticManifest::minimal(BTreeMap::from([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )]))
+    }
+
+    #[test]
+    fn optional_read_returns_none_when_manifest_is_absent() {
+        let dir = tempdir().expect("temp dir");
+
+        let read = read_manifest_optional(dir.path()).expect("optional read");
+
+        assert_eq!(read, None);
+    }
+
+    #[test]
+    fn write_and_read_manifest_round_trips_pretty_json() {
+        let dir = tempdir().expect("temp dir");
+        let manifest = manifest();
+
+        write_manifest(dir.path(), &manifest).expect("write manifest");
+        let json = std::fs::read_to_string(manifest_path(dir.path())).expect("read json");
+        assert!(
+            json.contains("\n  \"manifest_version\""),
+            "manifest should be written as pretty JSON"
+        );
+
+        let from_dir = read_manifest(dir.path()).expect("read manifest from dataset dir");
+        let from_file =
+            read_manifest(manifest_path(dir.path())).expect("read manifest from explicit path");
+        assert_eq!(from_dir, manifest);
+        assert_eq!(from_file, manifest);
+    }
+}

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -105,11 +105,10 @@ impl DatasetSemanticManifest {
                         name: name.clone(),
                     });
                 }
-                Some(SystemColumn::RecordId) => {}
                 None if name.starts_with(SYSTEM_COLUMN_PREFIX) => {
                     return Err(ManifestValidationError::ReservedUserColumn { name: name.clone() });
                 }
-                None => {}
+                Some(SystemColumn::RecordId) | None => {}
             }
         }
 
@@ -148,18 +147,25 @@ impl ManifestColumn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum DatasetDType {
+    #[serde(rename = "float64")]
     Float64,
+    #[serde(rename = "float32")]
     Float32,
+    #[serde(rename = "int64")]
     Int64,
     #[serde(rename = "uint64")]
     UInt64,
+    #[serde(rename = "bool")]
     Bool,
     #[serde(rename = "utf8")]
     Utf8,
+    #[serde(rename = "timestamp_us")]
     TimestampUs,
+    #[serde(rename = "complex128")]
     Complex128,
+    #[serde(rename = "trace")]
     Trace {
         layout: TraceLayout,
         axis: TraceAxisDType,
@@ -205,18 +211,24 @@ pub struct TraceDType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum TraceLayout {
+    #[serde(rename = "simple")]
     Simple,
+    #[serde(rename = "fixed_step")]
     FixedStep,
+    #[serde(rename = "variable_step")]
     VariableStep,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum TraceAxisDType {
+    #[serde(rename = "float64")]
     Float64,
+    #[serde(rename = "float32")]
     Float32,
+    #[serde(rename = "int64")]
     Int64,
     #[serde(rename = "uint64")]
     UInt64,
@@ -235,13 +247,17 @@ impl TraceAxisDType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum TraceValueDType {
+    #[serde(rename = "float64")]
     Float64,
+    #[serde(rename = "float32")]
     Float32,
+    #[serde(rename = "int64")]
     Int64,
     #[serde(rename = "uint64")]
     UInt64,
+    #[serde(rename = "complex128")]
     Complex128,
 }
 
@@ -278,23 +294,26 @@ impl Default for Realization {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum IndexRealization {
     #[default]
+    #[serde(rename = "none")]
     None,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum DuplicateResolutionDefault {
     #[default]
+    #[serde(rename = "latest_by_record_id")]
     LatestByRecordId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum SystemColumn {
     #[default]
+    #[serde(rename = "record_id")]
     RecordId,
 }
 

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -1,0 +1,559 @@
+use std::collections::BTreeMap;
+
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use serde::{Deserialize, Serialize};
+
+use crate::dataset::semantics::ManifestValidationError;
+
+pub const MANIFEST_VERSION_V1: u32 = 1;
+pub const RECORD_ID_COLUMN: &str = "__ds_record_id";
+const SYSTEM_COLUMN_PREFIX: &str = "__ds_";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetSemanticManifest {
+    pub manifest_version: u32,
+    pub columns: BTreeMap<String, ManifestColumn>,
+    pub realization: Realization,
+    pub compatibility: Compatibility,
+}
+
+impl DatasetSemanticManifest {
+    #[must_use]
+    pub fn minimal(columns: impl IntoIterator<Item = (String, ManifestColumn)>) -> Self {
+        let mut columns: BTreeMap<_, _> = columns.into_iter().collect();
+        columns.insert(RECORD_ID_COLUMN.to_string(), ManifestColumn::record_id());
+        Self {
+            manifest_version: MANIFEST_VERSION_V1,
+            columns,
+            realization: Realization::default(),
+            compatibility: Compatibility::default(),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ManifestValidationError> {
+        if self.manifest_version != MANIFEST_VERSION_V1 {
+            return Err(ManifestValidationError::UnsupportedVersion {
+                found: self.manifest_version,
+            });
+        }
+        if self.columns.is_empty() {
+            return Err(ManifestValidationError::EmptyColumns);
+        }
+        if self.realization.record_id_column != RECORD_ID_COLUMN {
+            return Err(ManifestValidationError::InvalidRecordIdReference {
+                expected: RECORD_ID_COLUMN.to_string(),
+                found: self.realization.record_id_column.clone(),
+            });
+        }
+        if !self.realization.append_only {
+            return Err(ManifestValidationError::AppendOnlyRequired);
+        }
+        self.validate_columns()
+    }
+
+    pub fn validate_against_arrow_schema(
+        &self,
+        schema: &Schema,
+    ) -> Result<(), ManifestValidationError> {
+        self.validate()?;
+
+        for (name, column) in &self.columns {
+            let field = schema
+                .field_with_name(name)
+                .map_err(|_| ManifestValidationError::MissingArrowColumn { name: name.clone() })?;
+            let expected = column.dtype.physical_data_type();
+            if field.data_type() != &expected {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: name.clone(),
+                    expected: expected.to_string(),
+                    found: field.data_type().to_string(),
+                });
+            }
+        }
+
+        for field in schema.fields() {
+            if !self.columns.contains_key(field.name()) {
+                return Err(ManifestValidationError::UnexpectedArrowColumn {
+                    name: field.name().clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_columns(&self) -> Result<(), ManifestValidationError> {
+        let record_id_column = self
+            .columns
+            .get(RECORD_ID_COLUMN)
+            .ok_or(ManifestValidationError::MissingRecordIdColumn)?;
+        if !record_id_column.is_record_id() {
+            return Err(ManifestValidationError::InvalidRecordIdColumn);
+        }
+
+        for (name, column) in &self.columns {
+            match column.system {
+                Some(SystemColumn::RecordId) if name != RECORD_ID_COLUMN => {
+                    return Err(ManifestValidationError::InvalidSystemColumn {
+                        name: name.clone(),
+                    });
+                }
+                Some(SystemColumn::RecordId) => {}
+                None if name.starts_with(SYSTEM_COLUMN_PREFIX) => {
+                    return Err(ManifestValidationError::ReservedUserColumn { name: name.clone() });
+                }
+                None => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestColumn {
+    pub dtype: DatasetDType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<SystemColumn>,
+}
+
+impl ManifestColumn {
+    #[must_use]
+    pub fn new(dtype: DatasetDType) -> Self {
+        Self {
+            dtype,
+            system: None,
+        }
+    }
+
+    #[must_use]
+    pub fn record_id() -> Self {
+        Self {
+            dtype: DatasetDType::UInt64,
+            system: Some(SystemColumn::RecordId),
+        }
+    }
+
+    #[must_use]
+    pub fn is_record_id(&self) -> bool {
+        self.dtype == DatasetDType::UInt64 && self.system == Some(SystemColumn::RecordId)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DatasetDType {
+    Float64,
+    Float32,
+    Int64,
+    #[serde(rename = "uint64")]
+    UInt64,
+    Bool,
+    #[serde(rename = "utf8")]
+    Utf8,
+    TimestampUs,
+    Complex128,
+    Trace {
+        layout: TraceLayout,
+        axis: TraceAxisDType,
+        value: TraceValueDType,
+    },
+}
+
+impl DatasetDType {
+    #[must_use]
+    pub fn trace(dtype: TraceDType) -> Self {
+        Self::Trace {
+            layout: dtype.layout,
+            axis: dtype.axis,
+            value: dtype.value,
+        }
+    }
+
+    #[must_use]
+    pub fn physical_data_type(&self) -> DataType {
+        match self {
+            Self::Float64 => DataType::Float64,
+            Self::Float32 => DataType::Float32,
+            Self::Int64 => DataType::Int64,
+            Self::UInt64 => DataType::UInt64,
+            Self::Bool => DataType::Boolean,
+            Self::Utf8 => DataType::Utf8,
+            Self::TimestampUs => DataType::Timestamp(TimeUnit::Microsecond, None),
+            Self::Complex128 => complex128_data_type(),
+            Self::Trace {
+                layout,
+                axis,
+                value,
+            } => trace_data_type(*layout, *axis, *value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceDType {
+    pub layout: TraceLayout,
+    pub axis: TraceAxisDType,
+    pub value: TraceValueDType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TraceLayout {
+    Simple,
+    FixedStep,
+    VariableStep,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TraceAxisDType {
+    Float64,
+    Float32,
+    Int64,
+    #[serde(rename = "uint64")]
+    UInt64,
+}
+
+impl TraceAxisDType {
+    #[must_use]
+    pub fn physical_data_type(self) -> DataType {
+        match self {
+            Self::Float64 => DataType::Float64,
+            Self::Float32 => DataType::Float32,
+            Self::Int64 => DataType::Int64,
+            Self::UInt64 => DataType::UInt64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TraceValueDType {
+    Float64,
+    Float32,
+    Int64,
+    #[serde(rename = "uint64")]
+    UInt64,
+    Complex128,
+}
+
+impl TraceValueDType {
+    #[must_use]
+    pub fn physical_data_type(self) -> DataType {
+        match self {
+            Self::Float64 => DataType::Float64,
+            Self::Float32 => DataType::Float32,
+            Self::Int64 => DataType::Int64,
+            Self::UInt64 => DataType::UInt64,
+            Self::Complex128 => complex128_data_type(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Realization {
+    pub append_only: bool,
+    pub record_id_column: String,
+    pub index_realization: IndexRealization,
+    pub duplicate_resolution_default: DuplicateResolutionDefault,
+}
+
+impl Default for Realization {
+    fn default() -> Self {
+        Self {
+            append_only: true,
+            record_id_column: RECORD_ID_COLUMN.to_string(),
+            index_realization: IndexRealization::default(),
+            duplicate_resolution_default: DuplicateResolutionDefault::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IndexRealization {
+    #[default]
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DuplicateResolutionDefault {
+    #[default]
+    LatestByRecordId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SystemColumn {
+    #[default]
+    RecordId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Compatibility {
+    pub allow_inference: bool,
+}
+
+impl Default for Compatibility {
+    fn default() -> Self {
+        Self {
+            allow_inference: true,
+        }
+    }
+}
+
+fn trace_data_type(layout: TraceLayout, axis: TraceAxisDType, value: TraceValueDType) -> DataType {
+    let axis = axis.physical_data_type();
+    let value = value.physical_data_type();
+    match layout {
+        TraceLayout::Simple => DataType::new_list(value, false),
+        TraceLayout::FixedStep => DataType::Struct(
+            vec![
+                Field::new("x0", axis.clone(), false),
+                Field::new("step", axis, false),
+                Field::new("y", DataType::new_list(value, false), false),
+            ]
+            .into(),
+        ),
+        TraceLayout::VariableStep => DataType::Struct(
+            vec![
+                Field::new("x", DataType::new_list(axis, false), false),
+                Field::new("y", DataType::new_list(value, false), false),
+            ]
+            .into(),
+        ),
+    }
+}
+
+fn complex128_data_type() -> DataType {
+    DataType::Struct(
+        vec![
+            Field::new("real", DataType::Float64, false),
+            Field::new("imag", DataType::Float64, false),
+        ]
+        .into(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use arrow_schema::{DataType, Field, Schema};
+    use serde_json::json;
+
+    use super::{
+        Compatibility, DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault,
+        IndexRealization, ManifestColumn, ManifestValidationError, RECORD_ID_COLUMN, Realization,
+        SystemColumn, TraceAxisDType, TraceDType, TraceLayout, TraceValueDType,
+    };
+
+    fn signal_columns() -> BTreeMap<String, ManifestColumn> {
+        BTreeMap::from([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )])
+    }
+
+    #[test]
+    fn minimal_manifest_serializes_to_adr_shape() {
+        let manifest = DatasetSemanticManifest::minimal(signal_columns());
+        let value = serde_json::to_value(&manifest).expect("serialize manifest");
+
+        assert_eq!(
+            value,
+            json!({
+                "manifest_version": 1,
+                "columns": {
+                    "__ds_record_id": {
+                        "dtype": { "kind": "uint64" },
+                        "system": { "kind": "record_id" }
+                    },
+                    "signal": {
+                        "dtype": { "kind": "float64" }
+                    }
+                },
+                "realization": {
+                    "append_only": true,
+                    "record_id_column": "__ds_record_id",
+                    "index_realization": { "kind": "none" },
+                    "duplicate_resolution_default": { "kind": "latest_by_record_id" }
+                },
+                "compatibility": {
+                    "allow_inference": true
+                }
+            })
+        );
+
+        let parsed: DatasetSemanticManifest =
+            serde_json::from_value(value).expect("deserialize manifest");
+        assert_eq!(parsed, manifest);
+        parsed.validate().expect("manifest should be valid");
+    }
+
+    #[test]
+    fn minimal_manifest_injects_record_id_and_defaults() {
+        let manifest = DatasetSemanticManifest::minimal(signal_columns());
+
+        assert_eq!(
+            manifest.columns.get(RECORD_ID_COLUMN),
+            Some(&ManifestColumn::record_id())
+        );
+        assert_eq!(manifest.realization, Realization::default());
+        assert_eq!(manifest.compatibility, Compatibility::default());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_version() {
+        let mut manifest = DatasetSemanticManifest::minimal(signal_columns());
+        manifest.manifest_version = 2;
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::UnsupportedVersion { found: 2 })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_missing_record_id() {
+        let manifest = DatasetSemanticManifest {
+            manifest_version: 1,
+            columns: signal_columns(),
+            realization: Realization::default(),
+            compatibility: Compatibility::default(),
+        };
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::MissingRecordIdColumn)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_wrong_record_id_dtype() {
+        let mut manifest = DatasetSemanticManifest::minimal(signal_columns());
+        manifest.columns.insert(
+            RECORD_ID_COLUMN.to_string(),
+            ManifestColumn {
+                dtype: DatasetDType::Int64,
+                system: Some(SystemColumn::RecordId),
+            },
+        );
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::InvalidRecordIdColumn)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bad_record_id_reference() {
+        let mut manifest = DatasetSemanticManifest::minimal(signal_columns());
+        manifest.realization.record_id_column = "other".to_string();
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::InvalidRecordIdReference {
+                expected: RECORD_ID_COLUMN.to_string(),
+                found: "other".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_reserved_user_prefix() {
+        let manifest = DatasetSemanticManifest::minimal([(
+            "__ds_user".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )]);
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::ReservedUserColumn {
+                name: "__ds_user".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_append_only_manifest() {
+        let mut manifest = DatasetSemanticManifest::minimal(signal_columns());
+        manifest.realization.append_only = false;
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::AppendOnlyRequired)
+        );
+    }
+
+    #[test]
+    fn validate_against_arrow_schema_accepts_supported_physical_types() {
+        let manifest = DatasetSemanticManifest::minimal([
+            (
+                "signal".to_string(),
+                ManifestColumn::new(DatasetDType::Float64),
+            ),
+            (
+                "complex".to_string(),
+                ManifestColumn::new(DatasetDType::Complex128),
+            ),
+            (
+                "trace".to_string(),
+                ManifestColumn::new(DatasetDType::trace(TraceDType {
+                    layout: TraceLayout::FixedStep,
+                    axis: TraceAxisDType::Float64,
+                    value: TraceValueDType::Complex128,
+                })),
+            ),
+        ]);
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new(
+                "complex",
+                DatasetDType::Complex128.physical_data_type(),
+                false,
+            ),
+            Field::new("signal", DataType::Float64, false),
+            Field::new(
+                "trace",
+                DatasetDType::trace(TraceDType {
+                    layout: TraceLayout::FixedStep,
+                    axis: TraceAxisDType::Float64,
+                    value: TraceValueDType::Complex128,
+                })
+                .physical_data_type(),
+                false,
+            ),
+        ]);
+
+        manifest
+            .validate_against_arrow_schema(&schema)
+            .expect("schema should match manifest");
+    }
+
+    #[test]
+    fn validate_against_arrow_schema_rejects_type_mismatch() {
+        let manifest = DatasetSemanticManifest::minimal(signal_columns());
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Utf8, false),
+        ]);
+
+        assert!(matches!(
+            manifest.validate_against_arrow_schema(&schema),
+            Err(ManifestValidationError::ArrowTypeMismatch { name, .. })
+                if name == "signal"
+        ));
+    }
+
+    #[test]
+    fn default_manifest_values_are_adr_values() {
+        assert_eq!(IndexRealization::default(), IndexRealization::None);
+        assert_eq!(
+            DuplicateResolutionDefault::default(),
+            DuplicateResolutionDefault::LatestByRecordId
+        );
+    }
+}

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -69,6 +69,13 @@ impl DatasetSemanticManifest {
                     found: field.data_type().to_string(),
                 });
             }
+            if field.is_nullable() {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: name.clone(),
+                    expected: format!("non-null {expected}"),
+                    found: format!("nullable {}", field.data_type()),
+                });
+            }
         }
 
         for field in schema.fields() {
@@ -545,6 +552,21 @@ mod tests {
             manifest.validate_against_arrow_schema(&schema),
             Err(ManifestValidationError::ArrowTypeMismatch { name, .. })
                 if name == "signal"
+        ));
+    }
+
+    #[test]
+    fn validate_against_arrow_schema_rejects_nullable_record_id() {
+        let manifest = DatasetSemanticManifest::minimal(signal_columns());
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, true),
+            Field::new("signal", DataType::Float64, false),
+        ]);
+
+        assert!(matches!(
+            manifest.validate_against_arrow_schema(&schema),
+            Err(ManifestValidationError::ArrowTypeMismatch { name, .. })
+                if name == RECORD_ID_COLUMN
         ));
     }
 

--- a/crates/fricon/src/dataset/storage/layout.rs
+++ b/crates/fricon/src/dataset/storage/layout.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+pub(crate) const MANIFEST_FILENAME: &str = "dataset_manifest.json";
+
 /// Generate a chunk filename for the given chunk index.
 pub(crate) fn chunk_filename(chunk_index: usize) -> String {
     format!("data_chunk_{chunk_index}.arrow")
@@ -8,4 +10,8 @@ pub(crate) fn chunk_filename(chunk_index: usize) -> String {
 /// Get the chunk path by joining the base path with the chunk filename.
 pub(crate) fn chunk_path(dir_path: &Path, chunk_index: usize) -> PathBuf {
     dir_path.join(chunk_filename(chunk_index))
+}
+
+pub(crate) fn manifest_path(dir_path: &Path) -> PathBuf {
+    dir_path.join(MANIFEST_FILENAME)
 }

--- a/dev-docs/adr/0002-decide-dataset-semantic-manifest-v1.md
+++ b/dev-docs/adr/0002-decide-dataset-semantic-manifest-v1.md
@@ -67,6 +67,8 @@ part of the foundation implementation.
 
 Manifest enums should use internally tagged JSON objects such as
 `{"kind": "none"}` rather than bare strings when a value may later need fields.
+Rust serde definitions should pin durable JSON names explicitly instead of
+depending on broad rename rules, especially for acronym-heavy dtype variants.
 Rust serde structs should keep optional sections defaultable and put invariant
 checks in explicit validation after deserialization. The durable format should
 not use `untagged` enums or broad `deny_unknown_fields` defaults.

--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -314,6 +314,8 @@ maintenance:
 
 - prefer internally tagged enums such as `{"kind": "none"}` over bare strings
   or booleans when a value may later gain fields
+- pin durable JSON names explicitly instead of depending on broad serde rename
+  rules, especially for acronym-heavy dtype variants
 - keep optional top-level sections as `Option<T>` with serde defaults
 - avoid `untagged` enums for durable manifest fields
 - do not use `deny_unknown_fields` unless intentionally rejecting newer
@@ -380,16 +382,25 @@ constrained Fricon-owned dtype enum that uses Arrow-aligned primitive variants
 and structured business variants:
 
 ```rust
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 enum DatasetDType {
+    #[serde(rename = "float64")]
     Float64,
+    #[serde(rename = "float32")]
     Float32,
+    #[serde(rename = "int64")]
     Int64,
+    #[serde(rename = "uint64")]
     UInt64,
+    #[serde(rename = "bool")]
     Bool,
+    #[serde(rename = "utf8")]
     Utf8,
+    #[serde(rename = "timestamp_us")]
     TimestampUs,
+    #[serde(rename = "complex128")]
     Complex128,
+    #[serde(rename = "trace")]
     Trace(TraceDType),
 }
 


### PR DESCRIPTION
closes #475 

## Summary
- Add a backend-only `dataset::semantics` slice for the v1 `dataset_manifest.json` foundation.
- Introduce serde-owned manifest, dtype, realization, compatibility, and error types.
- Add manifest path helpers plus read/write/defaulting and validation logic, including Arrow schema checks.
- Cover minimal manifests, invalid invariants, optional reads, and round-trip IO with unit tests.

## Testing
- `cargo +nightly fmt --all --check`
- `cargo nextest run -p fricon semantics`
- `cargo check -p fricon`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
