### PR TITLE
feat: materialize dataset record IDs in storage

### DIFF
--- a/crates/fricon-py/python/fricon/_helper.py
+++ b/crates/fricon-py/python/fricon/_helper.py
@@ -11,6 +11,7 @@ import polars as pl
 import pyarrow as pa
 
 _CHUNK_PATTERN = re.compile(r"data_chunk_(\d+)\.arrow$")
+_SYSTEM_COLUMN_PREFIX = "__ds_"
 
 
 def _collect_chunk_files(dir_path: str) -> list[Path]:
@@ -39,7 +40,13 @@ def read_arrow(dir_path: str) -> pa.Table:
     for f in files:
         with pa.memory_map(str(f), "rb") as source:
             tables.append(pa.ipc.open_file(source).read_all())
-    return pa.concat_tables(tables)
+    table = pa.concat_tables(tables)
+    visible_columns = [
+        name
+        for name in table.column_names
+        if not name.startswith(_SYSTEM_COLUMN_PREFIX)
+    ]
+    return table.select(visible_columns)
 
 
 def read_polars(dir_path: str) -> pl.LazyFrame:
@@ -47,4 +54,4 @@ def read_polars(dir_path: str) -> pl.LazyFrame:
     if not files:
         msg = f"no chunk files found in {dir_path}"
         raise FileNotFoundError(msg)
-    return pl.scan_ipc(files)
+    return pl.scan_ipc(files).select(pl.all().exclude("^__ds_.*$"))

--- a/crates/fricon-py/tests/integration/test_dataset_operations.py
+++ b/crates/fricon-py/tests/integration/test_dataset_operations.py
@@ -120,7 +120,10 @@ class TestDatasetOperations:
 
             reopened = dm.open(dataset.id)
             expected_rows = 2
-            assert reopened.to_arrow().num_rows == expected_rows
+            table = reopened.to_arrow()
+            assert table.num_rows == expected_rows
+            assert "__ds_record_id" not in table.column_names
+            assert "__ds_record_id" not in reopened.to_polars().collect().columns
 
             server_handle.shutdown()
             assert not server_handle.is_running

--- a/crates/fricon/src/dataset.rs
+++ b/crates/fricon/src/dataset.rs
@@ -13,8 +13,8 @@ mod tag;
 pub use self::{
     events::DatasetEvent,
     interpret::{
-        ColumnMeaning, DatasetInterpretation, InterpretationSource, ResolvedColumn,
-        ResolvedDuplicatePolicy,
+        ColumnMeaning, DatasetInterpretation, InterpretationSource, PhysicalColumnOrdinal,
+        ResolvedColumn, ResolvedDuplicatePolicy, VisibleColumnOrdinal,
     },
     model::{
         DatasetId, DatasetListQuery, DatasetMetadata, DatasetRecord, DatasetSortBy, DatasetStatus,

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -97,10 +97,10 @@ where
                     write_sessions.start_session(
                         dataset_record.id,
                         dataset_path.clone(),
-                        batch.schema(),
+                        &batch.schema(),
                     )
                 });
