### PR TITLE
feat: add dataset interpretation API

### DIFF
--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -214,8 +214,8 @@ pub(crate) async fn dataset_chart_data(
     options: &DatasetChartDataOptions,
 ) -> anyhow::Result<ChartSnapshot> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.schema();
-    let index_columns = dataset.index_columns();
+    let schema = dataset.try_schema()?;
+    let index_columns = dataset.try_index_columns()?;
     let common = options.common();
     let start = common.start.map_or(Bound::Unbounded, Bound::Included);
     let end = common.end.map_or(Bound::Unbounded, Bound::Excluded);
@@ -300,8 +300,8 @@ pub(crate) async fn dataset_live_chart_data(
     options: &LiveChartDataOptions,
 ) -> anyhow::Result<LiveChartDataResponse> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.schema();
-    let index_columns = dataset.index_columns();
+    let schema = dataset.try_schema()?;
+    let index_columns = dataset.try_index_columns()?;
     let total_rows = dataset.num_rows();
     let selected_columns =
         build_live_chart_selected_columns(schema, index_columns.as_deref(), options)?;

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -214,7 +214,7 @@ pub(crate) async fn dataset_chart_data(
     options: &DatasetChartDataOptions,
 ) -> anyhow::Result<ChartSnapshot> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.try_schema()?;
+    let schema = dataset.schema()?;
     let index_columns = dataset.try_index_columns()?;
     let common = options.common();
     let start = common.start.map_or(Bound::Unbounded, Bound::Included);
@@ -300,7 +300,7 @@ pub(crate) async fn dataset_live_chart_data(
     options: &LiveChartDataOptions,
 ) -> anyhow::Result<LiveChartDataResponse> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.try_schema()?;
+    let schema = dataset.schema()?;
     let index_columns = dataset.try_index_columns()?;
     let total_rows = dataset.num_rows();
     let selected_columns =

--- a/crates/fricon-ui/src/features/charts/filter_table.rs
+++ b/crates/fricon-ui/src/features/charts/filter_table.rs
@@ -164,8 +164,8 @@ pub(crate) async fn load_filter_data(
     exclude_columns: Option<Vec<String>>,
 ) -> Result<DataInternal> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.schema();
