### PR TITLE
feat: write dataset manifests during ingest

### DIFF
--- a/crates/fricon/src/dataset/ingest.rs
+++ b/crates/fricon/src/dataset/ingest.rs
@@ -13,6 +13,7 @@ mod session;
 mod storage;
 
 use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
 use uuid::Uuid;
 
 pub use self::error::IngestError;
@@ -61,6 +62,7 @@ pub(crate) struct CreateDatasetRequest {
 /// the dataset in `Aborted` status.
 #[derive(Debug)]
 pub(crate) enum CreateDatasetInput {
+    Schema(SchemaRef),
     Batch(RecordBatch),
     Finish,
     Abort,

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -115,12 +115,10 @@ where
 
     match terminal {
         CreateDatasetInput::Finish => {
-            if !manifest_written {
-                if let Err(error) = write_empty_manifest(&dataset_path) {
-                    debug!(error = %error, "Failed to write empty dataset semantic manifest");
-                    let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
-                    return Err(error);
-                }
+            if !manifest_written && let Err(error) = write_empty_manifest(&dataset_path) {
+                debug!(error = %error, "Failed to write empty dataset semantic manifest");
+                let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
+                return Err(error);
             }
             if let Some(session) = session.take()
                 && let Err(error) = session.finalize_session()
@@ -194,7 +192,10 @@ mod tests {
         dataset::{
             events::{DatasetEvent, test_utils::CollectEvents},
             model::{DatasetMetadata, DatasetStatus},
-            semantics::{DatasetDType, ManifestValidationError, RECORD_ID_COLUMN, read_manifest},
+            semantics::{
+                DatasetDType, ManifestError, ManifestValidationError, RECORD_ID_COLUMN,
+                read_manifest,
+            },
             storage::layout::manifest_path,
         },
         workspace::WorkspaceRoot,
@@ -493,7 +494,7 @@ mod tests {
         assert_eq!(repo.updated_statuses(), vec![DatasetStatus::Aborted]);
         assert!(matches!(
             error,
-            IngestError::Manifest(crate::dataset::semantics::ManifestError::Validation(
+            IngestError::Manifest(ManifestError::Validation(
                 ManifestValidationError::ReservedUserColumn { name }
             )) if name == "__ds_user"
         ));

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -18,6 +18,7 @@ use crate::{
             WriteSessionRegistry,
         },
         model::{DatasetId, DatasetRecord, DatasetStatus},
+        semantics::{DatasetSemanticManifest, ManifestColumn, ManifestError, write_manifest},
         storage,
     },
     workspace::WorkspacePaths,
@@ -66,13 +67,32 @@ where
     events.publish(DatasetEvent::Created(dataset_record.clone()));
 
     let mut session = None;
+    let mut manifest_written = false;
     let terminal = loop {
         let Some(event) = next_input() else {
             break CreateDatasetInput::Abort;
         };
 
         match event {
+            CreateDatasetInput::Schema(schema) => {
+                if !manifest_written {
+                    if let Err(error) = write_minimal_manifest(&dataset_path, schema.as_ref()) {
+                        debug!(error = %error, "Failed to write dataset semantic manifest");
+                        let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
+                        return Err(error);
+                    }
+                    manifest_written = true;
+                }
+            }
             CreateDatasetInput::Batch(batch) => {
+                if !manifest_written {
+                    if let Err(error) = write_minimal_manifest(&dataset_path, batch.schema_ref()) {
+                        debug!(error = %error, "Failed to write dataset semantic manifest");
+                        let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
+                        return Err(error);
+                    }
+                    manifest_written = true;
+                }
                 let session_ref = session.get_or_insert_with(|| {
                     write_sessions.start_session(
                         dataset_record.id,
@@ -95,6 +115,13 @@ where
 
     match terminal {
         CreateDatasetInput::Finish => {
+            if !manifest_written {
+                if let Err(error) = write_empty_manifest(&dataset_path) {
+                    debug!(error = %error, "Failed to write empty dataset semantic manifest");
+                    let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
+                    return Err(error);
+                }
+            }
             if let Some(session) = session.take()
                 && let Err(error) = session.finalize_session()
             {
@@ -120,7 +147,9 @@ where
             events.publish(DatasetEvent::StatusChanged(record.clone()));
             Ok(record)
         }
-        CreateDatasetInput::Batch(_) => unreachable!("batch cannot terminate dataset creation"),
+        CreateDatasetInput::Schema(_) | CreateDatasetInput::Batch(_) => {
+            unreachable!("non-terminal input cannot terminate dataset creation")
+        }
     }
 }
 
@@ -135,11 +164,27 @@ fn create_dataset_dir(paths: &WorkspacePaths, uid: Uuid) -> Result<PathBuf, Inge
     Ok(path)
 }
 
+fn write_minimal_manifest(
+    dataset_path: &std::path::Path,
+    schema: &arrow_schema::Schema,
+) -> Result<(), IngestError> {
+    let manifest =
+        DatasetSemanticManifest::minimal_from_arrow_schema(schema).map_err(ManifestError::from)?;
+    write_manifest(dataset_path, &manifest)?;
+    Ok(())
+}
+
+fn write_empty_manifest(dataset_path: &std::path::Path) -> Result<(), IngestError> {
+    let manifest = DatasetSemanticManifest::minimal(std::iter::empty::<(String, ManifestColumn)>());
+    write_manifest(dataset_path, &manifest)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::VecDeque, fs, sync::Mutex};
 
-    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_array::{Float64Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use chrono::Utc;
     use tempfile::TempDir;
@@ -149,6 +194,8 @@ mod tests {
         dataset::{
             events::{DatasetEvent, test_utils::CollectEvents},
             model::{DatasetMetadata, DatasetStatus},
+            semantics::{DatasetDType, ManifestValidationError, RECORD_ID_COLUMN, read_manifest},
+            storage::layout::manifest_path,
         },
         workspace::WorkspaceRoot,
     };
@@ -244,10 +291,24 @@ mod tests {
     }
 
     fn one_col_batch() -> RecordBatch {
-        let schema =
-            std::sync::Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        RecordBatch::try_new(schema, vec![std::sync::Arc::new(Int32Array::from(vec![1]))])
-            .expect("batch")
+        let schema = std::sync::Arc::new(Schema::new(vec![Field::new(
+            "id",
+            DataType::Float64,
+            false,
+        )]));
+        RecordBatch::try_new(
+            schema,
+            vec![std::sync::Arc::new(Float64Array::from(vec![1.0]))],
+        )
+        .expect("batch")
+    }
+
+    fn one_col_schema() -> std::sync::Arc<Schema> {
+        std::sync::Arc::new(Schema::new(vec![Field::new(
+            "id",
+            DataType::Float64,
+            false,
+        )]))
     }
 
     #[test]
@@ -277,6 +338,15 @@ mod tests {
             [DatasetEvent::Created(created), DatasetEvent::StatusChanged(status)]
             if created.id == record.id && status.id == record.id
         ));
+        let manifest = read_manifest(manifest_path(
+            &paths.dataset_path_from_uid(repo.created_uid()),
+        ))
+        .expect("read manifest");
+        assert_eq!(manifest.columns.len(), 1);
+        assert_eq!(
+            manifest.columns[RECORD_ID_COLUMN].dtype,
+            DatasetDType::UInt64
+        );
     }
 
     #[test]
@@ -342,6 +412,90 @@ mod tests {
                 && progress.id == record.id
                 && progress.row_count == 1
                 && status.id == record.id
+        ));
+
+        let manifest = read_manifest(manifest_path(
+            &paths.dataset_path_from_uid(repo.created_uid()),
+        ))
+        .expect("read manifest");
+        assert_eq!(
+            manifest.columns[RECORD_ID_COLUMN].dtype,
+            DatasetDType::UInt64
+        );
+        assert_eq!(manifest.columns["id"].dtype, DatasetDType::Float64);
+        assert!(manifest.realization.append_only);
+        assert!(manifest.compatibility.allow_inference);
+    }
+
+    #[test]
+    fn finish_after_schema_writes_manifest_without_batches() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = WorkspaceRoot::create_new(temp_dir.path()).expect("workspace");
+        let paths = workspace.paths().clone();
+        let repo = FakeRepo::new();
+        let events = CollectEvents::default();
+        let write_sessions = WriteSessionRegistry::new();
+        let mut inputs = VecDeque::from(vec![
+            CreateDatasetInput::Schema(one_col_schema()),
+            CreateDatasetInput::Finish,
+        ]);
+
+        let record = create_dataset_with(
+            &repo,
+            &paths,
+            &events,
+            &write_sessions,
+            &create_request(),
+            || inputs.pop_front(),
+        )
+        .expect("create dataset");
+
+        assert_eq!(record.metadata.status, DatasetStatus::Completed);
+        let manifest = read_manifest(manifest_path(
+            &paths.dataset_path_from_uid(repo.created_uid()),
+        ))
+        .expect("read manifest");
+        assert_eq!(manifest.columns["id"].dtype, DatasetDType::Float64);
+        assert_eq!(
+            manifest.columns[RECORD_ID_COLUMN].dtype,
+            DatasetDType::UInt64
+        );
+    }
+
+    #[test]
+    fn reserved_system_prefix_schema_aborts_and_returns_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = WorkspaceRoot::create_new(temp_dir.path()).expect("workspace");
+        let paths = workspace.paths().clone();
+        let repo = FakeRepo::new();
+        let events = CollectEvents::default();
+        let write_sessions = WriteSessionRegistry::new();
+        let schema = std::sync::Arc::new(Schema::new(vec![Field::new(
+            "__ds_user",
+            DataType::Float64,
+            false,
+        )]));
+        let mut inputs = VecDeque::from(vec![
+            CreateDatasetInput::Schema(schema),
+            CreateDatasetInput::Finish,
+        ]);
+
+        let error = create_dataset_with(
+            &repo,
+            &paths,
+            &events,
+            &write_sessions,
+            &create_request(),
+            || inputs.pop_front(),
+        )
+        .expect_err("reserved prefix should fail");
+
+        assert_eq!(repo.updated_statuses(), vec![DatasetStatus::Aborted]);
+        assert!(matches!(
+            error,
+            IngestError::Manifest(crate::dataset::semantics::ManifestError::Validation(
+                ManifestValidationError::ReservedUserColumn { name }
+            )) if name == "__ds_user"
         ));
     }
 

--- a/crates/fricon/src/dataset/ingest/error.rs
+++ b/crates/fricon/src/dataset/ingest/error.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::core::DatabaseError,
-    dataset::{schema::DatasetError, storage::error::DatasetFsError},
+    dataset::{schema::DatasetError, semantics::ManifestError, storage::error::DatasetFsError},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -11,6 +11,8 @@ pub enum IngestError {
     Dataset(#[from] DatasetError),
     #[error(transparent)]
     DatasetFs(#[from] DatasetFsError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
     #[error(transparent)]
     Database(#[from] DatabaseError),
 }

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -296,6 +296,40 @@ mod tests {
     }
 
     #[test]
+    fn reader_interpretation_accepts_manifest_before_record_id_materialization() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "signal",
+            DataType::Float64,
+            false,
+        )]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(schema, vec![Arc::new(Float64Array::from(vec![10.0, 20.0]))])
+                    .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+        write_manifest(
+            dir.path(),
+            &DatasetSemanticManifest::minimal([(
+                "signal".to_string(),
+                ManifestColumn::new(DatasetDType::Float64),
+            )]),
+        )
+        .expect("write manifest");
+
+        let reader =
+            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(interpretation.source, InterpretationSource::Manifest);
+        assert_eq!(interpretation.value_columns, vec![0]);
+        assert_eq!(interpretation.columns[0].meaning, ColumnMeaning::UserValue);
+    }
+
+    #[test]
     fn reader_interpretation_supports_manifest_dtypes_outside_legacy_schema() {
         let dir = tempfile::tempdir().expect("temp dir");
         let schema = Arc::new(Schema::new(vec![

--- a/crates/fricon/src/dataset/semantics/error.rs
+++ b/crates/fricon/src/dataset/semantics/error.rs
@@ -42,4 +42,6 @@ pub enum ManifestValidationError {
         expected: String,
         found: String,
     },
+    #[error("Unsupported Arrow type for dataset semantic manifest column {name}: {found}")]
+    UnsupportedArrowType { name: String, found: String },
 }

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -30,6 +30,21 @@ impl DatasetSemanticManifest {
         }
     }
 
+    pub fn minimal_from_arrow_schema(schema: &Schema) -> Result<Self, ManifestValidationError> {
+        let columns = schema
+            .fields()
+            .iter()
+            .map(|field| {
+                let name = field.name().clone();
+                let dtype = DatasetDType::try_from_arrow_field(field.as_ref())?;
+                Ok((name, ManifestColumn::new(dtype)))
+            })
+            .collect::<Result<Vec<_>, ManifestValidationError>>()?;
+        let manifest = Self::minimal(columns);
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
     pub fn validate(&self) -> Result<(), ManifestValidationError> {
         if self.manifest_version != MANIFEST_VERSION_V1 {
             return Err(ManifestValidationError::UnsupportedVersion {
@@ -58,6 +73,14 @@ impl DatasetSemanticManifest {
         self.validate()?;
 
         for (name, column) in &self.columns {
+            if column.system == Some(SystemColumn::RecordId)
+                && name == RECORD_ID_COLUMN
+                && schema.field_with_name(name).is_err()
+            {
+                // Temporary compatibility for manifest-only record IDs. Issue
+                // #478 will materialize this column into Arrow payloads.
+                continue;
+            }
             let field = schema
                 .field_with_name(name)
                 .map_err(|_| ManifestValidationError::MissingArrowColumn { name: name.clone() })?;
@@ -199,6 +222,47 @@ impl DatasetDType {
                 axis,
                 value,
             } => trace_data_type(*layout, *axis, *value),
+        }
+    }
+
+    fn try_from_arrow_field(field: &Field) -> Result<Self, ManifestValidationError> {
+        if field.name().starts_with(SYSTEM_COLUMN_PREFIX) {
+            return Err(ManifestValidationError::ReservedUserColumn {
+                name: field.name().clone(),
+            });
+        }
+        if field.is_nullable() {
+            return Err(ManifestValidationError::ArrowTypeMismatch {
+                name: field.name().clone(),
+                expected: "non-null supported v1 dataset dtype".to_string(),
+                found: format!("nullable {}", field.data_type()),
+            });
+        }
+        Self::try_from_arrow_data_type(field.name(), field.data_type())
+    }
+
+    fn try_from_arrow_data_type(
+        name: &str,
+        data_type: &DataType,
+    ) -> Result<Self, ManifestValidationError> {
+        if let Some(dtype) = try_trace_dtype(data_type)? {
+            return Ok(Self::trace(dtype));
+        }
+        if *data_type == complex128_data_type() {
+            return Ok(Self::Complex128);
+        }
+        match data_type {
+            DataType::Float64 => Ok(Self::Float64),
+            DataType::Float32 => Ok(Self::Float32),
+            DataType::Int64 => Ok(Self::Int64),
+            DataType::UInt64 => Ok(Self::UInt64),
+            DataType::Boolean => Ok(Self::Bool),
+            DataType::Utf8 => Ok(Self::Utf8),
+            DataType::Timestamp(TimeUnit::Microsecond, None) => Ok(Self::TimestampUs),
+            _ => Err(ManifestValidationError::UnsupportedArrowType {
+                name: name.to_string(),
+                found: data_type.to_string(),
+            }),
         }
     }
 }
@@ -363,11 +427,123 @@ fn complex128_data_type() -> DataType {
     )
 }
 
+fn try_trace_dtype(data_type: &DataType) -> Result<Option<TraceDType>, ManifestValidationError> {
+    match data_type {
+        DataType::List(value) => {
+            if value.is_nullable() {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: "trace value".to_string(),
+                    expected: "non-null trace value".to_string(),
+                    found: format!("nullable {}", value.data_type()),
+                });
+            }
+            let value = trace_value_dtype(value.data_type())?;
+            Ok(Some(TraceDType {
+                layout: TraceLayout::Simple,
+                axis: TraceAxisDType::Float64,
+                value,
+            }))
+        }
+        DataType::Struct(fields) => try_struct_trace_dtype(fields),
+        _ => Ok(None),
+    }
+}
+
+fn try_struct_trace_dtype(
+    fields: &arrow_schema::Fields,
+) -> Result<Option<TraceDType>, ManifestValidationError> {
+    match fields.as_ref() {
+        [x0, step, y]
+            if x0.name() == "x0"
+                && step.name() == "step"
+                && y.name() == "y"
+                && !x0.is_nullable()
+                && !step.is_nullable()
+                && !y.is_nullable() =>
+        {
+            let axis = trace_axis_dtype(x0.data_type())?;
+            if step.data_type() != x0.data_type() {
+                return Ok(None);
+            }
+            let DataType::List(value) = y.data_type() else {
+                return Ok(None);
+            };
+            if value.is_nullable() {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: "trace value".to_string(),
+                    expected: "non-null trace value".to_string(),
+                    found: format!("nullable {}", value.data_type()),
+                });
+            }
+            Ok(Some(TraceDType {
+                layout: TraceLayout::FixedStep,
+                axis,
+                value: trace_value_dtype(value.data_type())?,
+            }))
+        }
+        [x, y] if x.name() == "x" && y.name() == "y" && !x.is_nullable() && !y.is_nullable() => {
+            let (DataType::List(axis), DataType::List(value)) = (x.data_type(), y.data_type())
+            else {
+                return Ok(None);
+            };
+            if axis.is_nullable() {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: "trace axis".to_string(),
+                    expected: "non-null trace axis".to_string(),
+                    found: format!("nullable {}", axis.data_type()),
+                });
+            }
+            if value.is_nullable() {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: "trace value".to_string(),
+                    expected: "non-null trace value".to_string(),
+                    found: format!("nullable {}", value.data_type()),
+                });
+            }
+            Ok(Some(TraceDType {
+                layout: TraceLayout::VariableStep,
+                axis: trace_axis_dtype(axis.data_type())?,
+                value: trace_value_dtype(value.data_type())?,
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn trace_axis_dtype(data_type: &DataType) -> Result<TraceAxisDType, ManifestValidationError> {
+    match data_type {
+        DataType::Float64 => Ok(TraceAxisDType::Float64),
+        DataType::Float32 => Ok(TraceAxisDType::Float32),
+        DataType::Int64 => Ok(TraceAxisDType::Int64),
+        DataType::UInt64 => Ok(TraceAxisDType::UInt64),
+        _ => Err(ManifestValidationError::UnsupportedArrowType {
+            name: "trace axis".to_string(),
+            found: data_type.to_string(),
+        }),
+    }
+}
+
+fn trace_value_dtype(data_type: &DataType) -> Result<TraceValueDType, ManifestValidationError> {
+    if *data_type == complex128_data_type() {
+        return Ok(TraceValueDType::Complex128);
+    }
+    match data_type {
+        DataType::Float64 => Ok(TraceValueDType::Float64),
+        DataType::Float32 => Ok(TraceValueDType::Float32),
+        DataType::Int64 => Ok(TraceValueDType::Int64),
+        DataType::UInt64 => Ok(TraceValueDType::UInt64),
+        _ => Err(ManifestValidationError::UnsupportedArrowType {
+            name: "trace value".to_string(),
+            found: data_type.to_string(),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
 
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
     use serde_json::json;
 
     use super::{
@@ -557,6 +733,87 @@ mod tests {
         manifest
             .validate_against_arrow_schema(&schema)
             .expect("schema should match manifest");
+    }
+
+    #[test]
+    fn minimal_from_arrow_schema_records_supported_user_columns() {
+        let schema = Schema::new(vec![
+            Field::new("float", DataType::Float32, false),
+            Field::new("count", DataType::Int64, false),
+            Field::new("flag", DataType::Boolean, false),
+            Field::new("label", DataType::Utf8, false),
+            Field::new(
+                "time",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                false,
+            ),
+            Field::new(
+                "trace",
+                DatasetDType::trace(TraceDType {
+                    layout: TraceLayout::VariableStep,
+                    axis: TraceAxisDType::UInt64,
+                    value: TraceValueDType::Float64,
+                })
+                .physical_data_type(),
+                false,
+            ),
+        ]);
+
+        let manifest =
+            DatasetSemanticManifest::minimal_from_arrow_schema(&schema).expect("manifest");
+
+        assert_eq!(manifest.columns["float"].dtype, DatasetDType::Float32);
+        assert_eq!(manifest.columns["count"].dtype, DatasetDType::Int64);
+        assert_eq!(manifest.columns["flag"].dtype, DatasetDType::Bool);
+        assert_eq!(manifest.columns["label"].dtype, DatasetDType::Utf8);
+        assert_eq!(manifest.columns["time"].dtype, DatasetDType::TimestampUs);
+        assert_eq!(
+            manifest.columns["trace"].dtype,
+            DatasetDType::trace(TraceDType {
+                layout: TraceLayout::VariableStep,
+                axis: TraceAxisDType::UInt64,
+                value: TraceValueDType::Float64,
+            })
+        );
+        assert_eq!(
+            manifest.columns.get(RECORD_ID_COLUMN),
+            Some(&ManifestColumn::record_id())
+        );
+    }
+
+    #[test]
+    fn minimal_from_arrow_schema_rejects_reserved_user_prefix() {
+        let schema = Schema::new(vec![Field::new("__ds_user", DataType::Float64, false)]);
+
+        assert_eq!(
+            DatasetSemanticManifest::minimal_from_arrow_schema(&schema),
+            Err(ManifestValidationError::ReservedUserColumn {
+                name: "__ds_user".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn minimal_from_arrow_schema_rejects_unsupported_arrow_type() {
+        let schema = Schema::new(vec![Field::new("small", DataType::Int32, false)]);
+
+        assert_eq!(
+            DatasetSemanticManifest::minimal_from_arrow_schema(&schema),
+            Err(ManifestValidationError::UnsupportedArrowType {
+                name: "small".to_string(),
+                found: "Int32".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn validate_against_arrow_schema_allows_temporarily_missing_record_id() {
+        let manifest = DatasetSemanticManifest::minimal(signal_columns());
+        let schema = Schema::new(vec![Field::new("signal", DataType::Float64, false)]);
+
+        manifest
+            .validate_against_arrow_schema(&schema)
+            .expect("record id is manifest-only until materialization lands");
     }
 
     #[test]

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -245,8 +245,15 @@ impl DatasetDType {
         name: &str,
         data_type: &DataType,
     ) -> Result<Self, ManifestValidationError> {
-        if let Some(dtype) = try_trace_dtype(data_type)? {
-            return Ok(Self::trace(dtype));
+        match try_trace_dtype(data_type) {
+            Ok(Some(dtype)) => return Ok(Self::trace(dtype)),
+            Ok(None) => {}
+            Err(_) => {
+                return Err(ManifestValidationError::UnsupportedArrowType {
+                    name: name.to_string(),
+                    found: data_type.to_string(),
+                });
+            }
         }
         if *data_type == complex128_data_type() {
             return Ok(Self::Complex128);
@@ -804,6 +811,21 @@ mod tests {
                 found: "Int32".to_string()
             })
         );
+    }
+
+    #[test]
+    fn minimal_from_arrow_schema_reports_list_type_with_user_column_name() {
+        let schema = Schema::new(vec![Field::new(
+            "flags",
+            DataType::new_list(DataType::Boolean, false),
+            false,
+        )]);
+
+        assert!(matches!(
+            DatasetSemanticManifest::minimal_from_arrow_schema(&schema),
+            Err(ManifestValidationError::UnsupportedArrowType { name, found })
+                if name == "flags" && found.contains("Boolean")
+        ));
     }
 
     #[test]

--- a/crates/fricon/src/transport/grpc/create_stream.rs
+++ b/crates/fricon/src/transport/grpc/create_stream.rs
@@ -65,6 +65,7 @@ where
     S: Stream<Item = Result<CreateRequest, Status>> + Unpin,
 {
     let mut decoder = StreamDecoder::new();
+    let mut schema_sent = false;
 
     loop {
         tokio::select! {
@@ -74,6 +75,7 @@ where
                         match handle_stream_message(
                             request.create_message,
                             &mut decoder,
+                            &mut schema_sent,
                             &events_tx,
                         )
                         .await
@@ -139,10 +141,13 @@ async fn send_abort_and_error(
 async fn handle_stream_message(
     message: Option<CreateMessage>,
     decoder: &mut StreamDecoder,
+    schema_sent: &mut bool,
     events_tx: &mpsc::Sender<CreateDatasetInput>,
 ) -> Result<Option<CreateDatasetInput>, Status> {
     match message {
-        Some(CreateMessage::Payload(payload)) => decode_payload(payload, decoder, events_tx).await,
+        Some(CreateMessage::Payload(payload)) => {
+            decode_payload(payload, decoder, schema_sent, events_tx).await
+        }
         Some(CreateMessage::Metadata(_)) => {
             warn!("Unexpected metadata message after initial create metadata");
             Err(Status::invalid_argument(
@@ -171,18 +176,22 @@ async fn handle_stream_message(
 async fn decode_payload(
     payload: bytes::Bytes,
     decoder: &mut StreamDecoder,
+    schema_sent: &mut bool,
     events_tx: &mpsc::Sender<CreateDatasetInput>,
 ) -> Result<Option<CreateDatasetInput>, Status> {
     let mut buffer = Buffer::from(payload);
     while !buffer.is_empty() {
         match decoder.decode(&mut buffer) {
             Ok(Some(batch)) => {
+                send_schema_if_decoded(decoder, schema_sent, events_tx).await?;
                 events_tx
                     .send(CreateDatasetInput::Batch(batch))
                     .await
                     .map_err(|_| Status::internal("create ingest receiver dropped"))?;
             }
-            Ok(None) => {}
+            Ok(None) => {
+                send_schema_if_decoded(decoder, schema_sent, events_tx).await?;
+            }
             Err(error) => {
                 error!(error = %error, "Failed to decode Arrow payload");
                 return Err(Status::invalid_argument("failed to decode Arrow payload"));
@@ -190,6 +199,21 @@ async fn decode_payload(
         }
     }
     Ok(None)
+}
+
+async fn send_schema_if_decoded(
+    decoder: &StreamDecoder,
+    schema_sent: &mut bool,
+    events_tx: &mpsc::Sender<CreateDatasetInput>,
+) -> Result<(), Status> {
+    if !*schema_sent && let Some(schema) = decoder.schema() {
+        events_tx
+            .send(CreateDatasetInput::Schema(schema))
+            .await
+            .map_err(|_| Status::internal("create ingest receiver dropped"))?;
+        *schema_sent = true;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -267,6 +291,10 @@ mod tests {
         let (events, result) = collect_events(stream, CancellationToken::new()).await;
         assert!(result.is_ok());
 
+        assert!(matches!(
+            events.first(),
+            Some(CreateDatasetInput::Schema(_))
+        ));
         assert!(
             events
                 .iter()

--- a/crates/fricon/src/transport/grpc/dataset_service.rs
+++ b/crates/fricon/src/transport/grpc/dataset_service.rs
@@ -155,7 +155,10 @@ impl From<IngestAppError> for Status {
                 error.to_string(),
             ),
             IngestAppError::Domain(
-                IngestError::Dataset(_) | IngestError::DatasetFs(_) | IngestError::Database(_),
+                IngestError::Dataset(_)
+                | IngestError::DatasetFs(_)
+                | IngestError::Manifest(_)
+                | IngestError::Database(_),
             ) => dataset_status(
                 Code::Internal,
                 DatasetTransportErrorCode::Internal,

--- a/crates/fricon/src/transport/grpc/dataset_service.rs
+++ b/crates/fricon/src/transport/grpc/dataset_service.rs
@@ -17,7 +17,7 @@ use crate::{
     app::{AppHandle, CatalogAppError, IngestAppError, ReadAppError},
     dataset::{
         DatasetId, DatasetListQuery, DatasetUpdate, catalog::CatalogError, ingest::IngestError,
-        read::ReadError,
+        read::ReadError, semantics::ManifestError,
     },
     proto::{
         self, AddTagsRequest, AddTagsResponse, CreateRequest, CreateResponse, DeleteRequest,
@@ -154,6 +154,13 @@ impl From<IngestAppError> for Status {
                 DatasetTransportErrorCode::Internal,
                 error.to_string(),
             ),
+            IngestAppError::Domain(IngestError::Manifest(ManifestError::Validation(_))) => {
+                dataset_status(
+                    Code::InvalidArgument,
+                    DatasetTransportErrorCode::Internal,
+                    "invalid dataset manifest",
+                )
+            }
             IngestAppError::Domain(
                 IngestError::Dataset(_)
                 | IngestError::DatasetFs(_)
@@ -386,7 +393,11 @@ mod tests {
         app::{CatalogAppError, IngestAppError, ReadAppError},
         database::core::DatabaseError,
         dataset::{
-            catalog::CatalogError, ingest::IngestError, read::ReadError, schema::DatasetError,
+            catalog::CatalogError,
+            ingest::IngestError,
+            read::ReadError,
+            schema::DatasetError,
+            semantics::{ManifestError, ManifestValidationError},
         },
         transport::grpc::codec::CodecError,
     };
@@ -485,6 +496,21 @@ mod tests {
         )));
         assert_eq!(status.code(), Code::Internal);
         assert_eq!(status.message(), "dataset ingestion failed");
+        assert_eq!(
+            dataset_code(&status),
+            Some(DatasetTransportErrorCode::Internal.as_str())
+        );
+    }
+
+    #[test]
+    fn ingest_manifest_validation_failure_maps_to_invalid_argument() {
+        let status = Status::from(IngestAppError::Domain(IngestError::Manifest(
+            ManifestError::Validation(ManifestValidationError::ReservedUserColumn {
+                name: "__ds_user".to_string(),
+            }),
+        )));
+        assert_eq!(status.code(), Code::InvalidArgument);
+        assert_eq!(status.message(), "invalid dataset manifest");
         assert_eq!(
             dataset_code(&status),
             Some(DatasetTransportErrorCode::Internal.as_str())

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -12,13 +12,9 @@ as stable user-facing documentation. Public docs should describe workspaces and
 datasets through the CLI, Python API, and desktop UI rather than through the
 on-disk layout.
 
-Dataset semantics proposal documents describe future direction, not current
-storage facts. Use this file as the current source of truth until those
-proposals are implemented and this note is updated.
-
-The accepted future foundation for dataset semantic manifests is recorded in
-`dev-docs/adr/0002-decide-dataset-semantic-manifest-v1.md`; it is not current
-storage behavior until implementation lands.
+Dataset semantics proposal documents describe long-term direction. Use this
+file as the current source of truth for implemented storage facts, including
+the current v1 dataset semantic manifest sidecar.
 
 ## Workspace Layout
 
@@ -33,6 +29,7 @@ workspace/
     .graveyard/
     <uid[0:2]>/
       <uid>/
+        dataset_manifest.json
         data_chunk_0.arrow
         data_chunk_1.arrow
   backup/
@@ -58,6 +55,13 @@ Current dataset payloads are chunked [Arrow IPC][] files under the dataset
 directory. A dataset is modeled as one logical Arrow table split across
 `data_chunk_<n>.arrow` files as needed.
 
+New datasets created through ingest also store `dataset_manifest.json` beside
+the chunk files. The manifest records v1 dataset semantic columns, realization
+defaults, and compatibility settings. During the transition before physical
+record-id materialization, the manifest may declare the Fricon-owned
+`__ds_record_id` system column even when the Arrow chunks do not yet contain
+that physical column.
+
 The physical storage layout is an implementation detail. User-facing docs may
 mention Arrow-compatible tables, but should avoid promising exact file names,
 chunking behavior, or directory structure.
@@ -68,8 +72,8 @@ Current dataset catalog metadata lives in SQLite. This includes dataset name,
 description, favorite state, status, timestamps, and tags as represented by
 `DatasetRecord` / `DatasetMetadata`.
 
-Dataset payload facts live in Arrow chunk files. Future semantic manifest files
-described by the dataset semantic proposal docs are not current behavior.
+Dataset payload facts live in Arrow chunk files. Dataset semantic defaults and
+compatibility settings for new ingested datasets live in `dataset_manifest.json`.
 
 ## Write Buffering
 


### PR DESCRIPTION
## Summary
- Write `dataset_manifest.json` for new datasets during ingest.
- Emit an internal schema event from the Arrow create stream so manifest generation can happen as soon as the schema is known.
- Keep legacy manifest-missing datasets readable through compatibility inference and reject reserved `__ds_` user columns.
- Update current storage notes for the new dataset sidecar.

## Testing
- Added unit tests for manifest generation, reserved-prefix validation, temporary record-id compatibility, and create-stream schema emission.
- Ran Rust formatting, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo nextest run` successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