-                if let Err(error) = session_ref.write_batch(batch) {
+                if let Err(error) = session_ref.write_batch(&batch) {
                     debug!(error = %error, "Failed to write batch into dataset session");
                     break CreateDatasetInput::Abort;
                 }

--- a/crates/fricon/src/dataset/ingest/registry.rs
+++ b/crates/fricon/src/dataset/ingest/registry.rs
@@ -104,7 +104,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::WriteSessionRegistry;
-    use crate::dataset::storage::ChunkReader;
+    use crate::dataset::{semantics::materialized_schema, storage::ChunkReader};
 
     fn test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
@@ -130,7 +130,10 @@ mod tests {
 
         guard.finalize_session().unwrap();
 
-        let mut reader = ChunkReader::new(dir.path().to_owned(), Some(test_schema()));
+        let mut reader = ChunkReader::new(
+            dir.path().to_owned(),
+            Some(materialized_schema(test_schema().as_ref())),
+        );
         reader.read_all().unwrap();
         assert_eq!(reader.num_rows(), 3);
     }
@@ -147,7 +150,10 @@ mod tests {
 
         assert!(registry.get(1).is_none());
 
-        let mut reader = ChunkReader::new(dir.path().to_owned(), Some(test_schema()));
+        let mut reader = ChunkReader::new(
+            dir.path().to_owned(),
+            Some(materialized_schema(test_schema().as_ref())),
+        );
         reader.read_all().unwrap();
         assert_eq!(reader.num_rows(), 1);
     }
@@ -160,7 +166,10 @@ mod tests {
 
         guard.finalize_session().unwrap();
 
-        let mut reader = ChunkReader::new(dir.path().to_owned(), Some(test_schema()));
+        let mut reader = ChunkReader::new(
+            dir.path().to_owned(),
+            Some(materialized_schema(test_schema().as_ref())),
+        );
         reader.read_all().unwrap();
         assert_eq!(reader.num_rows(), 0);
     }

--- a/crates/fricon/src/dataset/ingest/registry.rs
+++ b/crates/fricon/src/dataset/ingest/registry.rs
@@ -31,7 +31,7 @@ impl WriteSessionGuard {
 
     pub(crate) fn write_batch(
         &mut self,
-        batch: arrow_array::RecordBatch,
+        batch: &arrow_array::RecordBatch,
     ) -> Result<(), IngestError> {
         self.session_mut().write(batch)
     }
@@ -71,7 +71,7 @@ impl WriteSessionRegistry {
         &self,
         id: i32,
         path: PathBuf,
-        schema: SchemaRef,
+        schema: &SchemaRef,
     ) -> WriteSessionGuard {
         let session = WriteSession::new(schema, path);
         if let Ok(mut m) = self.inner.write() {
@@ -122,9 +122,9 @@ mod tests {
     fn finalized_session_persists_data() {
         let dir = setup_session_dir();
         let registry = WriteSessionRegistry::new();
-        let mut guard = registry.start_session(1, dir.path().to_owned(), test_schema());
+        let mut guard = registry.start_session(1, dir.path().to_owned(), &test_schema());
 
-        guard.write_batch(test_batch(vec![1, 2, 3])).unwrap();
+        guard.write_batch(&test_batch(vec![1, 2, 3])).unwrap();
         let handle = registry.get(1).expect("handle exists during session");
         assert_eq!(handle.num_rows(), 3);
 
@@ -142,9 +142,9 @@ mod tests {
     fn dropped_session_finalizes_and_cleans_up_registry() {
         let dir = setup_session_dir();
         let registry = WriteSessionRegistry::new();
-        let mut guard = registry.start_session(1, dir.path().to_owned(), test_schema());
+        let mut guard = registry.start_session(1, dir.path().to_owned(), &test_schema());
 
-        guard.write_batch(test_batch(vec![7])).unwrap();
+        guard.write_batch(&test_batch(vec![7])).unwrap();
         assert!(registry.get(1).is_some());
         drop(guard);
 
@@ -162,7 +162,7 @@ mod tests {
     fn empty_finalize_succeeds_with_no_persisted_data() {
         let dir = setup_session_dir();
         let registry = WriteSessionRegistry::new();
-        let guard = registry.start_session(1, dir.path().to_owned(), test_schema());
+        let guard = registry.start_session(1, dir.path().to_owned(), &test_schema());
 
         guard.finalize_session().unwrap();
 

--- a/crates/fricon/src/dataset/ingest/session.rs
+++ b/crates/fricon/src/dataset/ingest/session.rs
@@ -22,7 +22,7 @@ pub(super) struct WriteSession {
 }
 
 impl WriteSession {
-    pub(super) fn new(schema: SchemaRef, dir_path: PathBuf) -> Self {
+    pub(super) fn new(schema: &SchemaRef, dir_path: PathBuf) -> Self {
         let storage_schema = materialized_schema(schema.as_ref());
         let writer = ChunkWriter::new(storage_schema.clone(), dir_path.clone());
         let in_progress_table = InProgressTable::new(storage_schema.clone(), dir_path);
@@ -35,7 +35,7 @@ impl WriteSession {
         }
     }
 
-    pub(super) fn write(&mut self, batch: RecordBatch) -> Result<(), IngestError> {
+    pub(super) fn write(&mut self, batch: &RecordBatch) -> Result<(), IngestError> {
         let (batch, next_record_id) =
             materialize_record_ids(self.storage_schema.clone(), batch, self.next_record_id)?;
         self.in_progress_table_mut().push(batch.clone())?;
@@ -129,10 +129,12 @@ mod tests {
     #[test]
     fn write_session_materializes_monotonic_record_ids() {
         let dir = TempDir::new().expect("temp dir");
-        let mut session = WriteSession::new(user_schema(), dir.path().to_owned());
+        let mut session = WriteSession::new(&user_schema(), dir.path().to_owned());
 
-        session.write(batch(vec![10.0, 20.0])).expect("first write");
-        session.write(batch(vec![30.0])).expect("second write");
+        session
+            .write(&batch(vec![10.0, 20.0]))
+            .expect("first write");
+        session.write(&batch(vec![30.0])).expect("second write");
         session.finish().expect("finish");
 
         let mut reader = ChunkReader::new(dir.path().to_owned(), None);
@@ -154,10 +156,10 @@ mod tests {
     #[test]
     fn write_session_empty_batch_does_not_advance_record_ids() {
         let dir = TempDir::new().expect("temp dir");
-        let mut session = WriteSession::new(user_schema(), dir.path().to_owned());
+        let mut session = WriteSession::new(&user_schema(), dir.path().to_owned());
 
-        session.write(batch(Vec::new())).expect("empty write");
-        session.write(batch(vec![10.0])).expect("second write");
+        session.write(&batch(Vec::new())).expect("empty write");
+        session.write(&batch(vec![10.0])).expect("second write");
         session.finish().expect("finish");
 
         let mut reader = ChunkReader::new(dir.path().to_owned(), None);

--- a/crates/fricon/src/dataset/ingest/session.rs
+++ b/crates/fricon/src/dataset/ingest/session.rs
@@ -10,30 +10,39 @@ use arrow_schema::SchemaRef;
 
 use crate::dataset::{
     ingest::{IngestError, storage::InProgressTable},
+    semantics::{materialize_record_ids, materialized_schema},
     storage::ChunkWriter,
 };
 
 pub(super) struct WriteSession {
     writer: ChunkWriter,
     in_progress_table: Arc<Mutex<InProgressTable>>,
+    storage_schema: SchemaRef,
+    next_record_id: u64,
 }
 
 impl WriteSession {
     pub(super) fn new(schema: SchemaRef, dir_path: PathBuf) -> Self {
-        let writer = ChunkWriter::new(schema.clone(), dir_path.clone());
-        let in_progress_table = InProgressTable::new(schema, dir_path);
+        let storage_schema = materialized_schema(schema.as_ref());
+        let writer = ChunkWriter::new(storage_schema.clone(), dir_path.clone());
+        let in_progress_table = InProgressTable::new(storage_schema.clone(), dir_path);
         let in_progress_table = Arc::new(Mutex::new(in_progress_table));
         Self {
             writer,
             in_progress_table,
+            storage_schema,
+            next_record_id: 0,
         }
     }
 
     pub(super) fn write(&mut self, batch: RecordBatch) -> Result<(), IngestError> {
+        let (batch, next_record_id) =
+            materialize_record_ids(self.storage_schema.clone(), batch, self.next_record_id)?;
         self.in_progress_table_mut().push(batch.clone())?;
         if self.writer.write(batch)? {
             self.in_progress_table_mut().continue_read_chunks()?;
         }
+        self.next_record_id = next_record_id;
         Ok(())
     }
 
@@ -90,5 +99,79 @@ impl WriteSessionHandle {
         let schema = inner.schema().clone();
         let batches = inner.range(range).map(Cow::into_owned).collect();
         (schema, batches)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Float64Array, RecordBatch, UInt64Array};
+    use arrow_schema::{DataType, Field, Schema};
+    use tempfile::TempDir;
+
+    use super::WriteSession;
+    use crate::dataset::{semantics::RECORD_ID_COLUMN, storage::ChunkReader};
+
+    fn user_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new(
+            "signal",
+            DataType::Float64,
+            false,
+        )]))
+    }
+
+    fn batch(values: Vec<f64>) -> RecordBatch {
+        RecordBatch::try_new(user_schema(), vec![Arc::new(Float64Array::from(values))])
+            .expect("batch")
+    }
+
+    #[test]
+    fn write_session_materializes_monotonic_record_ids() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut session = WriteSession::new(user_schema(), dir.path().to_owned());
+
+        session.write(batch(vec![10.0, 20.0])).expect("first write");
+        session.write(batch(vec![30.0])).expect("second write");
+        session.finish().expect("finish");
+
+        let mut reader = ChunkReader::new(dir.path().to_owned(), None);
+        reader.read_all().expect("read chunks");
+        let batches: Vec<_> = reader.range(..).map(std::borrow::Cow::into_owned).collect();
+        let stored =
+            arrow_select::concat::concat_batches(reader.schema().expect("schema"), &batches)
+                .expect("concat");
+
+        assert_eq!(stored.schema().field(0).name(), RECORD_ID_COLUMN);
+        let record_ids = stored
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("record ids");
+        assert_eq!(record_ids.values(), &[0, 1, 2]);
+    }
+
+    #[test]
+    fn write_session_empty_batch_does_not_advance_record_ids() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut session = WriteSession::new(user_schema(), dir.path().to_owned());
+
+        session.write(batch(Vec::new())).expect("empty write");
+        session.write(batch(vec![10.0])).expect("second write");
+        session.finish().expect("finish");
+
+        let mut reader = ChunkReader::new(dir.path().to_owned(), None);
+        reader.read_all().expect("read chunks");
+        let batches: Vec<_> = reader.range(..).map(std::borrow::Cow::into_owned).collect();
+        let stored =
+            arrow_select::concat::concat_batches(reader.schema().expect("schema"), &batches)
+                .expect("concat");
+        let record_ids = stored
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("record ids");
+
+        assert_eq!(record_ids.values(), &[0]);
     }
 }

--- a/crates/fricon/src/dataset/ingest/session.rs
+++ b/crates/fricon/src/dataset/ingest/session.rs
@@ -10,6 +10,7 @@ use arrow_schema::SchemaRef;
 
 use crate::dataset::{
     ingest::{IngestError, storage::InProgressTable},
+    schema::DatasetError,
     semantics::{materialize_record_ids, materialized_schema},
     storage::ChunkWriter,
 };
@@ -17,6 +18,7 @@ use crate::dataset::{
 pub(super) struct WriteSession {
     writer: ChunkWriter,
     in_progress_table: Arc<Mutex<InProgressTable>>,
+    user_schema: SchemaRef,
     storage_schema: SchemaRef,
     next_record_id: u64,
 }
@@ -30,12 +32,16 @@ impl WriteSession {
         Self {
             writer,
             in_progress_table,
+            user_schema: schema.clone(),
             storage_schema,
             next_record_id: 0,
         }
     }
 
     pub(super) fn write(&mut self, batch: &RecordBatch) -> Result<(), IngestError> {
+        if batch.schema() != self.user_schema {
+            return Err(IngestError::Dataset(DatasetError::SchemaMismatch));
+        }
         let (batch, next_record_id) =
             materialize_record_ids(self.storage_schema.clone(), batch, self.next_record_id)?;
         self.in_progress_table_mut().push(batch.clone())?;
@@ -111,7 +117,10 @@ mod tests {
     use tempfile::TempDir;
 
     use super::WriteSession;
-    use crate::dataset::{semantics::RECORD_ID_COLUMN, storage::ChunkReader};
+    use crate::dataset::{
+        ingest::IngestError, schema::DatasetError, semantics::RECORD_ID_COLUMN,
+        storage::ChunkReader,
+    };
 
     fn user_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![Field::new(
@@ -175,5 +184,46 @@ mod tests {
             .expect("record ids");
 
         assert_eq!(record_ids.values(), &[0]);
+    }
+
+    #[test]
+    fn write_session_rejects_same_type_schema_mismatch_before_materializing_ids() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut session = WriteSession::new(&user_schema(), dir.path().to_owned());
+        let mismatched_schema = Arc::new(Schema::new(vec![Field::new(
+            "renamed_signal",
+            DataType::Float64,
+            false,
+        )]));
+        let mismatched_batch = RecordBatch::try_new(
+            mismatched_schema,
+            vec![Arc::new(Float64Array::from(vec![99.0]))],
+        )
+        .expect("mismatched batch");
+
+        session.write(&batch(vec![10.0])).expect("first write");
+        let error = session
+            .write(&mismatched_batch)
+            .expect_err("schema mismatch should fail");
+        session.write(&batch(vec![20.0])).expect("second write");
+        session.finish().expect("finish");
+
+        assert!(matches!(
+            error,
+            IngestError::Dataset(DatasetError::SchemaMismatch)
+        ));
+        let mut reader = ChunkReader::new(dir.path().to_owned(), None);
+        reader.read_all().expect("read chunks");
+        let batches: Vec<_> = reader.range(..).map(std::borrow::Cow::into_owned).collect();
+        let stored =
+            arrow_select::concat::concat_batches(reader.schema().expect("schema"), &batches)
+                .expect("concat");
+        let record_ids = stored
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("record ids");
+
+        assert_eq!(record_ids.values(), &[0, 1]);
     }
 }

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -152,6 +152,8 @@ mod tests {
         ColumnMeaning, InterpretationSource, ResolvedDuplicatePolicy, resolve_from_manifest,
     };
     use crate::dataset::{
+        DatasetReader,
+        ingest::WriteSessionRegistry,
         interpret::resolve_from_compatibility_inference,
         read::ReadError,
         schema::DatasetSchema,
@@ -258,6 +260,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let schema = Arc::new(Schema::new(vec![
             Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("run", DataType::Float64, false),
             Field::new("signal", DataType::Float64, false),
         ]));
         let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
@@ -267,6 +270,7 @@ mod tests {
                     schema,
                     vec![
                         Arc::new(UInt64Array::from(vec![0, 1])),
+                        Arc::new(Float64Array::from(vec![1.0, 1.0])),
                         Arc::new(Float64Array::from(vec![10.0, 20.0])),
                     ],
                 )
@@ -276,21 +280,26 @@ mod tests {
         writer.finish().expect("finish writer");
         write_manifest(
             dir.path(),
-            &DatasetSemanticManifest::minimal([(
-                "signal".to_string(),
-                ManifestColumn::new(DatasetDType::Float64),
-            )]),
+            &DatasetSemanticManifest::minimal([
+                (
+                    "run".to_string(),
+                    ManifestColumn::new(DatasetDType::Float64),
+                ),
+                (
+                    "signal".to_string(),
+                    ManifestColumn::new(DatasetDType::Float64),
+                ),
+            ]),
         )
         .expect("write manifest");
 
-        let reader =
-            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
-        assert_eq!(reader.schema().expect("visible schema").columns().len(), 1);
-        assert_eq!(reader.arrow_schema().fields().len(), 1);
-        assert_eq!(reader.batches()[0].num_columns(), 1);
+        let reader = DatasetReader::open_dir(dir.path()).expect("reader");
+        assert_eq!(reader.schema().expect("visible schema").columns().len(), 2);
+        assert_eq!(reader.arrow_schema().fields().len(), 2);
+        assert_eq!(reader.batches()[0].num_columns(), 2);
         assert_eq!(
             reader.try_index_columns().expect("index columns"),
-            Some(Vec::new())
+            Some(vec![0, 1])
         );
         let interpretation = reader.interpret().expect("interpretation");
 
@@ -299,7 +308,7 @@ mod tests {
             interpretation.columns[0].meaning,
             ColumnMeaning::SystemRecordId
         );
-        assert_eq!(interpretation.value_columns, vec![1]);
+        assert_eq!(interpretation.value_columns, vec![1, 2]);
     }
 
     #[test]
@@ -314,18 +323,17 @@ mod tests {
             "signal".to_string(),
             ManifestColumn::new(DatasetDType::Float64),
         )]);
-        let registry = crate::dataset::ingest::WriteSessionRegistry::new();
-        let mut guard = registry.start_session(7, dir.path().to_owned(), user_schema.clone());
+        let registry = WriteSessionRegistry::new();
+        let mut guard = registry.start_session(7, dir.path().to_owned(), &user_schema);
         guard
             .write_batch(
-                RecordBatch::try_new(user_schema, vec![Arc::new(Float64Array::from(vec![10.0]))])
+                &RecordBatch::try_new(user_schema, vec![Arc::new(Float64Array::from(vec![10.0]))])
                     .expect("batch"),
             )
             .expect("write batch");
         let handle = registry.get(7).expect("active handle");
 
-        let reader =
-            crate::dataset::DatasetReader::from_handle(handle, Some(manifest)).expect("reader");
+        let reader = DatasetReader::from_handle(handle, Some(manifest)).expect("reader");
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
@@ -361,9 +369,8 @@ mod tests {
         )
         .expect("write manifest");
 
-        let error = match crate::dataset::DatasetReader::open_dir(dir.path().to_owned()) {
-            Ok(_) => panic!("reader should reject manifest-only record ids"),
-            Err(error) => error,
+        let Err(error) = DatasetReader::open_dir(dir.path()) else {
+            panic!("reader should reject manifest-only record ids");
         };
         assert!(matches!(error, ReadError::Manifest(_)));
     }
@@ -398,8 +405,7 @@ mod tests {
         )
         .expect("write manifest");
 
-        let reader =
-            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let reader = DatasetReader::open_dir(dir.path()).expect("reader");
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
@@ -438,9 +444,8 @@ mod tests {
         )
         .expect("write manifest");
 
-        let error = match crate::dataset::DatasetReader::open_dir(dir.path().to_owned()) {
-            Ok(_) => panic!("reader should reject manifest schema mismatch"),
-            Err(error) => error,
+        let Err(error) = DatasetReader::open_dir(dir.path()) else {
+            panic!("reader should reject manifest schema mismatch");
         };
 
         assert!(matches!(error, ReadError::Manifest(_)));
@@ -451,8 +456,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         write_legacy_numeric_dataset(dir.path(), vec![1.0, 1.0], vec![0.0, 1.0]);
 
-        let reader =
-            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let reader = DatasetReader::open_dir(dir.path()).expect("reader");
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(
@@ -478,8 +482,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         write_legacy_numeric_dataset(dir.path(), vec![1.0], vec![0.0]);
 
-        let reader =
-            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        let reader = DatasetReader::open_dir(dir.path()).expect("reader");
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -285,6 +285,9 @@ mod tests {
 
         let reader =
             crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
+        assert_eq!(reader.schema().expect("visible schema").columns().len(), 1);
+        assert_eq!(reader.arrow_schema().fields().len(), 1);
+        assert_eq!(reader.batches()[0].num_columns(), 1);
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
@@ -296,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn reader_interpretation_accepts_manifest_before_record_id_materialization() {
+    fn reader_interpretation_rejects_manifest_before_record_id_materialization() {
         let dir = tempfile::tempdir().expect("temp dir");
         let schema = Arc::new(Schema::new(vec![Field::new(
             "signal",
@@ -320,13 +323,11 @@ mod tests {
         )
         .expect("write manifest");
 
-        let reader =
-            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
-        let interpretation = reader.interpret().expect("interpretation");
-
-        assert_eq!(interpretation.source, InterpretationSource::Manifest);
-        assert_eq!(interpretation.value_columns, vec![0]);
-        assert_eq!(interpretation.columns[0].meaning, ColumnMeaning::UserValue);
+        let error = match crate::dataset::DatasetReader::open_dir(dir.path().to_owned()) {
+            Ok(_) => panic!("reader should reject manifest-only record ids"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, ReadError::Manifest(_)));
     }
 
     #[test]
@@ -399,9 +400,10 @@ mod tests {
         )
         .expect("write manifest");
 
-        let reader =
-            crate::dataset::DatasetReader::open_dir(dir.path().to_owned()).expect("reader");
-        let error = reader.interpret().expect_err("schema mismatch");
+        let error = match crate::dataset::DatasetReader::open_dir(dir.path().to_owned()) {
+            Ok(_) => panic!("reader should reject manifest schema mismatch"),
+            Err(error) => error,
+        };
 
         assert!(matches!(error, ReadError::Manifest(_)));
     }

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -288,6 +288,10 @@ mod tests {
         assert_eq!(reader.schema().expect("visible schema").columns().len(), 1);
         assert_eq!(reader.arrow_schema().fields().len(), 1);
         assert_eq!(reader.batches()[0].num_columns(), 1);
+        assert_eq!(
+            reader.try_index_columns().expect("index columns"),
+            Some(Vec::new())
+        );
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -1,12 +1,12 @@
 mod model;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use arrow_schema::Schema;
 
 pub use self::model::{
-    ColumnMeaning, DatasetInterpretation, InterpretationSource, ResolvedColumn,
-    ResolvedDuplicatePolicy,
+    ColumnMeaning, DatasetInterpretation, InterpretationSource, PhysicalColumnOrdinal,
+    ResolvedColumn, ResolvedDuplicatePolicy, VisibleColumnOrdinal,
 };
 use crate::dataset::{
     schema::{DatasetDataType, DatasetSchema, ScalarKind, TraceKind},
@@ -19,12 +19,21 @@ use crate::dataset::{
 pub(crate) fn resolve_from_manifest(
     arrow_schema: &Schema,
     manifest: &DatasetSemanticManifest,
+    visible_columns: &[usize],
 ) -> DatasetInterpretation {
+    let visible_ordinals: HashMap<_, _> = visible_columns
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(visible_ordinal, physical_ordinal)| {
+            (physical_ordinal, VisibleColumnOrdinal(visible_ordinal))
+        })
+        .collect();
     let columns: Vec<_> = arrow_schema
         .fields()
         .iter()
         .enumerate()
-        .map(|(ordinal, field)| {
+        .map(|(physical_ordinal, field)| {
             let name = field.name().to_owned();
             let column = manifest
                 .columns
@@ -33,7 +42,8 @@ pub(crate) fn resolve_from_manifest(
             let is_record_id = column.system == Some(SystemColumn::RecordId);
             ResolvedColumn {
                 name,
-                ordinal,
+                physical_ordinal: PhysicalColumnOrdinal(physical_ordinal),
+                visible_ordinal: visible_ordinals.get(&physical_ordinal).copied(),
                 dtype: column.dtype.clone(),
                 meaning: if is_record_id {
                     ColumnMeaning::SystemRecordId
@@ -51,7 +61,7 @@ pub(crate) fn resolve_from_manifest(
     let value_columns = columns
         .iter()
         .filter(|column| column.meaning == ColumnMeaning::UserValue)
-        .map(|column| column.ordinal)
+        .filter_map(|column| column.visible_ordinal)
         .collect();
 
     DatasetInterpretation {
@@ -73,6 +83,10 @@ pub(crate) fn resolve_from_compatibility_inference(
     index_columns: Option<Vec<usize>>,
 ) -> DatasetInterpretation {
     let index_columns = index_columns.unwrap_or_default();
+    let index_columns: Vec<_> = index_columns
+        .into_iter()
+        .map(VisibleColumnOrdinal)
+        .collect();
     let index_column_set: HashSet<_> = index_columns.iter().copied().collect();
 
     let columns: Vec<_> = schema
@@ -80,10 +94,12 @@ pub(crate) fn resolve_from_compatibility_inference(
         .iter()
         .enumerate()
         .map(|(ordinal, (name, data_type))| {
-            let is_index = index_column_set.contains(&ordinal);
+            let visible_ordinal = VisibleColumnOrdinal(ordinal);
+            let is_index = index_column_set.contains(&visible_ordinal);
             ResolvedColumn {
                 name: name.to_owned(),
-                ordinal,
+                physical_ordinal: PhysicalColumnOrdinal(ordinal),
+                visible_ordinal: Some(visible_ordinal),
                 dtype: dataset_dtype_from_compatibility_type(*data_type),
                 meaning: if is_index {
                     ColumnMeaning::CompatibilityIndex
@@ -101,7 +117,7 @@ pub(crate) fn resolve_from_compatibility_inference(
     let value_columns = columns
         .iter()
         .filter(|column| column.meaning == ColumnMeaning::UserValue)
-        .map(|column| column.ordinal)
+        .filter_map(|column| column.visible_ordinal)
         .collect();
 
     DatasetInterpretation {
@@ -143,25 +159,30 @@ fn trace_value_from_compatibility_type(scalar_kind: ScalarKind) -> TraceValueDTy
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{ops::Bound, sync::Arc};
 
     use arrow_array::{Float64Array, RecordBatch, StringArray, UInt64Array};
     use arrow_schema::{DataType, Field, Schema};
 
     use super::{
-        ColumnMeaning, InterpretationSource, ResolvedDuplicatePolicy, resolve_from_manifest,
+        ColumnMeaning, InterpretationSource, PhysicalColumnOrdinal, ResolvedDuplicatePolicy,
+        VisibleColumnOrdinal, resolve_from_manifest,
     };
     use crate::dataset::{
         DatasetReader,
         ingest::WriteSessionRegistry,
         interpret::resolve_from_compatibility_inference,
-        read::ReadError,
+        read::{ReadError, SelectOptions},
         schema::DatasetSchema,
         semantics::{
             DatasetDType, DatasetSemanticManifest, ManifestColumn, RECORD_ID_COLUMN, write_manifest,
         },
         storage::ChunkWriter,
     };
+
+    fn visible(indices: &[usize]) -> Vec<VisibleColumnOrdinal> {
+        indices.iter().copied().map(VisibleColumnOrdinal).collect()
+    }
 
     #[test]
     fn manifest_interpretation_marks_record_id_system_and_hidden() {
@@ -174,22 +195,27 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
         assert_eq!(
             interpretation.duplicate_policy,
             ResolvedDuplicatePolicy::LatestByRecordIdPlaceholder
         );
-        assert_eq!(interpretation.value_columns, vec![1]);
-        assert_eq!(interpretation.logical_index_columns, Vec::<usize>::new());
+        assert_eq!(interpretation.value_columns, visible(&[0]));
+        assert_eq!(
+            interpretation.logical_index_columns,
+            Vec::<VisibleColumnOrdinal>::new()
+        );
         assert_eq!(
             interpretation.chart_axis_candidate_columns,
-            Vec::<usize>::new()
+            Vec::<VisibleColumnOrdinal>::new()
         );
 
         let record_id = &interpretation.columns[0];
         assert_eq!(record_id.name, RECORD_ID_COLUMN);
+        assert_eq!(record_id.physical_ordinal, PhysicalColumnOrdinal(0));
+        assert_eq!(record_id.visible_ordinal, None);
         assert_eq!(record_id.meaning, ColumnMeaning::SystemRecordId);
         assert_eq!(record_id.dtype, DatasetDType::UInt64);
         assert!(!record_id.is_index);
@@ -198,6 +224,8 @@ mod tests {
         assert!(!record_id.is_chart_axis_candidate);
 
         let signal = &interpretation.columns[1];
+        assert_eq!(signal.physical_ordinal, PhysicalColumnOrdinal(1));
+        assert_eq!(signal.visible_ordinal, Some(VisibleColumnOrdinal(0)));
         assert_eq!(signal.meaning, ColumnMeaning::UserValue);
         assert_eq!(signal.dtype, DatasetDType::Float64);
         assert!(!signal.is_system);
@@ -223,9 +251,12 @@ mod tests {
             interpretation.duplicate_policy,
             ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder
         );
-        assert_eq!(interpretation.logical_index_columns, vec![0, 1]);
-        assert_eq!(interpretation.chart_axis_candidate_columns, vec![0, 1]);
-        assert_eq!(interpretation.value_columns, vec![2]);
+        assert_eq!(interpretation.logical_index_columns, visible(&[0, 1]));
+        assert_eq!(
+            interpretation.chart_axis_candidate_columns,
+            visible(&[0, 1])
+        );
+        assert_eq!(interpretation.value_columns, visible(&[2]));
         assert_eq!(
             interpretation.columns[0].meaning,
             ColumnMeaning::CompatibilityIndex
@@ -246,12 +277,15 @@ mod tests {
 
         let interpretation = resolve_from_compatibility_inference(&schema, None);
 
-        assert_eq!(interpretation.logical_index_columns, Vec::<usize>::new());
+        assert_eq!(
+            interpretation.logical_index_columns,
+            Vec::<VisibleColumnOrdinal>::new()
+        );
         assert_eq!(
             interpretation.chart_axis_candidate_columns,
-            Vec::<usize>::new()
+            Vec::<VisibleColumnOrdinal>::new()
         );
-        assert_eq!(interpretation.value_columns, vec![0, 1]);
+        assert_eq!(interpretation.value_columns, visible(&[0, 1]));
         assert!(interpretation.columns.iter().all(|column| !column.is_index));
     }
 
@@ -308,7 +342,30 @@ mod tests {
             interpretation.columns[0].meaning,
             ColumnMeaning::SystemRecordId
         );
-        assert_eq!(interpretation.value_columns, vec![1, 2]);
+        assert_eq!(interpretation.value_columns, visible(&[0, 1]));
+        assert_eq!(
+            interpretation.columns[1].physical_ordinal,
+            PhysicalColumnOrdinal(1)
+        );
+        assert_eq!(
+            interpretation.columns[1].visible_ordinal,
+            Some(VisibleColumnOrdinal(0))
+        );
+        let selected_columns = interpretation
+            .value_columns
+            .iter()
+            .map(|ordinal| ordinal.0)
+            .collect();
+        let (selected_schema, selected_batches) = reader
+            .select_data(&SelectOptions {
+                start: Bound::Unbounded,
+                end: Bound::Unbounded,
+                index_filters: None,
+                selected_columns: Some(selected_columns),
+            })
+            .expect("select value columns from interpretation");
+        assert_eq!(selected_schema.fields().len(), 2);
+        assert_eq!(selected_batches[0].num_columns(), 2);
     }
 
     #[test]
@@ -341,7 +398,7 @@ mod tests {
             interpretation.columns[0].meaning,
             ColumnMeaning::SystemRecordId
         );
-        assert_eq!(interpretation.value_columns, vec![1]);
+        assert_eq!(interpretation.value_columns, visible(&[0]));
     }
 
     #[test]
@@ -409,7 +466,7 @@ mod tests {
         let interpretation = reader.interpret().expect("interpretation");
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
-        assert_eq!(interpretation.value_columns, vec![1]);
+        assert_eq!(interpretation.value_columns, visible(&[0]));
         assert_eq!(interpretation.columns[1].dtype, DatasetDType::Utf8);
         assert_eq!(interpretation.columns[1].meaning, ColumnMeaning::UserValue);
     }
@@ -463,9 +520,12 @@ mod tests {
             interpretation.source,
             InterpretationSource::CompatibilityInference
         );
-        assert_eq!(interpretation.logical_index_columns, vec![0, 1]);
-        assert_eq!(interpretation.chart_axis_candidate_columns, vec![0, 1]);
-        assert_eq!(interpretation.value_columns, vec![2]);
+        assert_eq!(interpretation.logical_index_columns, visible(&[0, 1]));
+        assert_eq!(
+            interpretation.chart_axis_candidate_columns,
+            visible(&[0, 1])
+        );
+        assert_eq!(interpretation.value_columns, visible(&[2]));
         assert_eq!(
             interpretation.columns[0].meaning,
             ColumnMeaning::CompatibilityIndex
@@ -489,12 +549,15 @@ mod tests {
             interpretation.source,
             InterpretationSource::CompatibilityInference
         );
-        assert_eq!(interpretation.logical_index_columns, Vec::<usize>::new());
+        assert_eq!(
+            interpretation.logical_index_columns,
+            Vec::<VisibleColumnOrdinal>::new()
+        );
         assert_eq!(
             interpretation.chart_axis_candidate_columns,
-            Vec::<usize>::new()
+            Vec::<VisibleColumnOrdinal>::new()
         );
-        assert_eq!(interpretation.value_columns, vec![0, 1, 2]);
+        assert_eq!(interpretation.value_columns, visible(&[0, 1, 2]));
         assert!(interpretation.columns.iter().all(|column| !column.is_index));
     }
 

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -303,6 +303,40 @@ mod tests {
     }
 
     #[test]
+    fn live_reader_interpretation_reads_manifest_when_present() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let user_schema = Arc::new(Schema::new(vec![Field::new(
+            "signal",
+            DataType::Float64,
+            false,
+        )]));
+        let manifest = DatasetSemanticManifest::minimal([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )]);
+        let registry = crate::dataset::ingest::WriteSessionRegistry::new();
+        let mut guard = registry.start_session(7, dir.path().to_owned(), user_schema.clone());
+        guard
+            .write_batch(
+                RecordBatch::try_new(user_schema, vec![Arc::new(Float64Array::from(vec![10.0]))])
+                    .expect("batch"),
+            )
+            .expect("write batch");
+        let handle = registry.get(7).expect("active handle");
+
+        let reader =
+            crate::dataset::DatasetReader::from_handle(handle, Some(manifest)).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(interpretation.source, InterpretationSource::Manifest);
+        assert_eq!(
+            interpretation.columns[0].meaning,
+            ColumnMeaning::SystemRecordId
+        );
+        assert_eq!(interpretation.value_columns, vec![1]);
+    }
+
+    #[test]
     fn reader_interpretation_rejects_manifest_before_record_id_materialization() {
         let dir = tempfile::tempdir().expect("temp dir");
         let schema = Arc::new(Schema::new(vec![Field::new(

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -3,12 +3,18 @@ use crate::dataset::semantics::DatasetDType;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatasetInterpretation {
     pub columns: Vec<ResolvedColumn>,
-    pub value_columns: Vec<usize>,
-    pub logical_index_columns: Vec<usize>,
-    pub chart_axis_candidate_columns: Vec<usize>,
+    pub value_columns: Vec<VisibleColumnOrdinal>,
+    pub logical_index_columns: Vec<VisibleColumnOrdinal>,
+    pub chart_axis_candidate_columns: Vec<VisibleColumnOrdinal>,
     pub duplicate_policy: ResolvedDuplicatePolicy,
     pub source: InterpretationSource,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PhysicalColumnOrdinal(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VisibleColumnOrdinal(pub usize);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[expect(
@@ -17,7 +23,8 @@ pub struct DatasetInterpretation {
 )]
 pub struct ResolvedColumn {
     pub name: String,
-    pub ordinal: usize,
+    pub physical_ordinal: PhysicalColumnOrdinal,
+    pub visible_ordinal: Option<VisibleColumnOrdinal>,
     pub dtype: DatasetDType,
     pub meaning: ColumnMeaning,
     pub is_index: bool,

--- a/crates/fricon/src/dataset/read/access.rs
+++ b/crates/fricon/src/dataset/read/access.rs
@@ -26,12 +26,16 @@ pub(crate) fn get_dataset_reader(
 ) -> Result<DatasetReader, ReadError> {
     let dataset = repository.resolve_dataset(id)?;
 
+    let path = paths.dataset_path_from_uid(dataset.uid);
+
     // Prefer the active write session so reads observe in-progress data for a
     // dataset that has not yet been finalized to disk.
     if let Some(handle) = write_sessions.get(dataset.id) {
-        Ok(DatasetReader::from_handle(handle))
+        Ok(DatasetReader::from_handle(
+            handle,
+            crate::dataset::semantics::read_manifest_optional(&path)?,
+        )?)
     } else {
-        let path = paths.dataset_path_from_uid(dataset.uid);
         Ok(DatasetReader::open_dir(path)?)
     }
 }

--- a/crates/fricon/src/dataset/read/access.rs
+++ b/crates/fricon/src/dataset/read/access.rs
@@ -8,6 +8,7 @@ use crate::{
         ingest::WriteSessionRegistry,
         model::DatasetId,
         read::{DatasetReadRepository, DatasetReader, ReadError},
+        semantics::read_manifest_optional,
     },
     workspace::WorkspacePaths,
 };
@@ -33,9 +34,9 @@ pub(crate) fn get_dataset_reader(
     if let Some(handle) = write_sessions.get(dataset.id) {
         Ok(DatasetReader::from_handle(
             handle,
-            crate::dataset::semantics::read_manifest_optional(&path)?,
+            read_manifest_optional(&path)?,
         )?)
     } else {
-        Ok(DatasetReader::open_dir(path)?)
+        Ok(DatasetReader::open_dir(&path)?)
     }
 }

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -245,20 +245,27 @@ fn project_batch(
 }
 
 impl DatasetReader {
-    pub(crate) fn from_handle(source: WriteSessionHandle) -> Self {
+    pub(crate) fn from_handle(
+        source: WriteSessionHandle,
+        manifest: Option<DatasetSemanticManifest>,
+    ) -> Result<Self, ReadError> {
         let physical_arrow_schema = source.schema();
+        if let Some(manifest) = manifest.as_ref() {
+            manifest
+                .validate_against_arrow_schema(physical_arrow_schema.as_ref())
+                .map_err(ManifestError::from)?;
+        }
         let (arrow_schema, visible_columns) =
-            visible_projection_from_manifest(&physical_arrow_schema, None)
-                .expect("write session schema projection should be valid");
+            visible_projection_from_manifest(&physical_arrow_schema, manifest.as_ref())?;
         let schema = arrow_schema.as_ref().try_into().ok();
-        Self {
+        Ok(Self {
             source: DatasetSource::WriteSession(source),
             schema,
             physical_arrow_schema,
             arrow_schema,
             visible_columns,
-            manifest: None,
-        }
+            manifest,
+        })
     }
 
     pub(crate) fn open_dir(path: PathBuf) -> Result<Self, ReadError> {

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -5,7 +5,7 @@ use arrow_array::{ArrayRef, BooleanArray, RecordBatch, RecordBatchOptions, Scala
 use arrow_ord::{cmp::eq, ord::make_comparator};
 use arrow_schema::{Schema, SchemaRef, SortOptions};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 
 use crate::dataset::{
     ingest::WriteSessionHandle,
@@ -14,7 +14,9 @@ use crate::dataset::{
     },
     read::{ReadError, SelectOptions},
     schema::{DatasetDataType, DatasetError, DatasetSchema},
-    semantics::{ManifestError, read_manifest_optional},
+    semantics::{
+        DatasetSemanticManifest, ManifestError, is_hidden_system_column, read_manifest_optional,
+    },
     storage::ChunkReader,
 };
 
@@ -51,21 +53,29 @@ impl DatasetSource {
     fn select_data(
         &self,
         options: &SelectOptions,
+        output_schema: SchemaRef,
+        physical_columns: Vec<usize>,
     ) -> Result<(SchemaRef, Vec<RecordBatch>), ReadError> {
         let index_filters = options.index_filters.as_ref();
-        let selected_columns = options.selected_columns.as_deref();
         match self {
             Self::WriteSession(handle) => {
                 let (schema, batches) =
                     handle.snapshot_range_with_schema((options.start, options.end));
-                select_data_owned(batches, &schema, index_filters, selected_columns)
-                    .map_err(Into::into)
+                select_data_owned(
+                    batches,
+                    &schema,
+                    index_filters,
+                    output_schema,
+                    &physical_columns,
+                )
+                .map_err(Into::into)
             }
             Self::File(reader) => select_data(
                 reader.range((options.start, options.end)),
                 reader.schema().ok_or(ReadError::EmptyDataset)?,
                 index_filters,
-                selected_columns,
+                output_schema,
+                &physical_columns,
             )
             .map_err(Into::into),
         }
@@ -75,8 +85,10 @@ impl DatasetSource {
 pub struct DatasetReader {
     source: DatasetSource,
     schema: Option<DatasetSchema>,
+    physical_arrow_schema: SchemaRef,
     arrow_schema: SchemaRef,
-    dataset_dir: Option<PathBuf>,
+    visible_columns: Vec<usize>,
+    manifest: Option<DatasetSemanticManifest>,
 }
 
 #[derive(Debug, Default)]
@@ -122,24 +134,13 @@ fn select_data<'a>(
     source: impl Iterator<Item = Cow<'a, RecordBatch>>,
     source_schema: &SchemaRef,
     index_filters: Option<&RecordBatch>,
-    selected_columns: Option<&[usize]>,
+    output_schema: SchemaRef,
+    selected_columns: &[usize],
 ) -> Result<(SchemaRef, Vec<RecordBatch>), DatasetError> {
     let filter = if let Some(filters) = index_filters {
         Filter::new(source_schema, filters)?
     } else {
         Filter::default()
-    };
-
-    let (output_schema, selected_columns) = if let Some(columns) = selected_columns {
-        (
-            Arc::new(source_schema.project(columns)?),
-            Either::Left(columns.iter().copied()),
-        )
-    } else {
-        (
-            source_schema.clone(),
-            Either::Right(0..source_schema.fields.len()),
-        )
     };
 
     let results = source
@@ -159,8 +160,8 @@ fn select_data<'a>(
                 Ok(None)
             } else {
                 let arrays = selected_columns
-                    .clone()
-                    .into_iter()
+                    .iter()
+                    .copied()
                     .map(|column| {
                         let array = batch.column(column);
                         if let Some(predicate) = &predicate {
@@ -190,38 +191,99 @@ fn select_data_owned(
     batches: Vec<RecordBatch>,
     source_schema: &SchemaRef,
     index_filters: Option<&RecordBatch>,
-    selected_columns: Option<&[usize]>,
+    output_schema: SchemaRef,
+    selected_columns: &[usize],
 ) -> Result<(SchemaRef, Vec<RecordBatch>), DatasetError> {
     select_data(
         batches.into_iter().map(Cow::Owned),
         source_schema,
         index_filters,
+        output_schema,
         selected_columns,
     )
 }
 
+fn visible_projection_from_manifest(
+    physical_schema: &SchemaRef,
+    manifest: Option<&DatasetSemanticManifest>,
+) -> Result<(SchemaRef, Vec<usize>), DatasetError> {
+    let visible_columns: Vec<_> = physical_schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, field)| {
+            let manifest_column = manifest.and_then(|manifest| manifest.columns.get(field.name()));
+            (!is_hidden_system_column(field.name(), manifest_column)).then_some(index)
+        })
+        .collect();
+    let visible_schema = Arc::new(physical_schema.project(&visible_columns)?);
+    Ok((visible_schema, visible_columns))
+}
+
+fn visible_projection_legacy(
+    physical_schema: &SchemaRef,
+) -> Result<(SchemaRef, Vec<usize>), DatasetError> {
+    let visible_columns: Vec<_> = (0..physical_schema.fields().len()).collect();
+    let visible_schema = Arc::new(physical_schema.project(&visible_columns)?);
+    Ok((visible_schema, visible_columns))
+}
+
+fn project_batch(
+    batch: &RecordBatch,
+    output_schema: SchemaRef,
+    physical_columns: &[usize],
+) -> Result<RecordBatch, DatasetError> {
+    let arrays = physical_columns
+        .iter()
+        .map(|&index| batch.column(index).clone())
+        .collect();
+    Ok(RecordBatch::try_new_with_options(
+        output_schema,
+        arrays,
+        &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+    )?)
+}
+
 impl DatasetReader {
     pub(crate) fn from_handle(source: WriteSessionHandle) -> Self {
-        let arrow_schema = source.schema();
+        let physical_arrow_schema = source.schema();
+        let (arrow_schema, visible_columns) =
+            visible_projection_from_manifest(&physical_arrow_schema, None)
+                .expect("write session schema projection should be valid");
         let schema = arrow_schema.as_ref().try_into().ok();
         Self {
             source: DatasetSource::WriteSession(source),
             schema,
+            physical_arrow_schema,
             arrow_schema,
-            dataset_dir: None,
+            visible_columns,
+            manifest: None,
         }
     }
 
     pub(crate) fn open_dir(path: PathBuf) -> Result<Self, ReadError> {
         let mut reader = ChunkReader::new(path.clone(), None);
         reader.read_all()?;
-        let arrow_schema = reader.schema().ok_or(ReadError::EmptyDataset)?.clone();
+        let physical_arrow_schema = reader.schema().ok_or(ReadError::EmptyDataset)?.clone();
+        let manifest = read_manifest_optional(&path)?;
+        if let Some(manifest) = manifest.as_ref() {
+            manifest
+                .validate_against_arrow_schema(physical_arrow_schema.as_ref())
+                .map_err(ManifestError::from)?;
+        }
+        let (arrow_schema, visible_columns) = if manifest.is_some() {
+            visible_projection_from_manifest(&physical_arrow_schema, manifest.as_ref())?
+        } else {
+            visible_projection_legacy(&physical_arrow_schema)?
+        };
         let schema = arrow_schema.as_ref().try_into().ok();
         Ok(Self {
             source: DatasetSource::File(reader),
             schema,
+            physical_arrow_schema,
             arrow_schema,
-            dataset_dir: Some(path),
+            visible_columns,
+            manifest,
         })
     }
 
@@ -248,24 +310,52 @@ impl DatasetReader {
 
     #[must_use]
     pub fn batches(&self) -> Vec<RecordBatch> {
-        self.source.range(..)
+        self.source
+            .range(..)
+            .iter()
+            .map(|batch| {
+                project_batch(batch, self.arrow_schema.clone(), &self.visible_columns)
+                    .expect("visible dataset projection should be valid")
+            })
+            .collect()
     }
 
     pub fn select_data(
         &self,
         options: &SelectOptions,
     ) -> Result<(SchemaRef, Vec<RecordBatch>), ReadError> {
-        self.source.select_data(options)
+        let visible_columns: Vec<_> = options.selected_columns.as_ref().map_or_else(
+            || (0..self.visible_columns.len()).collect(),
+            std::clone::Clone::clone,
+        );
+        let output_schema = Arc::new(
+            self.arrow_schema
+                .project(&visible_columns)
+                .map_err(DatasetError::from)?,
+        );
+        let physical_columns: Vec<usize> = visible_columns
+            .iter()
+            .map(|&index| {
+                self.visible_columns.get(index).copied().ok_or_else(|| {
+                    DatasetError::Arrow(arrow_schema::ArrowError::InvalidArgumentError(format!(
+                        "selected dataset column index out of bounds: {index}"
+                    )))
+                })
+            })
+            .try_collect()?;
+        self.source
+            .select_data(options, output_schema, physical_columns)
     }
 
     pub fn interpret(&self) -> Result<DatasetInterpretation, ReadError> {
-        if let Some(dataset_dir) = &self.dataset_dir
-            && let Some(manifest) = read_manifest_optional(dataset_dir)?
-        {
+        if let Some(manifest) = &self.manifest {
             manifest
-                .validate_against_arrow_schema(self.arrow_schema.as_ref())
+                .validate_against_arrow_schema(self.physical_arrow_schema.as_ref())
                 .map_err(ManifestError::from)?;
-            return Ok(resolve_from_manifest(self.arrow_schema.as_ref(), &manifest));
+            return Ok(resolve_from_manifest(
+                self.physical_arrow_schema.as_ref(),
+                manifest,
+            ));
         }
 
         Ok(resolve_from_compatibility_inference(

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::Ordering, ops::RangeBounds, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, cmp::Ordering, ops::RangeBounds, path::Path, sync::Arc};
 
 use arrow_arith::boolean::and;
 use arrow_array::{ArrayRef, BooleanArray, RecordBatch, RecordBatchOptions, Scalar};
@@ -54,7 +54,7 @@ impl DatasetSource {
         &self,
         options: &SelectOptions,
         output_schema: SchemaRef,
-        physical_columns: Vec<usize>,
+        physical_columns: &[usize],
     ) -> Result<(SchemaRef, Vec<RecordBatch>), ReadError> {
         let index_filters = options.index_filters.as_ref();
         match self {
@@ -66,7 +66,7 @@ impl DatasetSource {
                     &schema,
                     index_filters,
                     output_schema,
-                    &physical_columns,
+                    physical_columns,
                 )
                 .map_err(Into::into)
             }
@@ -75,7 +75,7 @@ impl DatasetSource {
                 reader.schema().ok_or(ReadError::EmptyDataset)?,
                 index_filters,
                 output_schema,
-                &physical_columns,
+                physical_columns,
             )
             .map_err(Into::into),
         }
@@ -268,11 +268,11 @@ impl DatasetReader {
         })
     }
 
-    pub(crate) fn open_dir(path: PathBuf) -> Result<Self, ReadError> {
-        let mut reader = ChunkReader::new(path.clone(), None);
+    pub(crate) fn open_dir(path: &Path) -> Result<Self, ReadError> {
+        let mut reader = ChunkReader::new(path.to_owned(), None);
         reader.read_all()?;
         let physical_arrow_schema = reader.schema().ok_or(ReadError::EmptyDataset)?.clone();
-        let manifest = read_manifest_optional(&path)?;
+        let manifest = read_manifest_optional(path)?;
         if let Some(manifest) = manifest.as_ref() {
             manifest
                 .validate_against_arrow_schema(physical_arrow_schema.as_ref())
@@ -351,7 +351,7 @@ impl DatasetReader {
             })
             .try_collect()?;
         self.source
-            .select_data(options, output_schema, physical_columns)
+            .select_data(options, output_schema, &physical_columns)
     }
 
     pub fn interpret(&self) -> Result<DatasetInterpretation, ReadError> {
@@ -377,17 +377,18 @@ impl DatasetReader {
     }
 
     pub fn try_index_columns(&self) -> Result<Option<Vec<usize>>, ReadError> {
-        if self.visible_columns.len() != self.physical_arrow_schema.fields().len() {
-            return Ok(Some(Vec::new()));
-        }
-
         let schema = self.schema()?;
         if self.source.num_rows() < 2 {
             Ok(None)
         } else {
-            let sample = self.source.range(..2);
+            let samples = self
+                .source
+                .range(..2)
+                .iter()
+                .map(|batch| project_batch(batch, self.arrow_schema.clone(), &self.visible_columns))
+                .try_collect::<_, Vec<_>, _>()?;
             let sample =
-                concat_batches(&sample[0].schema(), &sample).expect("Should have same schema");
+                concat_batches(&self.arrow_schema, &samples).expect("Should have same schema");
             let mut result = vec![];
             for (index, (sample_array, column_type)) in sample
                 .columns()

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -370,6 +370,10 @@ impl DatasetReader {
     }
 
     pub fn try_index_columns(&self) -> Result<Option<Vec<usize>>, ReadError> {
+        if self.visible_columns.len() != self.physical_arrow_schema.fields().len() {
+            return Ok(Some(Vec::new()));
+        }
+
         let schema = self.schema()?;
         if self.source.num_rows() < 2 {
             Ok(None)

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -362,6 +362,7 @@ impl DatasetReader {
             return Ok(resolve_from_manifest(
                 self.physical_arrow_schema.as_ref(),
                 manifest,
+                &self.visible_columns,
             ));
         }
 

--- a/crates/fricon/src/dataset/semantics.rs
+++ b/crates/fricon/src/dataset/semantics.rs
@@ -1,7 +1,11 @@
 mod error;
 mod io;
+mod materialize;
 mod model;
 
+pub(crate) use self::materialize::{
+    is_hidden_system_column, materialize_record_ids, materialized_schema,
+};
 pub use self::{
     error::{ManifestError, ManifestValidationError},
     io::{read_manifest, read_manifest_optional, write_manifest},

--- a/crates/fricon/src/dataset/semantics/materialize.rs
+++ b/crates/fricon/src/dataset/semantics/materialize.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, RecordBatch, UInt64Array};
+use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
+
+use crate::dataset::{
+    schema::DatasetError,
+    semantics::{ManifestColumn, RECORD_ID_COLUMN, SystemColumn},
+};
+
+#[must_use]
+pub(crate) fn materialized_schema(user_schema: &Schema) -> SchemaRef {
+    let fields: Vec<_> = std::iter::once(Arc::new(Field::new(
+        RECORD_ID_COLUMN,
+        DataType::UInt64,
+        false,
+    )))
+    .chain(user_schema.fields().iter().cloned())
+    .collect();
+    Arc::new(Schema::new_with_metadata(
+        fields,
+        user_schema.metadata().clone(),
+    ))
+}
+
+pub(crate) fn materialize_record_ids(
+    storage_schema: SchemaRef,
+    batch: RecordBatch,
+    next_record_id: u64,
+) -> Result<(RecordBatch, u64), DatasetError> {
+    let row_count = u64::try_from(batch.num_rows()).map_err(|_| {
+        DatasetError::Arrow(ArrowError::InvalidArgumentError(
+            "record batch row count does not fit in uint64".to_string(),
+        ))
+    })?;
+    let end_record_id = next_record_id.checked_add(row_count).ok_or_else(|| {
+        DatasetError::Arrow(ArrowError::InvalidArgumentError(
+            "dataset record id overflow".to_string(),
+        ))
+    })?;
+
+    let record_ids: ArrayRef =
+        Arc::new(UInt64Array::from_iter_values(next_record_id..end_record_id));
+    let columns: Vec<_> = std::iter::once(record_ids)
+        .chain(batch.columns().iter().cloned())
+        .collect();
+    let batch = RecordBatch::try_new(storage_schema, columns)?;
+    Ok((batch, end_record_id))
+}
+
+#[must_use]
+pub(crate) fn is_hidden_system_column(name: &str, column: Option<&ManifestColumn>) -> bool {
+    column.is_some_and(|column| column.system == Some(SystemColumn::RecordId))
+        || name == RECORD_ID_COLUMN
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Float64Array, UInt64Array};
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::{materialize_record_ids, materialized_schema};
+    use crate::dataset::semantics::RECORD_ID_COLUMN;
+
+    fn user_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new(
+            "signal",
+            DataType::Float64,
+            false,
+        )]))
+    }
+
+    #[test]
+    fn materialized_schema_prepends_record_id() {
+        let schema = materialized_schema(user_schema().as_ref());
+
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), RECORD_ID_COLUMN);
+        assert_eq!(schema.field(0).data_type(), &DataType::UInt64);
+        assert!(!schema.field(0).is_nullable());
+        assert_eq!(schema.field(1).name(), "signal");
+    }
+
+    #[test]
+    fn materialize_record_ids_prepends_monotonic_ids() {
+        let user_schema = user_schema();
+        let storage_schema = materialized_schema(user_schema.as_ref());
+        let batch = arrow_array::RecordBatch::try_new(
+            user_schema,
+            vec![Arc::new(Float64Array::from(vec![10.0, 20.0, 30.0]))],
+        )
+        .expect("batch");
+
+        let (batch, next) = materialize_record_ids(storage_schema, batch, 7).expect("materialize");
+
+        assert_eq!(next, 10);
+        let record_ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("record ids");
+        assert_eq!(record_ids.values(), &[7, 8, 9]);
+    }
+}

--- a/crates/fricon/src/dataset/semantics/materialize.rs
+++ b/crates/fricon/src/dataset/semantics/materialize.rs
@@ -25,7 +25,7 @@ pub(crate) fn materialized_schema(user_schema: &Schema) -> SchemaRef {
 
 pub(crate) fn materialize_record_ids(
     storage_schema: SchemaRef,
-    batch: RecordBatch,
+    batch: &RecordBatch,
     next_record_id: u64,
 ) -> Result<(RecordBatch, u64), DatasetError> {
     let row_count = u64::try_from(batch.num_rows()).map_err(|_| {
@@ -93,7 +93,7 @@ mod tests {
         )
         .expect("batch");
 
-        let (batch, next) = materialize_record_ids(storage_schema, batch, 7).expect("materialize");
+        let (batch, next) = materialize_record_ids(storage_schema, &batch, 7).expect("materialize");
 
         assert_eq!(next, 10);
         let record_ids = batch

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -73,30 +73,32 @@ impl DatasetSemanticManifest {
         self.validate()?;
 
         for (name, column) in &self.columns {
-            if column.system == Some(SystemColumn::RecordId)
-                && name == RECORD_ID_COLUMN
-                && schema.field_with_name(name).is_err()
-            {
-                // Temporary compatibility for manifest-only record IDs. Issue
-                // #478 will materialize this column into Arrow payloads.
-                continue;
-            }
             let field = schema
                 .field_with_name(name)
                 .map_err(|_| ManifestValidationError::MissingArrowColumn { name: name.clone() })?;
             let expected = column.dtype.physical_data_type();
-            if field.data_type() != &expected {
-                return Err(ManifestValidationError::ArrowTypeMismatch {
-                    name: name.clone(),
-                    expected: expected.to_string(),
-                    found: field.data_type().to_string(),
-                });
-            }
             if field.is_nullable() {
                 return Err(ManifestValidationError::ArrowTypeMismatch {
                     name: name.clone(),
                     expected: format!("non-null {expected}"),
                     found: format!("nullable {}", field.data_type()),
+                });
+            }
+            if column.system == Some(SystemColumn::RecordId) {
+                if field.data_type() != &expected {
+                    return Err(ManifestValidationError::ArrowTypeMismatch {
+                        name: name.clone(),
+                        expected: expected.to_string(),
+                        found: field.data_type().to_string(),
+                    });
+                }
+            } else if DatasetDType::try_from_arrow_data_type(field.name(), field.data_type())?
+                != column.dtype
+            {
+                return Err(ManifestValidationError::ArrowTypeMismatch {
+                    name: name.clone(),
+                    expected: expected.to_string(),
+                    found: field.data_type().to_string(),
                 });
             }
         }
@@ -829,13 +831,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_against_arrow_schema_allows_temporarily_missing_record_id() {
+    fn validate_against_arrow_schema_rejects_missing_record_id() {
         let manifest = DatasetSemanticManifest::minimal(signal_columns());
         let schema = Schema::new(vec![Field::new("signal", DataType::Float64, false)]);
 
-        manifest
-            .validate_against_arrow_schema(&schema)
-            .expect("record id is manifest-only until materialization lands");
+        assert!(matches!(
+            manifest.validate_against_arrow_schema(&schema),
+            Err(ManifestValidationError::MissingArrowColumn { name })
+                if name == RECORD_ID_COLUMN
+        ));
     }
 
     #[test]

--- a/crates/fricon/src/lib.rs
+++ b/crates/fricon/src/lib.rs
@@ -22,8 +22,9 @@ pub use self::{
         ColumnMeaning, DatasetArray, DatasetDataType, DatasetEvent, DatasetId,
         DatasetInterpretation, DatasetListQuery, DatasetMetadata, DatasetReader, DatasetRecord,
         DatasetRow, DatasetScalar, DatasetSchema, DatasetSortBy, DatasetStatus, DatasetUpdate,
-        FixedStepTrace, InterpretationSource, ResolvedColumn, ResolvedDuplicatePolicy, ScalarArray,
-        ScalarKind, SelectOptions, SortDirection, TraceKind, VariableStepTrace,
+        FixedStepTrace, InterpretationSource, PhysicalColumnOrdinal, ResolvedColumn,
+        ResolvedDuplicatePolicy, ScalarArray, ScalarKind, SelectOptions, SortDirection, TraceKind,
+        VariableStepTrace, VisibleColumnOrdinal,
     },
     workspace::{WorkspaceError, WorkspaceRoot, get_log_dir},
 };

--- a/crates/fricon/tests/integration_test.rs
+++ b/crates/fricon/tests/integration_test.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::pedantic, clippy::restriction)]
-use std::sync::Arc;
+use std::{fs::File, sync::Arc};
 
-use arrow_array::{Array, Float64Array, RecordBatch};
+use arrow_array::{Array, Float64Array, RecordBatch, UInt64Array};
+use arrow_ipc::reader::FileReader;
 use fricon::{
-    AppManager, Client, ClientError, DatasetId, DatasetListQuery, DatasetRow, DatasetScalar,
-    DatasetStatus, ExistingUiProbeResult, FixedStepTrace, ScalarArray, VariableStepTrace,
-    WorkspaceRoot, app::UiCommand,
+    AppManager, Client, ClientError, ColumnMeaning, DatasetId, DatasetListQuery, DatasetRow,
+    DatasetScalar, DatasetStatus, ExistingUiProbeResult, FixedStepTrace, ScalarArray,
+    VariableStepTrace, WorkspaceRoot, app::UiCommand, dataset::semantics::RECORD_ID_COLUMN,
 };
 use indexmap::IndexMap;
 use num::complex::Complex64;
@@ -238,11 +239,30 @@ async fn test_dataset_create_metadata_payload_finish_completes() -> anyhow::Resu
     assert_eq!(dataset.tags(), &["test", "integration"]);
     assert_eq!(dataset.status(), DatasetStatus::Completed);
 
+    let chunk = File::open(dataset.path().join("data_chunk_0.arrow"))?;
+    let mut physical_reader = FileReader::try_new(chunk, None)?;
+    let physical_batch = physical_reader
+        .next()
+        .expect("first physical batch should exist")?;
+    assert_eq!(physical_batch.schema().field(0).name(), RECORD_ID_COLUMN);
+    let record_ids = physical_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .expect("record ids");
+    assert_eq!(record_ids.values(), &[0, 1, 2]);
+
     // Load dataset using DatasetManager directly
     let reader = app_manager
         .handle()
         .get_dataset_reader(DatasetId::Id(dataset.id()))
         .await?;
+    let interpretation = reader.interpret()?;
+    assert_eq!(
+        interpretation.columns[0].meaning,
+        ColumnMeaning::SystemRecordId
+    );
+    assert!(interpretation.columns[0].hidden_by_default);
     let loaded_batches: Vec<RecordBatch> = reader.batches();
 
     // Verify loaded data matches original

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -57,10 +57,10 @@ directory. A dataset is modeled as one logical Arrow table split across
 
 New datasets created through ingest also store `dataset_manifest.json` beside
 the chunk files. The manifest records v1 dataset semantic columns, realization
-defaults, and compatibility settings. During the transition before physical
-record-id materialization, the manifest may declare the Fricon-owned
-`__ds_record_id` system column even when the Arrow chunks do not yet contain
-that physical column.
+defaults, and compatibility settings. New semantic datasets physically
+materialize the Fricon-owned `__ds_record_id: uint64` system column as the
+first Arrow column. Earlier transition snapshots may contain manifests that
+declare `__ds_record_id` before the Arrow chunks materialized that column.
 
 The physical storage layout is an implementation detail. User-facing docs may
 mention Arrow-compatible tables, but should avoid promising exact file names,


### PR DESCRIPTION
closes #478 

## Summary
- Materialize `__ds_record_id` into new semantic dataset Arrow payloads at ingest time
- Keep user-facing reads filtered to visible columns while preserving hidden system metadata for interpretation
- Update Python helpers, integration tests, and storage notes to reflect the new physical layout

## Testing
- Rust formatting, `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo nextest run` passed
- Python formatting, editable build, `ruff check`, and `pytest` passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