-    let index_columns = dataset.index_columns();
+    let schema = dataset.try_schema()?;
+    let index_columns = dataset.try_index_columns()?;
 
     let Some(index_col_indices) = index_columns else {
         return Ok(DataInternal::empty());

--- a/crates/fricon-ui/src/features/charts/filter_table.rs
+++ b/crates/fricon-ui/src/features/charts/filter_table.rs
@@ -164,7 +164,7 @@ pub(crate) async fn load_filter_data(
     exclude_columns: Option<Vec<String>>,
 ) -> Result<DataInternal> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.try_schema()?;
+    let schema = dataset.schema()?;
     let index_columns = dataset.try_index_columns()?;
 
     let Some(index_col_indices) = index_columns else {

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -1,4 +1,4 @@
-use fricon::{DatasetDataType, DatasetListQuery, dataset::model::DatasetId};
+use fricon::{DatasetDataType, DatasetListQuery, ReadAppError, dataset::model::DatasetId};
 
 use super::{
     error::UiDatasetError,
@@ -48,8 +48,8 @@ pub(crate) async fn get_dataset_detail(
     let payload_available = record.metadata.deleted_at.is_none();
     let columns = if payload_available {
         let reader = session.dataset(id).await?;
-        let schema = reader.schema();
-        let index = reader.index_columns();
+        let schema = reader.try_schema().map_err(ReadAppError::from)?;
+        let index = reader.try_index_columns().map_err(ReadAppError::from)?;
         schema
             .columns()
             .iter()

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -48,7 +48,7 @@ pub(crate) async fn get_dataset_detail(
     let payload_available = record.metadata.deleted_at.is_none();
     let columns = if payload_available {
         let reader = session.dataset(id).await?;
-        let schema = reader.try_schema().map_err(ReadAppError::from)?;
+        let schema = reader.schema().map_err(ReadAppError::from)?;
         let index = reader.try_index_columns().map_err(ReadAppError::from)?;
         schema
             .columns()

--- a/crates/fricon-ui/src/tauri_api.rs
+++ b/crates/fricon-ui/src/tauri_api.rs
@@ -174,6 +174,7 @@ impl From<ReadError> for ApiError {
             ReadError::Deleted { .. } => ApiErrorCode::DatasetDeleted,
             ReadError::EmptyDataset
             | ReadError::Dataset(_)
+            | ReadError::Manifest(_)
             | ReadError::DatasetFs(_)
             | ReadError::Database(_) => ApiErrorCode::Internal,
         };

--- a/crates/fricon/src/dataset.rs
+++ b/crates/fricon/src/dataset.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod events;
 pub mod ingest;
+pub mod interpret;
 pub mod model;
 pub mod portability;
 pub mod read;
@@ -11,6 +12,10 @@ mod tag;
 
 pub use self::{
     events::DatasetEvent,
+    interpret::{
+        ColumnMeaning, DatasetInterpretation, InterpretationSource, ResolvedColumn,
+        ResolvedDuplicatePolicy,
+    },
     model::{
         DatasetId, DatasetListQuery, DatasetMetadata, DatasetRecord, DatasetSortBy, DatasetStatus,
         DatasetUpdate, SortDirection,

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -18,7 +18,7 @@ use crate::dataset::{
 
 pub(crate) fn resolve_from_manifest(
     arrow_schema: &Schema,
-    manifest: DatasetSemanticManifest,
+    manifest: &DatasetSemanticManifest,
 ) -> DatasetInterpretation {
     let columns: Vec<_> = arrow_schema
         .fields()
@@ -153,6 +153,7 @@ mod tests {
     };
     use crate::dataset::{
         interpret::resolve_from_compatibility_inference,
+        read::ReadError,
         schema::DatasetSchema,
         semantics::{
             DatasetDType, DatasetSemanticManifest, ManifestColumn, RECORD_ID_COLUMN, write_manifest,
@@ -171,7 +172,7 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, manifest);
+        let interpretation = resolve_from_manifest(&schema, &manifest);
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
         assert_eq!(
@@ -368,10 +369,7 @@ mod tests {
             crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
         let error = reader.interpret().expect_err("schema mismatch");
 
-        assert!(matches!(
-            error,
-            crate::dataset::read::ReadError::Manifest(_)
-        ));
+        assert!(matches!(error, ReadError::Manifest(_)));
     }
 
     #[test]

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -1,0 +1,409 @@
+mod model;
+
+use std::collections::HashSet;
+
+use arrow_schema::Schema;
+
+pub use self::model::{
+    ColumnMeaning, DatasetInterpretation, InterpretationSource, ResolvedColumn,
+    ResolvedDuplicatePolicy,
+};
+use crate::dataset::{
+    schema::{DatasetDataType, DatasetSchema, ScalarKind, TraceKind},
+    semantics::{
+        DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault, SystemColumn,
+        TraceAxisDType, TraceLayout, TraceValueDType,
+    },
+};
+
+pub(crate) fn resolve_from_manifest(
+    arrow_schema: &Schema,
+    manifest: DatasetSemanticManifest,
+) -> DatasetInterpretation {
+    let columns: Vec<_> = arrow_schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(ordinal, field)| {
+            let name = field.name().to_owned();
+            let column = manifest
+                .columns
+                .get(&name)
+                .expect("manifest should be validated against arrow schema");
+            let is_record_id = column.system == Some(SystemColumn::RecordId);
+            ResolvedColumn {
+                name,
+                ordinal,
+                dtype: column.dtype.clone(),
+                meaning: if is_record_id {
+                    ColumnMeaning::SystemRecordId
+                } else {
+                    ColumnMeaning::UserValue
+                },
+                is_index: false,
+                is_system: is_record_id,
+                hidden_by_default: is_record_id,
+                is_chart_axis_candidate: false,
+            }
+        })
+        .collect();
+
+    let value_columns = columns
+        .iter()
+        .filter(|column| column.meaning == ColumnMeaning::UserValue)
+        .map(|column| column.ordinal)
+        .collect();
+
+    DatasetInterpretation {
+        columns,
+        value_columns,
+        logical_index_columns: Vec::new(),
+        chart_axis_candidate_columns: Vec::new(),
+        duplicate_policy: match manifest.realization.duplicate_resolution_default {
+            DuplicateResolutionDefault::LatestByRecordId => {
+                ResolvedDuplicatePolicy::LatestByRecordIdPlaceholder
+            }
+        },
+        source: InterpretationSource::Manifest,
+    }
+}
+
+pub(crate) fn resolve_from_compatibility_inference(
+    schema: &DatasetSchema,
+    index_columns: Option<Vec<usize>>,
+) -> DatasetInterpretation {
+    let index_columns = index_columns.unwrap_or_default();
+    let index_column_set: HashSet<_> = index_columns.iter().copied().collect();
+
+    let columns: Vec<_> = schema
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(ordinal, (name, data_type))| {
+            let is_index = index_column_set.contains(&ordinal);
+            ResolvedColumn {
+                name: name.to_owned(),
+                ordinal,
+                dtype: dataset_dtype_from_compatibility_type(*data_type),
+                meaning: if is_index {
+                    ColumnMeaning::CompatibilityIndex
+                } else {
+                    ColumnMeaning::UserValue
+                },
+                is_index,
+                is_system: false,
+                hidden_by_default: false,
+                is_chart_axis_candidate: is_index,
+            }
+        })
+        .collect();
+
+    let value_columns = columns
+        .iter()
+        .filter(|column| column.meaning == ColumnMeaning::UserValue)
+        .map(|column| column.ordinal)
+        .collect();
+
+    DatasetInterpretation {
+        columns,
+        value_columns,
+        logical_index_columns: index_columns.clone(),
+        chart_axis_candidate_columns: index_columns,
+        duplicate_policy: ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder,
+        source: InterpretationSource::CompatibilityInference,
+    }
+}
+
+fn dataset_dtype_from_compatibility_type(data_type: DatasetDataType) -> DatasetDType {
+    match data_type {
+        DatasetDataType::Scalar(ScalarKind::Numeric) => DatasetDType::Float64,
+        DatasetDataType::Scalar(ScalarKind::Complex) => DatasetDType::Complex128,
+        DatasetDataType::Trace(trace_kind, scalar_kind) => DatasetDType::Trace {
+            layout: trace_layout_from_compatibility_type(trace_kind),
+            axis: TraceAxisDType::Float64,
+            value: trace_value_from_compatibility_type(scalar_kind),
+        },
+    }
+}
+
+fn trace_layout_from_compatibility_type(trace_kind: TraceKind) -> TraceLayout {
+    match trace_kind {
+        TraceKind::Simple => TraceLayout::Simple,
+        TraceKind::FixedStep => TraceLayout::FixedStep,
+        TraceKind::VariableStep => TraceLayout::VariableStep,
+    }
+}
+
+fn trace_value_from_compatibility_type(scalar_kind: ScalarKind) -> TraceValueDType {
+    match scalar_kind {
+        ScalarKind::Numeric => TraceValueDType::Float64,
+        ScalarKind::Complex => TraceValueDType::Complex128,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Float64Array, RecordBatch, UInt64Array};
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::{
+        ColumnMeaning, InterpretationSource, ResolvedDuplicatePolicy, resolve_from_manifest,
+    };
+    use crate::dataset::{
+        interpret::resolve_from_compatibility_inference,
+        schema::DatasetSchema,
+        semantics::{
+            DatasetDType, DatasetSemanticManifest, ManifestColumn, RECORD_ID_COLUMN, write_manifest,
+        },
+        storage::ChunkWriter,
+    };
+
+    #[test]
+    fn manifest_interpretation_marks_record_id_system_and_hidden() {
+        let manifest = DatasetSemanticManifest::minimal([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )]);
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]);
+
+        let interpretation = resolve_from_manifest(&schema, manifest);
+
+        assert_eq!(interpretation.source, InterpretationSource::Manifest);
+        assert_eq!(
+            interpretation.duplicate_policy,
+            ResolvedDuplicatePolicy::LatestByRecordIdPlaceholder
+        );
+        assert_eq!(interpretation.value_columns, vec![1]);
+        assert_eq!(interpretation.logical_index_columns, Vec::<usize>::new());
+        assert_eq!(
+            interpretation.chart_axis_candidate_columns,
+            Vec::<usize>::new()
+        );
+
+        let record_id = &interpretation.columns[0];
+        assert_eq!(record_id.name, RECORD_ID_COLUMN);
+        assert_eq!(record_id.meaning, ColumnMeaning::SystemRecordId);
+        assert_eq!(record_id.dtype, DatasetDType::UInt64);
+        assert!(!record_id.is_index);
+        assert!(record_id.is_system);
+        assert!(record_id.hidden_by_default);
+        assert!(!record_id.is_chart_axis_candidate);
+
+        let signal = &interpretation.columns[1];
+        assert_eq!(signal.meaning, ColumnMeaning::UserValue);
+        assert_eq!(signal.dtype, DatasetDType::Float64);
+        assert!(!signal.is_system);
+        assert!(!signal.hidden_by_default);
+    }
+
+    #[test]
+    fn compatibility_interpretation_uses_legacy_index_columns() {
+        let schema = DatasetSchema::try_from(&Schema::new(vec![
+            Field::new("run", DataType::Float64, false),
+            Field::new("step", DataType::Float64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]))
+        .expect("schema");
+
+        let interpretation = resolve_from_compatibility_inference(&schema, Some(vec![0, 1]));
+
+        assert_eq!(
+            interpretation.source,
+            InterpretationSource::CompatibilityInference
+        );
+        assert_eq!(
+            interpretation.duplicate_policy,
+            ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder
+        );
+        assert_eq!(interpretation.logical_index_columns, vec![0, 1]);
+        assert_eq!(interpretation.chart_axis_candidate_columns, vec![0, 1]);
+        assert_eq!(interpretation.value_columns, vec![2]);
+        assert_eq!(
+            interpretation.columns[0].meaning,
+            ColumnMeaning::CompatibilityIndex
+        );
+        assert!(interpretation.columns[0].is_index);
+        assert!(interpretation.columns[0].is_chart_axis_candidate);
+        assert_eq!(interpretation.columns[2].meaning, ColumnMeaning::UserValue);
+        assert!(!interpretation.columns[2].is_index);
+    }
+
+    #[test]
+    fn compatibility_interpretation_handles_missing_inferred_indexes() {
+        let schema = DatasetSchema::try_from(&Schema::new(vec![
+            Field::new("run", DataType::Float64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]))
+        .expect("schema");
+
+        let interpretation = resolve_from_compatibility_inference(&schema, None);
+
+        assert_eq!(interpretation.logical_index_columns, Vec::<usize>::new());
+        assert_eq!(
+            interpretation.chart_axis_candidate_columns,
+            Vec::<usize>::new()
+        );
+        assert_eq!(interpretation.value_columns, vec![0, 1]);
+        assert!(interpretation.columns.iter().all(|column| !column.is_index));
+    }
+
+    #[test]
+    fn reader_interpretation_reads_manifest_when_present() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(UInt64Array::from(vec![0, 1])),
+                        Arc::new(Float64Array::from(vec![10.0, 20.0])),
+                    ],
+                )
+                .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+        write_manifest(
+            dir.path(),
+            &DatasetSemanticManifest::minimal([(
+                "signal".to_string(),
+                ManifestColumn::new(DatasetDType::Float64),
+            )]),
+        )
+        .expect("write manifest");
+
+        let reader =
+            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(interpretation.source, InterpretationSource::Manifest);
+        assert_eq!(
+            interpretation.columns[0].meaning,
+            ColumnMeaning::SystemRecordId
+        );
+        assert_eq!(interpretation.value_columns, vec![1]);
+    }
+
+    #[test]
+    fn reader_interpretation_reports_manifest_schema_mismatch() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(UInt64Array::from(vec![0, 1])),
+                        Arc::new(Float64Array::from(vec![10.0, 20.0])),
+                    ],
+                )
+                .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+        write_manifest(
+            dir.path(),
+            &DatasetSemanticManifest::minimal([(
+                "signal".to_string(),
+                ManifestColumn::new(DatasetDType::Utf8),
+            )]),
+        )
+        .expect("write manifest");
+
+        let reader =
+            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let error = reader.interpret().expect_err("schema mismatch");
+
+        assert!(matches!(
+            error,
+            crate::dataset::read::ReadError::Manifest(_)
+        ));
+    }
+
+    #[test]
+    fn reader_interpretation_falls_back_to_legacy_index_inference() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        write_legacy_numeric_dataset(dir.path(), vec![1.0, 1.0], vec![0.0, 1.0]);
+
+        let reader =
+            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(
+            interpretation.source,
+            InterpretationSource::CompatibilityInference
+        );
+        assert_eq!(interpretation.logical_index_columns, vec![0, 1]);
+        assert_eq!(interpretation.chart_axis_candidate_columns, vec![0, 1]);
+        assert_eq!(interpretation.value_columns, vec![2]);
+        assert_eq!(
+            interpretation.columns[0].meaning,
+            ColumnMeaning::CompatibilityIndex
+        );
+        assert_eq!(
+            interpretation.columns[1].meaning,
+            ColumnMeaning::CompatibilityIndex
+        );
+        assert_eq!(interpretation.columns[2].meaning, ColumnMeaning::UserValue);
+    }
+
+    #[test]
+    fn reader_interpretation_with_less_than_two_rows_has_no_legacy_indexes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        write_legacy_numeric_dataset(dir.path(), vec![1.0], vec![0.0]);
+
+        let reader =
+            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(
+            interpretation.source,
+            InterpretationSource::CompatibilityInference
+        );
+        assert_eq!(interpretation.logical_index_columns, Vec::<usize>::new());
+        assert_eq!(
+            interpretation.chart_axis_candidate_columns,
+            Vec::<usize>::new()
+        );
+        assert_eq!(interpretation.value_columns, vec![0, 1, 2]);
+        assert!(interpretation.columns.iter().all(|column| !column.is_index));
+    }
+
+    fn write_legacy_numeric_dataset(dir: &std::path::Path, run: Vec<f64>, step: Vec<f64>) {
+        let signal: Vec<f64> = step.iter().map(|value| value + 10.0).collect();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("run", DataType::Float64, false),
+            Field::new("step", DataType::Float64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(Float64Array::from(run)),
+                        Arc::new(Float64Array::from(step)),
+                        Arc::new(Float64Array::from(signal)),
+                    ],
+                )
+                .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+    }
+}

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -145,7 +145,7 @@ fn trace_value_from_compatibility_type(scalar_kind: ScalarKind) -> TraceValueDTy
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{Float64Array, RecordBatch, UInt64Array};
+    use arrow_array::{Float64Array, RecordBatch, StringArray, UInt64Array};
     use arrow_schema::{DataType, Field, Schema};
 
     use super::{
@@ -292,6 +292,46 @@ mod tests {
             ColumnMeaning::SystemRecordId
         );
         assert_eq!(interpretation.value_columns, vec![1]);
+    }
+
+    #[test]
+    fn reader_interpretation_supports_manifest_dtypes_outside_legacy_schema() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("label", DataType::Utf8, false),
+        ]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(UInt64Array::from(vec![0, 1])),
+                        Arc::new(StringArray::from(vec!["first", "second"])),
+                    ],
+                )
+                .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+        write_manifest(
+            dir.path(),
+            &DatasetSemanticManifest::minimal([(
+                "label".to_string(),
+                ManifestColumn::new(DatasetDType::Utf8),
+            )]),
+        )
+        .expect("write manifest");
+
+        let reader =
+            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(interpretation.source, InterpretationSource::Manifest);
+        assert_eq!(interpretation.value_columns, vec![1]);
+        assert_eq!(interpretation.columns[1].dtype, DatasetDType::Utf8);
+        assert_eq!(interpretation.columns[1].meaning, ColumnMeaning::UserValue);
     }
 
     #[test]

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -11,6 +11,10 @@ pub struct DatasetInterpretation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "resolved column flags are compatibility and UI-facing projections"
+)]
 pub struct ResolvedColumn {
     pub name: String,
     pub ordinal: usize,

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -1,0 +1,42 @@
+use crate::dataset::semantics::DatasetDType;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatasetInterpretation {
+    pub columns: Vec<ResolvedColumn>,
+    pub value_columns: Vec<usize>,
+    pub logical_index_columns: Vec<usize>,
+    pub chart_axis_candidate_columns: Vec<usize>,
+    pub duplicate_policy: ResolvedDuplicatePolicy,
+    pub source: InterpretationSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedColumn {
+    pub name: String,
+    pub ordinal: usize,
+    pub dtype: DatasetDType,
+    pub meaning: ColumnMeaning,
+    pub is_index: bool,
+    pub is_system: bool,
+    pub hidden_by_default: bool,
+    pub is_chart_axis_candidate: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnMeaning {
+    UserValue,
+    CompatibilityIndex,
+    SystemRecordId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterpretationSource {
+    Manifest,
+    CompatibilityInference,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedDuplicatePolicy {
+    LatestByRecordIdPlaceholder,
+    CompatibilityRowOrderPlaceholder,
+}

--- a/crates/fricon/src/dataset/read/access.rs
+++ b/crates/fricon/src/dataset/read/access.rs
@@ -29,7 +29,7 @@ pub(crate) fn get_dataset_reader(
     // Prefer the active write session so reads observe in-progress data for a
     // dataset that has not yet been finalized to disk.
     if let Some(handle) = write_sessions.get(dataset.id) {
-        Ok(DatasetReader::from_handle(handle)?)
+        Ok(DatasetReader::from_handle(handle))
     } else {
         let path = paths.dataset_path_from_uid(dataset.uid);
         Ok(DatasetReader::open_dir(path)?)

--- a/crates/fricon/src/dataset/read/error.rs
+++ b/crates/fricon/src/dataset/read/error.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::core::DatabaseError,
-    dataset::{schema::DatasetError, storage::error::DatasetFsError},
+    dataset::{schema::DatasetError, semantics::ManifestError, storage::error::DatasetFsError},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -13,6 +13,8 @@ pub enum ReadError {
     EmptyDataset,
     #[error(transparent)]
     Dataset(#[from] DatasetError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
     #[error(transparent)]
     DatasetFs(#[from] DatasetFsError),
     #[error(transparent)]

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -74,7 +74,7 @@ impl DatasetSource {
 
 pub struct DatasetReader {
     source: DatasetSource,
-    schema: DatasetSchema,
+    schema: Option<DatasetSchema>,
     arrow_schema: SchemaRef,
     dataset_dir: Option<PathBuf>,
 }
@@ -203,7 +203,7 @@ fn select_data_owned(
 impl DatasetReader {
     pub(crate) fn from_handle(source: WriteSessionHandle) -> Result<Self, ReadError> {
         let arrow_schema = source.schema();
-        let schema = arrow_schema.as_ref().try_into()?;
+        let schema = arrow_schema.as_ref().try_into().ok();
         Ok(Self {
             source: DatasetSource::WriteSession(source),
             schema,
@@ -216,7 +216,7 @@ impl DatasetReader {
         let mut reader = ChunkReader::new(path.clone(), None);
         reader.read_all()?;
         let arrow_schema = reader.schema().ok_or(ReadError::EmptyDataset)?.clone();
-        let schema = arrow_schema.as_ref().try_into()?;
+        let schema = arrow_schema.as_ref().try_into().ok();
         Ok(Self {
             source: DatasetSource::File(reader),
             schema,
@@ -227,7 +227,15 @@ impl DatasetReader {
 
     #[must_use]
     pub fn schema(&self) -> &DatasetSchema {
-        &self.schema
+        self.schema
+            .as_ref()
+            .expect("dataset schema is not compatible with the legacy schema model")
+    }
+
+    pub fn try_schema(&self) -> Result<&DatasetSchema, ReadError> {
+        self.schema
+            .as_ref()
+            .ok_or(ReadError::Dataset(DatasetError::IncompatibleType))
     }
 
     #[must_use]
@@ -268,15 +276,20 @@ impl DatasetReader {
         }
 
         Ok(resolve_from_compatibility_inference(
-            &self.schema,
-            self.index_columns(),
+            self.try_schema()?,
+            self.try_index_columns()?,
         ))
     }
 
     #[must_use]
     pub fn index_columns(&self) -> Option<Vec<usize>> {
+        self.try_index_columns().ok().flatten()
+    }
+
+    pub fn try_index_columns(&self) -> Result<Option<Vec<usize>>, ReadError> {
+        let schema = self.try_schema()?;
         if self.source.num_rows() < 2 {
-            None
+            Ok(None)
         } else {
             let sample = self.source.range(..2);
             let sample =
@@ -285,7 +298,7 @@ impl DatasetReader {
             for (index, (sample_array, column_type)) in sample
                 .columns()
                 .iter()
-                .zip(self.schema.columns().values())
+                .zip(schema.columns().values())
                 .enumerate()
             {
                 if !matches!(column_type, DatasetDataType::Scalar(_)) {
@@ -298,7 +311,7 @@ impl DatasetReader {
                     break;
                 }
             }
-            Some(result)
+            Ok(Some(result))
         }
     }
 }

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -201,15 +201,15 @@ fn select_data_owned(
 }
 
 impl DatasetReader {
-    pub(crate) fn from_handle(source: WriteSessionHandle) -> Result<Self, ReadError> {
+    pub(crate) fn from_handle(source: WriteSessionHandle) -> Self {
         let arrow_schema = source.schema();
         let schema = arrow_schema.as_ref().try_into().ok();
-        Ok(Self {
+        Self {
             source: DatasetSource::WriteSession(source),
             schema,
             arrow_schema,
             dataset_dir: None,
-        })
+        }
     }
 
     pub(crate) fn open_dir(path: PathBuf) -> Result<Self, ReadError> {
@@ -265,7 +265,7 @@ impl DatasetReader {
             manifest
                 .validate_against_arrow_schema(self.arrow_schema.as_ref())
                 .map_err(ManifestError::from)?;
-            return Ok(resolve_from_manifest(self.arrow_schema.as_ref(), manifest));
+            return Ok(resolve_from_manifest(self.arrow_schema.as_ref(), &manifest));
         }
 
         Ok(resolve_from_compatibility_inference(

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -9,8 +9,12 @@ use itertools::{Either, Itertools};
 
 use crate::dataset::{
     ingest::WriteSessionHandle,
+    interpret::{
+        DatasetInterpretation, resolve_from_compatibility_inference, resolve_from_manifest,
+    },
     read::{ReadError, SelectOptions},
     schema::{DatasetDataType, DatasetError, DatasetSchema},
+    semantics::{ManifestError, read_manifest_optional},
     storage::ChunkReader,
 };
 
@@ -72,6 +76,7 @@ pub struct DatasetReader {
     source: DatasetSource,
     schema: DatasetSchema,
     arrow_schema: SchemaRef,
+    dataset_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Default)]
@@ -203,11 +208,12 @@ impl DatasetReader {
             source: DatasetSource::WriteSession(source),
             schema,
             arrow_schema,
+            dataset_dir: None,
         })
     }
 
     pub(crate) fn open_dir(path: PathBuf) -> Result<Self, ReadError> {
-        let mut reader = ChunkReader::new(path, None);
+        let mut reader = ChunkReader::new(path.clone(), None);
         reader.read_all()?;
         let arrow_schema = reader.schema().ok_or(ReadError::EmptyDataset)?.clone();
         let schema = arrow_schema.as_ref().try_into()?;
@@ -215,6 +221,7 @@ impl DatasetReader {
             source: DatasetSource::File(reader),
             schema,
             arrow_schema,
+            dataset_dir: Some(path),
         })
     }
 
@@ -248,6 +255,22 @@ impl DatasetReader {
         options: &SelectOptions,
     ) -> Result<(SchemaRef, Vec<RecordBatch>), ReadError> {
         self.source.select_data(options)
+    }
+
+    pub fn interpret(&self) -> Result<DatasetInterpretation, ReadError> {
+        if let Some(dataset_dir) = &self.dataset_dir
+            && let Some(manifest) = read_manifest_optional(dataset_dir)?
+        {
+            manifest
+                .validate_against_arrow_schema(self.arrow_schema.as_ref())
+                .map_err(ManifestError::from)?;
+            return Ok(resolve_from_manifest(self.arrow_schema.as_ref(), manifest));
+        }
+
+        Ok(resolve_from_compatibility_inference(
+            &self.schema,
+            self.index_columns(),
+        ))
     }
 
     #[must_use]

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -225,14 +225,7 @@ impl DatasetReader {
         })
     }
 
-    #[must_use]
-    pub fn schema(&self) -> &DatasetSchema {
-        self.schema
-            .as_ref()
-            .expect("dataset schema is not compatible with the legacy schema model")
-    }
-
-    pub fn try_schema(&self) -> Result<&DatasetSchema, ReadError> {
+    pub fn schema(&self) -> Result<&DatasetSchema, ReadError> {
         self.schema
             .as_ref()
             .ok_or(ReadError::Dataset(DatasetError::IncompatibleType))
@@ -276,7 +269,7 @@ impl DatasetReader {
         }
 
         Ok(resolve_from_compatibility_inference(
-            self.try_schema()?,
+            self.schema()?,
             self.try_index_columns()?,
         ))
     }
@@ -287,7 +280,7 @@ impl DatasetReader {
     }
 
     pub fn try_index_columns(&self) -> Result<Option<Vec<usize>>, ReadError> {
-        let schema = self.try_schema()?;
+        let schema = self.schema()?;
         if self.source.num_rows() < 2 {
             Ok(None)
         } else {

--- a/crates/fricon/src/lib.rs
+++ b/crates/fricon/src/lib.rs
@@ -19,10 +19,11 @@ pub use self::{
     app::{AppHandle, AppManager, CatalogAppError, IngestAppError, ReadAppError},
     client::{Client, ClientError, Dataset, DatasetWriter, ExistingUiProbeResult},
     dataset::{
-        DatasetArray, DatasetDataType, DatasetEvent, DatasetId, DatasetListQuery, DatasetMetadata,
-        DatasetReader, DatasetRecord, DatasetRow, DatasetScalar, DatasetSchema, DatasetSortBy,
-        DatasetStatus, DatasetUpdate, FixedStepTrace, ScalarArray, ScalarKind, SelectOptions,
-        SortDirection, TraceKind, VariableStepTrace,
+        ColumnMeaning, DatasetArray, DatasetDataType, DatasetEvent, DatasetId,
+        DatasetInterpretation, DatasetListQuery, DatasetMetadata, DatasetReader, DatasetRecord,
+        DatasetRow, DatasetScalar, DatasetSchema, DatasetSortBy, DatasetStatus, DatasetUpdate,
+        FixedStepTrace, InterpretationSource, ResolvedColumn, ResolvedDuplicatePolicy, ScalarArray,
+        ScalarKind, SelectOptions, SortDirection, TraceKind, VariableStepTrace,
     },
     workspace::{WorkspaceError, WorkspaceRoot, get_log_dir},
 };

--- a/crates/fricon/src/transport/grpc/dataset_service.rs
+++ b/crates/fricon/src/transport/grpc/dataset_service.rs
@@ -187,7 +187,10 @@ impl From<ReadAppError> for Status {
                 error.to_string(),
             ),
             ReadAppError::Domain(
-                ReadError::Dataset(_) | ReadError::DatasetFs(_) | ReadError::Database(_),
+                ReadError::Dataset(_)
+                | ReadError::Manifest(_)
+                | ReadError::DatasetFs(_)
+                | ReadError::Database(_),
             ) => dataset_status(
                 Code::Internal,
                 DatasetTransportErrorCode::Internal,

--- a/crates/fricon/tests/integration_test.rs
+++ b/crates/fricon/tests/integration_test.rs
@@ -246,7 +246,7 @@ async fn test_dataset_create_metadata_payload_finish_completes() -> anyhow::Resu
     let loaded_batches: Vec<RecordBatch> = reader.batches();
 
     // Verify loaded data matches original
-    assert_eq!(reader.schema(), &test_schema);
+    assert_eq!(reader.schema()?, &test_schema);
     assert_eq!(loaded_batches.len(), 1);
     let loaded_batch = &loaded_batches[0];
 


### PR DESCRIPTION
closes #476 

## Summary
- Add a dataset interpretation model that resolves column meaning, index candidates, and duplicate policy from either a semantic manifest or legacy compatibility inference.
- Teach dataset reads to surface manifest validation failures and fall back cleanly to compatibility-based interpretation when no manifest is present.
- Update UI chart and dataset-detail queries to use the new fallible schema/index accessors, and map manifest read errors to internal API errors.

## Testing
- Added unit coverage for manifest-based interpretation, legacy inference, manifest/schema mismatch handling, and reader fallback behavior.
- Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
