### PR TITLE
feat: add Python column metadata API

### DIFF
--- a/.changeset/python-column-metadata.md
+++ b/.changeset/python-column-metadata.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Add Python column metadata declarations
+
+Python dataset creation now accepts typed column declarations with units,
+labels, hidden-by-default state, and chart-axis hints that persist in dataset
+manifests.

--- a/crates/fricon-py/python/fricon/__init__.py
+++ b/crates/fricon-py/python/fricon/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from ._core import (
+    Column,
     Dataset,
     DatasetManager,
     DatasetWriter,
@@ -19,6 +20,7 @@ except PackageNotFoundError:
     __version__ = "0+unknown"
 
 __all__ = [
+    "Column",
     "Dataset",
     "DatasetManager",
     "DatasetWriter",

--- a/crates/fricon-py/python/fricon/_core.pyi
+++ b/crates/fricon-py/python/fricon/_core.pyi
@@ -11,6 +11,7 @@ from numpy import floating
 from typing_extensions import Self
 
 __all__ = [
+    "Column",
     "Dataset",
     "DatasetManager",
     "DatasetWriter",
@@ -44,6 +45,32 @@ class Workspace:
     @property
     def dataset_manager(self) -> DatasetManager: ...
 
+_DeclaredColumnDType: TypeAlias = type[float] | type[complex] | type[Trace]
+
+@final
+class Column:
+    def __new__(
+        cls,
+        dtype: _DeclaredColumnDType | None = ...,
+        *,
+        unit: str | None = ...,
+        label: str | None = ...,
+        hidden_by_default: bool = ...,
+        chart_axis: bool = ...,
+    ) -> Self: ...
+    @property
+    def dtype(self) -> _DeclaredColumnDType | None: ...
+    @property
+    def unit(self) -> str | None: ...
+    @property
+    def label(self) -> str | None: ...
+    @property
+    def hidden_by_default(self) -> bool: ...
+    @property
+    def chart_axis(self) -> bool: ...
+
+_ColumnSpec: TypeAlias = _DeclaredColumnDType | Column
+
 @final
 class DatasetManager:
     def create(
@@ -52,6 +79,7 @@ class DatasetManager:
         *,
         description: str | None = ...,
         tags: Iterable[str] | None = ...,
+        columns: Mapping[str, _ColumnSpec] | None = ...,
     ) -> DatasetWriter: ...
     def open(
         self,

--- a/crates/fricon-py/src/lib.rs
+++ b/crates/fricon-py/src/lib.rs
@@ -27,8 +27,8 @@ mod convert;
 mod _core {
     #[pymodule_export]
     use super::{
-        Dataset, DatasetManager, DatasetWriter, FriconDatasetError, ServerHandle, Trace, Workspace,
-        serve_workspace,
+        Column, Dataset, DatasetManager, DatasetWriter, FriconDatasetError, ServerHandle, Trace,
+        Workspace, serve_workspace,
     };
     #[cfg(feature = "python-cli-entrypoints")]
     #[pymodule_export]
@@ -40,17 +40,17 @@ use std::{mem, path::PathBuf, time::Duration};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use fricon::{
-    Client, ClientError,
+    Client, ClientError, ColumnMetadata,
     app::AppManager,
     dataset::{
         model::{DatasetMetadata, DatasetRecord, DatasetStatus},
-        schema::{DatasetScalar, FixedStepTrace, VariableStepTrace},
+        schema::{DatasetRow, DatasetScalar, FixedStepTrace, VariableStepTrace},
     },
 };
 use indexmap::IndexMap;
 use pyo3::{
     create_exception,
-    exceptions::{PyException, PyRuntimeError},
+    exceptions::{PyException, PyRuntimeError, PyTypeError, PyValueError},
     prelude::*,
     sync::PyOnceLock,
     types::{PyDict, PyList},
@@ -140,6 +140,198 @@ fn map_client_error(error: ClientError) -> PyErr {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeclaredDType {
+    Float,
+    Complex,
+    Trace,
+}
+
+#[derive(Clone)]
+struct ColumnDeclaration {
+    name: String,
+    dtype: Option<DeclaredDType>,
+    metadata: ColumnMetadata,
+}
+
+#[derive(Clone)]
+struct ColumnDeclarations(Vec<ColumnDeclaration>);
+
+impl ColumnDeclarations {
+    fn metadata(&self) -> Vec<ColumnMetadata> {
+        self.0
+            .iter()
+            .map(|declaration| declaration.metadata.clone())
+            .collect()
+    }
+}
+
+/// Stored column metadata for dataset creation.
+#[pyclass(module = "fricon._core")]
+pub struct Column {
+    dtype: Option<Py<PyAny>>,
+    unit: Option<String>,
+    label: Option<String>,
+    hidden_by_default: bool,
+    chart_axis: bool,
+}
+
+#[pymethods]
+impl Column {
+    #[new]
+    #[pyo3(signature=(dtype=None,*,unit=None,label=None,hidden_by_default=false,chart_axis=false))]
+    pub fn new(
+        dtype: Option<Py<PyAny>>,
+        unit: Option<String>,
+        label: Option<String>,
+        hidden_by_default: bool,
+        chart_axis: bool,
+    ) -> Self {
+        Self {
+            dtype,
+            unit,
+            label,
+            hidden_by_default,
+            chart_axis,
+        }
+    }
+
+    #[getter]
+    pub fn dtype(&self, py: Python<'_>) -> Option<Py<PyAny>> {
+        self.dtype.as_ref().map(|dtype| dtype.clone_ref(py))
+    }
+
+    #[getter]
+    pub fn unit(&self) -> Option<&str> {
+        self.unit.as_deref()
+    }
+
+    #[getter]
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    #[getter]
+    pub const fn hidden_by_default(&self) -> bool {
+        self.hidden_by_default
+    }
+
+    #[getter]
+    pub const fn chart_axis(&self) -> bool {
+        self.chart_axis
+    }
+}
+
+fn parse_declared_dtype(dtype: &Bound<'_, PyAny>) -> PyResult<DeclaredDType> {
+    let name: String = dtype.getattr("__name__")?.extract()?;
+    let module: String = dtype.getattr("__module__")?.extract()?;
+    match (module.as_str(), name.as_str()) {
+        ("builtins", "float") => Ok(DeclaredDType::Float),
+        ("builtins", "complex") => Ok(DeclaredDType::Complex),
+        ("fricon._core", "Trace") => Ok(DeclaredDType::Trace),
+        _ => Err(PyTypeError::new_err(format!(
+            "Unsupported column dtype {module}.{name}; expected float, complex, or Trace."
+        ))),
+    }
+}
+
+fn parse_column_spec(py: Python<'_>, name: String, spec: Py<PyAny>) -> PyResult<ColumnDeclaration> {
+    let bound = spec.bind(py);
+    if let Ok(column) = bound.extract::<PyRef<'_, Column>>() {
+        let dtype = column
+            .dtype
+            .as_ref()
+            .map(|dtype| parse_declared_dtype(dtype.bind(py)))
+            .transpose()?;
+        return Ok(ColumnDeclaration {
+            name: name.clone(),
+            dtype,
+            metadata: ColumnMetadata {
+                name,
+                unit: column.unit.clone(),
+                label: column.label.clone(),
+                hidden_by_default: column.hidden_by_default,
+                chart_axis: column.chart_axis,
+            },
+        });
+    }
+
+    Ok(ColumnDeclaration {
+        name: name.clone(),
+        dtype: Some(parse_declared_dtype(bound)?),
+        metadata: ColumnMetadata::new(name),
+    })
+}
+
+fn parse_column_declarations(
+    py: Python<'_>,
+    columns: Option<IndexMap<String, Py<PyAny>>>,
+) -> PyResult<Option<ColumnDeclarations>> {
+    let Some(columns) = columns else {
+        return Ok(None);
+    };
+    if columns.is_empty() {
+        return Err(PyValueError::new_err("columns must not be empty."));
+    }
+    let declarations = columns
+        .into_iter()
+        .map(|(name, spec)| parse_column_spec(py, name, spec))
+        .collect::<PyResult<Vec<_>>>()?;
+    Ok(Some(ColumnDeclarations(declarations)))
+}
+
+fn build_declared_row(
+    py: Python<'_>,
+    mut values: IndexMap<String, Py<PyAny>>,
+    declarations: &ColumnDeclarations,
+) -> PyResult<DatasetRow> {
+    let mut ordered = IndexMap::new();
+    for declaration in &declarations.0 {
+        let value = values.shift_remove(&declaration.name).ok_or_else(|| {
+            PyValueError::new_err(format!("Missing declared column '{}'.", declaration.name))
+        })?;
+        ordered.insert(declaration.name.clone(), value);
+    }
+    if let Some(extra) = values.keys().next() {
+        return Err(PyValueError::new_err(format!(
+            "Unexpected column '{extra}' was not declared."
+        )));
+    }
+
+    let row = convert::build_row(py, ordered)?;
+    for declaration in &declarations.0 {
+        if let Some(dtype) = declaration.dtype {
+            let scalar = &row.0[&declaration.name];
+            validate_declared_dtype(&declaration.name, dtype, scalar)?;
+        }
+    }
+    Ok(row)
+}
+
+fn validate_declared_dtype(
+    name: &str,
+    dtype: DeclaredDType,
+    scalar: &DatasetScalar,
+) -> PyResult<()> {
+    let matches = match dtype {
+        DeclaredDType::Float => matches!(scalar, DatasetScalar::Numeric(_)),
+        DeclaredDType::Complex => matches!(scalar, DatasetScalar::Complex(_)),
+        DeclaredDType::Trace => matches!(
+            scalar,
+            DatasetScalar::SimpleTrace(_)
+                | DatasetScalar::FixedStepTrace(_)
+                | DatasetScalar::VariableStepTrace(_)
+        ),
+    };
+    if matches {
+        Ok(())
+    } else {
+        Err(PyValueError::new_err(format!(
+            "Column '{name}' value does not match its declared dtype."
+        )))
+    }
+}
+
 /// A client of fricon workspace server.
 #[pyclass(module = "fricon._core", from_py_object)]
 #[derive(Clone)]
@@ -186,24 +378,29 @@ impl DatasetManager {
     ///     name: Name of the dataset.
     ///     description: Description of the dataset.
     ///     tags: Tags of the dataset. Duplicate tags will be added only once.
+    ///     columns: Optional stored column declarations and metadata.
     ///
     /// Returns:
     ///     A writer of the newly created dataset.
-    #[pyo3(signature = (name, *, description=None, tags=None))]
+    #[pyo3(signature = (name, *, description=None, tags=None, columns=None))]
     pub fn create(
         &self,
+        py: Python<'_>,
         name: String,
         description: Option<String>,
         tags: Option<Vec<String>>,
-    ) -> Result<DatasetWriter> {
+        columns: Option<IndexMap<String, Py<PyAny>>>,
+    ) -> PyResult<DatasetWriter> {
         let description = description.unwrap_or_default();
         let tags = tags.unwrap_or_default();
+        let columns = parse_column_declarations(py, columns)?;
 
         Ok(DatasetWriter::new(
             self.workspace.client.clone(),
             name,
             description,
             tags,
+            columns,
         ))
     }
 
@@ -553,8 +750,12 @@ enum WriterState {
         name: String,
         description: String,
         tags: Vec<String>,
+        columns: Option<ColumnDeclarations>,
     },
-    Writing(fricon::DatasetWriter),
+    Writing {
+        writer: fricon::DatasetWriter,
+        columns: Option<ColumnDeclarations>,
+    },
     Finished,
 }
 
@@ -569,13 +770,20 @@ pub struct DatasetWriter {
 }
 
 impl DatasetWriter {
-    const fn new(client: Client, name: String, description: String, tags: Vec<String>) -> Self {
+    fn new(
+        client: Client,
+        name: String,
+        description: String,
+        tags: Vec<String>,
+        columns: Option<ColumnDeclarations>,
+    ) -> Self {
         Self {
             state: WriterState::NotStarted {
                 client,
                 name,
                 description,
                 tags,
+                columns,
             },
             dataset: None,
         }
@@ -587,7 +795,7 @@ impl DatasetWriter {
         }
 
         match mem::replace(&mut self.state, WriterState::Finished) {
-            WriterState::Writing(writer) => {
+            WriterState::Writing { writer, .. } => {
                 let inner = if abort {
                     py.detach(|| get_runtime().block_on(writer.abort()))
                         .map_err(map_client_error)?
@@ -604,12 +812,14 @@ impl DatasetWriter {
                 name,
                 description,
                 tags,
+                columns,
             } => {
                 self.state = WriterState::NotStarted {
                     client,
                     name,
                     description,
                     tags,
+                    columns,
                 };
                 Err(generic_py_err("No data to finalize."))
             }
@@ -661,9 +871,17 @@ impl DatasetWriter {
                 name,
                 description,
                 tags,
+                columns,
             } => {
-                let row = convert::build_row(py, values)?;
+                let row = if let Some(columns) = columns.as_ref() {
+                    build_declared_row(py, values, columns)?
+                } else {
+                    convert::build_row(py, values)?
+                };
                 let schema = row.to_schema();
+                let column_metadata = columns
+                    .as_ref()
+                    .map_or_else(Vec::new, ColumnDeclarations::metadata);
                 let writer = py
                     .detach(|| -> std::result::Result<_, ClientError> {
                         let mut writer = get_runtime().block_on(client.create_dataset(
@@ -671,22 +889,30 @@ impl DatasetWriter {
                             description,
                             tags,
                             schema,
+                            column_metadata,
                         ))?;
                         get_runtime().block_on(writer.write(row))?;
                         Ok(writer)
                     })
                     .map_err(map_client_error)?;
-                self.state = WriterState::Writing(writer);
+                self.state = WriterState::Writing { writer, columns };
             }
-            WriterState::Writing(mut writer) => {
-                let row = convert::build_row(py, values)?;
+            WriterState::Writing {
+                mut writer,
+                columns,
+            } => {
+                let row = if let Some(columns) = columns.as_ref() {
+                    build_declared_row(py, values, columns)?
+                } else {
+                    convert::build_row(py, values)?
+                };
                 writer = py
                     .detach(|| -> std::result::Result<_, ClientError> {
                         get_runtime().block_on(writer.write(row))?;
                         Ok(writer)
                     })
                     .map_err(map_client_error)?;
-                self.state = WriterState::Writing(writer);
+                self.state = WriterState::Writing { writer, columns };
             }
             WriterState::Finished => {
                 return Err(generic_py_err("Writer closed."));
@@ -726,7 +952,7 @@ impl DatasetWriter {
             return Ok(());
         }
 
-        if matches!(self.state, WriterState::Writing(_)) {
+        if matches!(self.state, WriterState::Writing { .. }) {
             let _ = self.finish(py)?;
         } else {
             self.state = WriterState::Finished;

--- a/crates/fricon-py/tests/import_test.py
+++ b/crates/fricon-py/tests/import_test.py
@@ -5,4 +5,21 @@ import fricon
 
 def test_import() -> None:
     assert fricon.__name__ == "fricon"
+    assert hasattr(fricon, "Column")
     assert hasattr(fricon, "FriconDatasetError")
+
+
+def test_column_constructor() -> None:
+    column = fricon.Column(
+        float,
+        unit="V",
+        label="Voltage",
+        hidden_by_default=True,
+        chart_axis=True,
+    )
+
+    assert column.dtype is float
+    assert column.unit == "V"
+    assert column.label == "Voltage"
+    assert column.hidden_by_default
+    assert column.chart_axis

--- a/crates/fricon-py/tests/integration/test_dataset_operations.py
+++ b/crates/fricon-py/tests/integration/test_dataset_operations.py
@@ -5,6 +5,7 @@ Integration tests for dataset operations.
 from __future__ import annotations
 
 import gc
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -62,6 +63,86 @@ class TestDatasetOperations:
             assert datasets.iloc[0]["name"] == "context_test"
 
             # Explicitly shutdown the server
+            server_handle.shutdown()
+            assert not server_handle.is_running
+
+    def test_dataset_column_metadata_round_trips_to_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_path = Path(tmpdir) / "test_workspace"
+            workspace, server_handle = fricon._core.serve_workspace(workspace_path)
+            dm = workspace.dataset_manager
+
+            with dm.create(
+                "column_metadata",
+                columns={
+                    "voltage": fricon.Column(
+                        float,
+                        unit="V",
+                        label="Voltage",
+                        hidden_by_default=True,
+                        chart_axis=True,
+                    ),
+                    "measurement": complex,
+                },
+            ) as writer:
+                writer.write(measurement=1.0 + 2.0j, voltage=0.25)
+                dataset = writer.finish()
+
+            manifest_path = Path(dataset.path) / "dataset_manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            voltage = manifest["columns"]["voltage"]
+            assert voltage["dtype"] == {"kind": "float64"}
+            assert voltage["unit"] == "V"
+            assert voltage["label"] == "Voltage"
+            assert voltage["hidden_by_default"] is True
+            assert voltage["chart_axis"] is True
+            assert manifest["columns"]["measurement"]["dtype"] == {"kind": "complex128"}
+            assert dataset.to_arrow().column_names == ["voltage", "measurement"]
+
+            server_handle.shutdown()
+            assert not server_handle.is_running
+
+    def test_dataset_column_metadata_can_infer_dtype(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_path = Path(tmpdir) / "test_workspace"
+            workspace, server_handle = fricon._core.serve_workspace(workspace_path)
+            dm = workspace.dataset_manager
+
+            with dm.create(
+                "metadata_only",
+                columns={"phase": fricon.Column(unit="rad")},
+            ) as writer:
+                writer.write(phase=1.5)
+                dataset = writer.finish()
+
+            manifest = json.loads(
+                (Path(dataset.path) / "dataset_manifest.json").read_text()
+            )
+            phase = manifest["columns"]["phase"]
+            assert phase["dtype"] == {"kind": "float64"}
+            assert phase["unit"] == "rad"
+
+            server_handle.shutdown()
+            assert not server_handle.is_running
+
+    def test_dataset_declared_columns_require_exact_first_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_path = Path(tmpdir) / "test_workspace"
+            workspace, server_handle = fricon._core.serve_workspace(workspace_path)
+            dm = workspace.dataset_manager
+
+            writer = dm.create("missing_column", columns={"voltage": float})
+            with pytest.raises(ValueError, match="Missing declared column 'voltage'"):
+                writer.write(current=1.0)
+
+            writer = dm.create("extra_column", columns={"voltage": float})
+            with pytest.raises(ValueError, match="Unexpected column 'current'"):
+                writer.write(voltage=1.0, current=2.0)
+
+            writer = dm.create("wrong_dtype", columns={"measurement": complex})
+            with pytest.raises(ValueError, match="declared dtype"):
+                writer.write(measurement=1.0)
+
             server_handle.shutdown()
             assert not server_handle.is_running
 

--- a/crates/fricon-py/tests/integration/test_dataset_operations.py
+++ b/crates/fricon-py/tests/integration/test_dataset_operations.py
@@ -9,6 +9,7 @@ import json
 import tempfile
 import time
 from pathlib import Path
+from typing import cast
 
 import fricon
 import fricon._core
@@ -89,14 +90,16 @@ class TestDatasetOperations:
                 dataset = writer.finish()
 
             manifest_path = Path(dataset.path) / "dataset_manifest.json"
-            manifest = json.loads(manifest_path.read_text())
-            voltage = manifest["columns"]["voltage"]
+            manifest = cast("dict[str, object]", json.loads(manifest_path.read_text()))
+            columns = cast("dict[str, object]", manifest["columns"])
+            voltage = cast("dict[str, object]", columns["voltage"])
             assert voltage["dtype"] == {"kind": "float64"}
             assert voltage["unit"] == "V"
             assert voltage["label"] == "Voltage"
             assert voltage["hidden_by_default"] is True
             assert voltage["chart_axis"] is True
-            assert manifest["columns"]["measurement"]["dtype"] == {"kind": "complex128"}
+            measurement = cast("dict[str, object]", columns["measurement"])
+            assert measurement["dtype"] == {"kind": "complex128"}
             assert dataset.to_arrow().column_names == ["voltage", "measurement"]
 
             server_handle.shutdown()
@@ -115,10 +118,12 @@ class TestDatasetOperations:
                 writer.write(phase=1.5)
                 dataset = writer.finish()
 
-            manifest = json.loads(
-                (Path(dataset.path) / "dataset_manifest.json").read_text()
+            manifest = cast(
+                "dict[str, object]",
+                json.loads((Path(dataset.path) / "dataset_manifest.json").read_text()),
             )
-            phase = manifest["columns"]["phase"]
+            columns = cast("dict[str, object]", manifest["columns"])
+            phase = cast("dict[str, object]", columns["phase"])
             assert phase["dtype"] == {"kind": "float64"}
             assert phase["unit"] == "rad"
 

--- a/crates/fricon-ui/src/bin/create-smoke-workspace.rs
+++ b/crates/fricon-ui/src/bin/create-smoke-workspace.rs
@@ -80,6 +80,7 @@ async fn seed_workspace(workspace: PathBuf) -> Result<()> {
             "Small scalar dataset for Tauri desktop smoke coverage".to_string(),
             vec!["smoke".to_string(), "desktop".to_string()],
             schema,
+            Vec::new(),
         )
         .await
         .context("failed to create smoke dataset writer")?;

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -698,6 +698,7 @@ mod tests {
                 String::new(),
                 vec![],
                 schema,
+                Vec::new(),
             )
             .await?;
         for row in rows {

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -206,6 +206,7 @@ mod tests {
                 String::new(),
                 vec!["test".to_string()],
                 schema,
+                Vec::new(),
             )
             .await?;
         for row in rows {

--- a/crates/fricon/proto/fricon/v1alpha/dataset.proto
+++ b/crates/fricon/proto/fricon/v1alpha/dataset.proto
@@ -49,6 +49,15 @@ message CreateMetadata {
   string name = 1;
   string description = 2;
   repeated string tags = 3;
+  repeated ColumnMetadata columns = 4;
+}
+
+message ColumnMetadata {
+  string name = 1;
+  optional string unit = 2;
+  optional string label = 3;
+  bool hidden_by_default = 4;
+  bool chart_axis = 5;
 }
 
 message CreateAbort {}

--- a/crates/fricon/src/app.rs
+++ b/crates/fricon/src/app.rs
@@ -496,6 +496,7 @@ impl AppHandle {
             name,
             description,
             tags,
+            column_metadata: Vec::new(),
         };
         self.run_ingest_task(
             "failed to join dataset create task",

--- a/crates/fricon/src/client.rs
+++ b/crates/fricon/src/client.rs
@@ -28,12 +28,14 @@ use crate::{
     dataset::{
         model::{DatasetRecord, DatasetStatus},
         schema::{DatasetArray, DatasetRow, DatasetSchema},
+        semantics::ColumnMetadata,
     },
     proto::{
-        AddTagsRequest, CreateAbort, CreateFinish, CreateMetadata, CreateRequest, CreateResponse,
-        GetRequest, RemoveTagsRequest, SearchRequest, UpdateRequest, VersionRequest,
-        create_request::CreateMessage, dataset_service_client::DatasetServiceClient,
-        fricon_service_client::FriconServiceClient, get_request::IdEnum,
+        AddTagsRequest, ColumnMetadata as ProtoColumnMetadata, CreateAbort, CreateFinish,
+        CreateMetadata, CreateRequest, CreateResponse, GetRequest, RemoveTagsRequest,
+        SearchRequest, UpdateRequest, VersionRequest, create_request::CreateMessage,
+        dataset_service_client::DatasetServiceClient, fricon_service_client::FriconServiceClient,
+        get_request::IdEnum,
     },
     transport::{
         grpc::{
@@ -180,6 +182,7 @@ impl Client {
         description: String,
         tags: Vec<String>,
         schema: DatasetSchema,
+        column_metadata: Vec<ColumnMetadata>,
     ) -> Result<DatasetWriter, ClientError> {
         Ok(DatasetWriter::new(
             self.clone(),
@@ -187,6 +190,7 @@ impl Client {
             description,
             tags,
             schema,
+            column_metadata,
             tokio::runtime::Handle::current(),
         ))
     }
@@ -321,6 +325,7 @@ impl DatasetWriter {
         description: String,
         tags: Vec<String>,
         schema: DatasetSchema,
+        column_metadata: Vec<ColumnMetadata>,
         runtime: tokio::runtime::Handle,
     ) -> Self {
         let (tx, rx) = mpsc::channel::<StreamMessage>(16);
@@ -328,8 +333,14 @@ impl DatasetWriter {
         let arrow_schema = Arc::new(schema.to_arrow_schema());
         let connection_handle = runtime.spawn({
             let client = client.clone();
-            let request_stream =
-                build_request_stream(name, description, tags, arrow_schema.clone(), rx);
+            let request_stream = build_request_stream(
+                name,
+                description,
+                tags,
+                column_metadata,
+                arrow_schema.clone(),
+                rx,
+            );
             async move {
                 let request = Request::new(request_stream);
                 let response = client
@@ -482,10 +493,21 @@ fn finish_request() -> CreateRequest {
     }
 }
 
+fn column_metadata_to_proto(value: ColumnMetadata) -> ProtoColumnMetadata {
+    ProtoColumnMetadata {
+        name: value.name,
+        unit: value.unit,
+        label: value.label,
+        hidden_by_default: value.hidden_by_default,
+        chart_axis: value.chart_axis,
+    }
+}
+
 fn build_request_stream(
     name: String,
     description: String,
     tags: Vec<String>,
+    column_metadata: Vec<ColumnMetadata>,
     arrow_schema: SchemaRef,
     message_rx: mpsc::Receiver<StreamMessage>,
 ) -> impl Stream<Item = CreateRequest> {
@@ -495,6 +517,7 @@ fn build_request_stream(
                 name,
                 description,
                 tags,
+                columns: column_metadata.into_iter().map(column_metadata_to_proto).collect(),
             })),
         };
 
@@ -773,7 +796,8 @@ mod tests {
         split_payload_chunk,
     };
     use crate::{
-        APP_VERSION, IPC_PROTOCOL_VERSION, proto::create_request::CreateMessage,
+        APP_VERSION, IPC_PROTOCOL_VERSION, dataset::semantics::ColumnMetadata,
+        proto::create_request::CreateMessage,
         transport::grpc::dataset_service::DATASET_ERROR_CODE_METADATA_KEY,
     };
 
@@ -911,6 +935,7 @@ mod tests {
             "dataset".to_string(),
             "desc".to_string(),
             vec!["tag".to_string()],
+            Vec::new(),
             schema,
             message_rx,
         );
@@ -945,6 +970,7 @@ mod tests {
             "dataset".to_string(),
             "desc".to_string(),
             vec![],
+            Vec::new(),
             schema,
             message_rx,
         );
@@ -975,6 +1001,7 @@ mod tests {
             "dataset".to_string(),
             "desc".to_string(),
             vec![],
+            Vec::new(),
             schema,
             message_rx,
         );
@@ -990,6 +1017,42 @@ mod tests {
             messages[messages.len() - 1],
             CreateMessage::Abort(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn build_request_stream_sends_column_metadata() {
+        let (message_tx, message_rx) = mpsc::channel(2);
+        drop(message_tx);
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));
+        let stream = build_request_stream(
+            "dataset".to_string(),
+            "desc".to_string(),
+            vec![],
+            vec![ColumnMetadata {
+                name: "x".to_string(),
+                unit: Some("V".to_string()),
+                label: Some("Voltage".to_string()),
+                hidden_by_default: true,
+                chart_axis: true,
+            }],
+            schema,
+            message_rx,
+        );
+
+        let messages: Vec<_> = stream
+            .map(|req| req.create_message.expect("message"))
+            .collect()
+            .await;
+        let CreateMessage::Metadata(metadata) = &messages[0] else {
+            panic!("first message should be metadata");
+        };
+
+        assert_eq!(metadata.columns.len(), 1);
+        assert_eq!(metadata.columns[0].name, "x");
+        assert_eq!(metadata.columns[0].unit.as_deref(), Some("V"));
+        assert_eq!(metadata.columns[0].label.as_deref(), Some("Voltage"));
+        assert!(metadata.columns[0].hidden_by_default);
+        assert!(metadata.columns[0].chart_axis);
     }
 
     #[test]

--- a/crates/fricon/src/database/dataset.rs
+++ b/crates/fricon/src/database/dataset.rs
@@ -722,6 +722,7 @@ mod tests {
             name: "existing".to_string(),
             description: "existing dataset".to_string(),
             tags: vec!["old".to_string(), "stale".to_string()],
+            column_metadata: Vec::new(),
         };
         let existing = DatasetIngestRepository::create_dataset_record(&fixture.repo, &request, uid)
             .expect("create dataset");

--- a/crates/fricon/src/dataset.rs
+++ b/crates/fricon/src/dataset.rs
@@ -26,6 +26,7 @@ pub use self::{
         DatasetArray, DatasetDataType, DatasetRow, DatasetScalar, DatasetSchema, FixedStepTrace,
         ScalarArray, ScalarKind, TraceKind, VariableStepTrace,
     },
+    semantics::ColumnMetadata,
 };
 pub(crate) use self::{
     ingest::{CreateDatasetInput, CreateDatasetRequest},

--- a/crates/fricon/src/dataset/ingest.rs
+++ b/crates/fricon/src/dataset/ingest.rs
@@ -20,7 +20,10 @@ pub use self::error::IngestError;
 pub(crate) use self::{
     registry::WriteSessionRegistry, service::DatasetIngestService, session::WriteSessionHandle,
 };
-use crate::dataset::model::{DatasetId, DatasetRecord, DatasetStatus};
+use crate::dataset::{
+    model::{DatasetId, DatasetRecord, DatasetStatus},
+    semantics::ColumnMetadata,
+};
 
 /// Persistence port for ingest-time dataset creation and status updates.
 ///
@@ -53,6 +56,7 @@ pub(crate) struct CreateDatasetRequest {
     pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) tags: Vec<String>,
+    pub(crate) column_metadata: Vec<ColumnMetadata>,
 }
 
 /// Stream input driving a dataset ingest session.

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -76,7 +76,11 @@ where
         match event {
             CreateDatasetInput::Schema(schema) => {
                 if !manifest_written {
-                    if let Err(error) = write_minimal_manifest(&dataset_path, schema.as_ref()) {
+                    if let Err(error) = write_minimal_manifest(
+                        &dataset_path,
+                        schema.as_ref(),
+                        &request.column_metadata,
+                    ) {
                         debug!(error = %error, "Failed to write dataset semantic manifest");
                         let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
                         return Err(error);
@@ -86,7 +90,11 @@ where
             }
             CreateDatasetInput::Batch(batch) => {
                 if !manifest_written {
-                    if let Err(error) = write_minimal_manifest(&dataset_path, batch.schema_ref()) {
+                    if let Err(error) = write_minimal_manifest(
+                        &dataset_path,
+                        batch.schema_ref(),
+                        &request.column_metadata,
+                    ) {
                         debug!(error = %error, "Failed to write dataset semantic manifest");
                         let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
                         return Err(error);
@@ -165,9 +173,13 @@ fn create_dataset_dir(paths: &WorkspacePaths, uid: Uuid) -> Result<PathBuf, Inge
 fn write_minimal_manifest(
     dataset_path: &std::path::Path,
     schema: &arrow_schema::Schema,
+    column_metadata: &[crate::dataset::semantics::ColumnMetadata],
 ) -> Result<(), IngestError> {
-    let manifest =
-        DatasetSemanticManifest::minimal_from_arrow_schema(schema).map_err(ManifestError::from)?;
+    let manifest = DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata(
+        schema,
+        column_metadata.iter().cloned(),
+    )
+    .map_err(ManifestError::from)?;
     write_manifest(dataset_path, &manifest)?;
     Ok(())
 }
@@ -193,8 +205,8 @@ mod tests {
             events::{DatasetEvent, test_utils::CollectEvents},
             model::{DatasetMetadata, DatasetStatus},
             semantics::{
-                DatasetDType, ManifestError, ManifestValidationError, RECORD_ID_COLUMN,
-                read_manifest,
+                ColumnMetadata, DatasetDType, ManifestError, ManifestValidationError,
+                RECORD_ID_COLUMN, read_manifest,
             },
             storage::layout::manifest_path,
         },
@@ -288,6 +300,7 @@ mod tests {
             name: "dataset".to_string(),
             description: "desc".to_string(),
             tags: vec!["tag".to_string()],
+            column_metadata: Vec::new(),
         }
     }
 
@@ -426,6 +439,43 @@ mod tests {
         assert_eq!(manifest.columns["id"].dtype, DatasetDType::Float64);
         assert!(manifest.realization.append_only);
         assert!(manifest.compatibility.allow_inference);
+    }
+
+    #[test]
+    fn schema_write_persists_column_metadata() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = WorkspaceRoot::create_new(temp_dir.path()).expect("workspace");
+        let paths = workspace.paths().clone();
+        let repo = FakeRepo::new();
+        let events = CollectEvents::default();
+        let write_sessions = WriteSessionRegistry::new();
+        let mut request = create_request();
+        request.column_metadata = vec![ColumnMetadata {
+            name: "id".to_string(),
+            unit: Some("V".to_string()),
+            label: Some("Voltage".to_string()),
+            hidden_by_default: true,
+            chart_axis: true,
+        }];
+        let mut inputs = VecDeque::from(vec![
+            CreateDatasetInput::Schema(one_col_schema()),
+            CreateDatasetInput::Finish,
+        ]);
+
+        create_dataset_with(&repo, &paths, &events, &write_sessions, &request, || {
+            inputs.pop_front()
+        })
+        .expect("create dataset");
+
+        let manifest = read_manifest(manifest_path(
+            &paths.dataset_path_from_uid(repo.created_uid()),
+        ))
+        .expect("read manifest");
+        let id = &manifest.columns["id"];
+        assert_eq!(id.unit.as_deref(), Some("V"));
+        assert_eq!(id.label.as_deref(), Some("Voltage"));
+        assert!(id.hidden_by_default);
+        assert!(id.chart_axis);
     }
 
     #[test]

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -18,7 +18,9 @@ use crate::{
             WriteSessionRegistry,
         },
         model::{DatasetId, DatasetRecord, DatasetStatus},
-        semantics::{DatasetSemanticManifest, ManifestColumn, ManifestError, write_manifest},
+        semantics::{
+            ColumnMetadata, DatasetSemanticManifest, ManifestColumn, ManifestError, write_manifest,
+        },
         storage,
     },
     workspace::WorkspacePaths,
@@ -173,7 +175,7 @@ fn create_dataset_dir(paths: &WorkspacePaths, uid: Uuid) -> Result<PathBuf, Inge
 fn write_minimal_manifest(
     dataset_path: &std::path::Path,
     schema: &arrow_schema::Schema,
-    column_metadata: &[crate::dataset::semantics::ColumnMetadata],
+    column_metadata: &[ColumnMetadata],
 ) -> Result<(), IngestError> {
     let manifest = DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata(
         schema,

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -52,8 +52,10 @@ pub(crate) fn resolve_from_manifest(
                 },
                 is_index: false,
                 is_system: is_record_id,
-                hidden_by_default: is_record_id,
-                is_chart_axis_candidate: false,
+                hidden_by_default: is_record_id || column.hidden_by_default,
+                is_chart_axis_candidate: column.chart_axis,
+                unit: column.unit.clone(),
+                label: column.label.clone(),
             }
         })
         .collect();
@@ -63,12 +65,17 @@ pub(crate) fn resolve_from_manifest(
         .filter(|column| column.meaning == ColumnMeaning::UserValue)
         .filter_map(|column| column.visible_ordinal)
         .collect();
+    let chart_axis_candidate_columns = columns
+        .iter()
+        .filter(|column| column.is_chart_axis_candidate)
+        .filter_map(|column| column.visible_ordinal)
+        .collect();
 
     DatasetInterpretation {
         columns,
         value_columns,
         logical_index_columns: Vec::new(),
-        chart_axis_candidate_columns: Vec::new(),
+        chart_axis_candidate_columns,
         duplicate_policy: match manifest.realization.duplicate_resolution_default {
             DuplicateResolutionDefault::LatestByRecordId => {
                 ResolvedDuplicatePolicy::LatestByRecordIdPlaceholder
@@ -110,6 +117,8 @@ pub(crate) fn resolve_from_compatibility_inference(
                 is_system: false,
                 hidden_by_default: false,
                 is_chart_axis_candidate: is_index,
+                unit: None,
+                label: None,
             }
         })
         .collect();
@@ -230,6 +239,29 @@ mod tests {
         assert_eq!(signal.dtype, DatasetDType::Float64);
         assert!(!signal.is_system);
         assert!(!signal.hidden_by_default);
+    }
+
+    #[test]
+    fn manifest_interpretation_resolves_column_metadata() {
+        let mut signal = ManifestColumn::new(DatasetDType::Float64);
+        signal.unit = Some("V".to_string());
+        signal.label = Some("Voltage".to_string());
+        signal.hidden_by_default = true;
+        signal.chart_axis = true;
+        let manifest = DatasetSemanticManifest::minimal([("signal".to_string(), signal)]);
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]);
+
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
+        let signal = &interpretation.columns[1];
+
+        assert_eq!(signal.unit.as_deref(), Some("V"));
+        assert_eq!(signal.label.as_deref(), Some("Voltage"));
+        assert!(signal.hidden_by_default);
+        assert!(signal.is_chart_axis_candidate);
+        assert_eq!(interpretation.chart_axis_candidate_columns, visible(&[0]));
     }
 
     #[test]

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -31,6 +31,8 @@ pub struct ResolvedColumn {
     pub is_system: bool,
     pub hidden_by_default: bool,
     pub is_chart_axis_candidate: bool,
+    pub unit: Option<String>,
+    pub label: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/fricon/src/dataset/semantics.rs
+++ b/crates/fricon/src/dataset/semantics.rs
@@ -10,8 +10,9 @@ pub use self::{
     error::{ManifestError, ManifestValidationError},
     io::{read_manifest, read_manifest_optional, write_manifest},
     model::{
-        Compatibility, DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault,
-        IndexRealization, MANIFEST_VERSION_V1, ManifestColumn, RECORD_ID_COLUMN, Realization,
-        SystemColumn, TraceAxisDType, TraceDType, TraceLayout, TraceValueDType,
+        ColumnMetadata, Compatibility, DatasetDType, DatasetSemanticManifest,
+        DuplicateResolutionDefault, IndexRealization, MANIFEST_VERSION_V1, ManifestColumn,
+        RECORD_ID_COLUMN, Realization, SystemColumn, TraceAxisDType, TraceDType, TraceLayout,
+        TraceValueDType,
     },
 };

--- a/crates/fricon/src/dataset/semantics/error.rs
+++ b/crates/fricon/src/dataset/semantics/error.rs
@@ -30,8 +30,14 @@ pub enum ManifestValidationError {
     ReservedUserColumn { name: String },
     #[error("System column {name} is not valid in v1 dataset semantic manifests")]
     InvalidSystemColumn { name: String },
+    #[error("System column {name} cannot carry user column metadata")]
+    InvalidSystemColumnMetadata { name: String },
     #[error("Dataset semantic manifest v1 requires append_only=true")]
     AppendOnlyRequired,
+    #[error("Column metadata names a column that is not in the Arrow schema: {name}")]
+    UnknownColumnMetadata { name: String },
+    #[error("Column metadata was declared more than once: {name}")]
+    DuplicateColumnMetadata { name: String },
     #[error("Arrow schema is missing manifest column: {name}")]
     MissingArrowColumn { name: String },
     #[error("Arrow schema has a column not declared in the manifest: {name}")]

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -31,6 +31,13 @@ impl DatasetSemanticManifest {
     }
 
     pub fn minimal_from_arrow_schema(schema: &Schema) -> Result<Self, ManifestValidationError> {
+        Self::minimal_from_arrow_schema_with_metadata(schema, std::iter::empty())
+    }
+
+    pub fn minimal_from_arrow_schema_with_metadata(
+        schema: &Schema,
+        metadata: impl IntoIterator<Item = ColumnMetadata>,
+    ) -> Result<Self, ManifestValidationError> {
         let columns = schema
             .fields()
             .iter()
@@ -40,9 +47,39 @@ impl DatasetSemanticManifest {
                 Ok((name, ManifestColumn::new(dtype)))
             })
             .collect::<Result<Vec<_>, ManifestValidationError>>()?;
-        let manifest = Self::minimal(columns);
+        let mut manifest = Self::minimal(columns);
+        manifest.apply_column_metadata(metadata)?;
         manifest.validate()?;
         Ok(manifest)
+    }
+
+    fn apply_column_metadata(
+        &mut self,
+        metadata: impl IntoIterator<Item = ColumnMetadata>,
+    ) -> Result<(), ManifestValidationError> {
+        let mut seen = BTreeMap::new();
+        for metadata in metadata {
+            if seen.insert(metadata.name.clone(), ()).is_some() {
+                return Err(ManifestValidationError::DuplicateColumnMetadata {
+                    name: metadata.name,
+                });
+            }
+            let column = self.columns.get_mut(&metadata.name).ok_or_else(|| {
+                ManifestValidationError::UnknownColumnMetadata {
+                    name: metadata.name.clone(),
+                }
+            })?;
+            if column.system.is_some() {
+                return Err(ManifestValidationError::InvalidSystemColumnMetadata {
+                    name: metadata.name,
+                });
+            }
+            column.unit = metadata.unit;
+            column.label = metadata.label;
+            column.hidden_by_default = metadata.hidden_by_default;
+            column.chart_axis = metadata.chart_axis;
+        }
+        Ok(())
     }
 
     pub fn validate(&self) -> Result<(), ManifestValidationError> {
@@ -130,6 +167,16 @@ impl DatasetSemanticManifest {
                         name: name.clone(),
                     });
                 }
+                Some(SystemColumn::RecordId)
+                    if column.unit.is_some()
+                        || column.label.is_some()
+                        || column.hidden_by_default
+                        || column.chart_axis =>
+                {
+                    return Err(ManifestValidationError::InvalidSystemColumnMetadata {
+                        name: name.clone(),
+                    });
+                }
                 None if name.starts_with(SYSTEM_COLUMN_PREFIX) => {
                     return Err(ManifestValidationError::ReservedUserColumn { name: name.clone() });
                 }
@@ -146,6 +193,14 @@ pub struct ManifestColumn {
     pub dtype: DatasetDType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system: Option<SystemColumn>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub hidden_by_default: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub chart_axis: bool,
 }
 
 impl ManifestColumn {
@@ -154,6 +209,10 @@ impl ManifestColumn {
         Self {
             dtype,
             system: None,
+            unit: None,
+            label: None,
+            hidden_by_default: false,
+            chart_axis: false,
         }
     }
 
@@ -162,6 +221,10 @@ impl ManifestColumn {
         Self {
             dtype: DatasetDType::UInt64,
             system: Some(SystemColumn::RecordId),
+            unit: None,
+            label: None,
+            hidden_by_default: false,
+            chart_axis: false,
         }
     }
 
@@ -169,6 +232,32 @@ impl ManifestColumn {
     pub fn is_record_id(&self) -> bool {
         self.dtype == DatasetDType::UInt64 && self.system == Some(SystemColumn::RecordId)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnMetadata {
+    pub name: String,
+    pub unit: Option<String>,
+    pub label: Option<String>,
+    pub hidden_by_default: bool,
+    pub chart_axis: bool,
+}
+
+impl ColumnMetadata {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            unit: None,
+            label: None,
+            hidden_by_default: false,
+            chart_axis: false,
+        }
+    }
+}
+
+const fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -556,9 +645,10 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        Compatibility, DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault,
-        IndexRealization, ManifestColumn, ManifestValidationError, RECORD_ID_COLUMN, Realization,
-        SystemColumn, TraceAxisDType, TraceDType, TraceLayout, TraceValueDType,
+        ColumnMetadata, Compatibility, DatasetDType, DatasetSemanticManifest,
+        DuplicateResolutionDefault, IndexRealization, ManifestColumn, ManifestValidationError,
+        RECORD_ID_COLUMN, Realization, SystemColumn, TraceAxisDType, TraceDType, TraceLayout,
+        TraceValueDType,
     };
 
     fn signal_columns() -> BTreeMap<String, ManifestColumn> {
@@ -650,6 +740,10 @@ mod tests {
             ManifestColumn {
                 dtype: DatasetDType::Int64,
                 system: Some(SystemColumn::RecordId),
+                unit: None,
+                label: None,
+                hidden_by_default: false,
+                chart_axis: false,
             },
         );
 
@@ -787,6 +881,72 @@ mod tests {
         assert_eq!(
             manifest.columns.get(RECORD_ID_COLUMN),
             Some(&ManifestColumn::record_id())
+        );
+    }
+
+    #[test]
+    fn minimal_from_arrow_schema_applies_column_metadata() {
+        let schema = Schema::new(vec![Field::new("signal", DataType::Float64, false)]);
+        let metadata = [ColumnMetadata {
+            name: "signal".to_string(),
+            unit: Some("V".to_string()),
+            label: Some("Voltage".to_string()),
+            hidden_by_default: true,
+            chart_axis: true,
+        }];
+
+        let manifest =
+            DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata(&schema, metadata)
+                .expect("manifest");
+        let signal = &manifest.columns["signal"];
+
+        assert_eq!(signal.unit.as_deref(), Some("V"));
+        assert_eq!(signal.label.as_deref(), Some("Voltage"));
+        assert!(signal.hidden_by_default);
+        assert!(signal.chart_axis);
+
+        let value = serde_json::to_value(&manifest).expect("serialize manifest");
+        assert_eq!(
+            value["columns"]["signal"],
+            json!({
+                "dtype": { "kind": "float64" },
+                "unit": "V",
+                "label": "Voltage",
+                "hidden_by_default": true,
+                "chart_axis": true
+            })
+        );
+    }
+
+    #[test]
+    fn minimal_from_arrow_schema_rejects_unknown_metadata_column() {
+        let schema = Schema::new(vec![Field::new("signal", DataType::Float64, false)]);
+
+        assert_eq!(
+            DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata(
+                &schema,
+                [ColumnMetadata::new("missing")]
+            ),
+            Err(ManifestValidationError::UnknownColumnMetadata {
+                name: "missing".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_system_column_metadata() {
+        let mut manifest = DatasetSemanticManifest::minimal(signal_columns());
+        manifest
+            .columns
+            .get_mut(RECORD_ID_COLUMN)
+            .expect("record id")
+            .label = Some("Record".to_string());
+
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::InvalidSystemColumnMetadata {
+                name: RECORD_ID_COLUMN.to_string()
+            })
         );
     }
 

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use serde::{Deserialize, Serialize};
@@ -57,9 +57,9 @@ impl DatasetSemanticManifest {
         &mut self,
         metadata: impl IntoIterator<Item = ColumnMetadata>,
     ) -> Result<(), ManifestValidationError> {
-        let mut seen = BTreeMap::new();
+        let mut seen = BTreeSet::new();
         for metadata in metadata {
-            if seen.insert(metadata.name.clone(), ()).is_some() {
+            if !seen.insert(metadata.name.clone()) {
                 return Err(ManifestValidationError::DuplicateColumnMetadata {
                     name: metadata.name,
                 });
@@ -256,6 +256,10 @@ impl ColumnMetadata {
     }
 }
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires a predicate over a field reference"
+)]
 const fn is_false(value: &bool) -> bool {
     !*value
 }

--- a/crates/fricon/src/lib.rs
+++ b/crates/fricon/src/lib.rs
@@ -19,7 +19,7 @@ pub use self::{
     app::{AppHandle, AppManager, CatalogAppError, IngestAppError, ReadAppError},
     client::{Client, ClientError, Dataset, DatasetWriter, ExistingUiProbeResult},
     dataset::{
-        ColumnMeaning, DatasetArray, DatasetDataType, DatasetEvent, DatasetId,
+        ColumnMeaning, ColumnMetadata, DatasetArray, DatasetDataType, DatasetEvent, DatasetId,
         DatasetInterpretation, DatasetListQuery, DatasetMetadata, DatasetReader, DatasetRecord,
         DatasetRow, DatasetScalar, DatasetSchema, DatasetSortBy, DatasetStatus, DatasetUpdate,
         FixedStepTrace, InterpretationSource, PhysicalColumnOrdinal, ResolvedColumn,
@@ -35,4 +35,4 @@ const DEFAULT_DATASET_LIST_LIMIT: i64 = 200;
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Version of the IPC/gRPC protocol between clients and the workspace server.
-const IPC_PROTOCOL_VERSION: u32 = 1;
+const IPC_PROTOCOL_VERSION: u32 = 2;

--- a/crates/fricon/src/transport/grpc/create_stream.rs
+++ b/crates/fricon/src/transport/grpc/create_stream.rs
@@ -7,8 +7,11 @@ use tonic::{Code, Status, Streaming};
 use tracing::{error, instrument, warn};
 
 use crate::{
-    dataset::{CreateDatasetInput, CreateDatasetRequest},
-    proto::{CreateMetadata, CreateRequest, create_request::CreateMessage},
+    dataset::{CreateDatasetInput, CreateDatasetRequest, semantics::ColumnMetadata},
+    proto::{
+        ColumnMetadata as ProtoColumnMetadata, CreateMetadata, CreateRequest,
+        create_request::CreateMessage,
+    },
 };
 
 pub(crate) struct CreateStreamParts {
@@ -34,6 +37,7 @@ pub(crate) async fn parse_create_stream(
         name,
         description,
         tags,
+        columns,
     })) = first_message.create_message
     else {
         warn!("First create stream message must be metadata");
@@ -50,10 +54,24 @@ pub(crate) async fn parse_create_stream(
             name,
             description,
             tags,
+            column_metadata: columns
+                .into_iter()
+                .map(column_metadata_from_proto)
+                .collect(),
         },
         events_rx,
         events_task,
     })
+}
+
+fn column_metadata_from_proto(value: ProtoColumnMetadata) -> ColumnMetadata {
+    ColumnMetadata {
+        name: value.name,
+        unit: value.unit,
+        label: value.label,
+        hidden_by_default: value.hidden_by_default,
+        chart_axis: value.chart_axis,
+    }
 }
 
 async fn produce_create_events<S>(
@@ -227,7 +245,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::proto::{CreateAbort, CreateFinish};
+    use crate::proto::{ColumnMetadata as ProtoColumnMetadata, CreateAbort, CreateFinish};
 
     fn payload_message(payload: bytes::Bytes) -> CreateRequest {
         CreateRequest {
@@ -253,6 +271,24 @@ mod tests {
                 name: "name".to_string(),
                 description: "desc".to_string(),
                 tags: vec![],
+                columns: vec![],
+            })),
+        }
+    }
+
+    fn metadata_message_with_columns() -> CreateRequest {
+        CreateRequest {
+            create_message: Some(CreateMessage::Metadata(CreateMetadata {
+                name: "name".to_string(),
+                description: "desc".to_string(),
+                tags: vec![],
+                columns: vec![ProtoColumnMetadata {
+                    name: "signal".to_string(),
+                    unit: Some("V".to_string()),
+                    label: Some("Voltage".to_string()),
+                    hidden_by_default: true,
+                    chart_axis: true,
+                }],
             })),
         }
     }
@@ -301,6 +337,24 @@ mod tests {
                 .any(|event| matches!(event, CreateDatasetInput::Batch(_)))
         );
         assert!(matches!(events.last(), Some(CreateDatasetInput::Finish)));
+    }
+
+    #[test]
+    fn column_metadata_conversion_preserves_fields() {
+        let CreateMessage::Metadata(metadata) = metadata_message_with_columns()
+            .create_message
+            .expect("metadata message")
+        else {
+            panic!("expected metadata");
+        };
+        let column =
+            column_metadata_from_proto(metadata.columns.into_iter().next().expect("column"));
+
+        assert_eq!(column.name, "signal");
+        assert_eq!(column.unit.as_deref(), Some("V"));
+        assert_eq!(column.label.as_deref(), Some("Voltage"));
+        assert!(column.hidden_by_default);
+        assert!(column.chart_axis);
     }
 
     #[tokio::test]

--- a/crates/fricon/tests/integration_test.rs
+++ b/crates/fricon/tests/integration_test.rs
@@ -223,6 +223,7 @@ async fn test_dataset_create_metadata_payload_finish_completes() -> anyhow::Resu
             "Test dataset for integration test".to_string(),
             vec!["test".to_string(), "integration".to_string()],
             test_schema.clone(),
+            Vec::new(),
         )
         .await?;
 
@@ -335,6 +336,7 @@ async fn test_dataset_create_abort_returns_aborted_metadata() -> anyhow::Result<
             "This dataset is aborted explicitly".to_string(),
             vec!["test".to_string(), "abort".to_string()],
             test_schema,
+            Vec::new(),
         )
         .await?;
 
@@ -396,6 +398,7 @@ async fn test_dataset_create_without_finish_is_aborted() -> anyhow::Result<()> {
             "This dataset will be aborted".to_string(),
             vec!["test".to_string(), "abort".to_string()],
             test_schema.clone(),
+            Vec::new(),
         )
         .await?;
 
@@ -555,6 +558,7 @@ async fn test_deleted_dataset_returns_typed_deleted_error() -> anyhow::Result<()
             "Dataset that will be deleted".to_string(),
             vec!["test".to_string()],
             test_schema,
+            Vec::new(),
         )
         .await?;
     writer.write(create_test_rows().remove(0)).await?;


### PR DESCRIPTION
## Summary
- Add `fricon.Column` and `DatasetManager.create(..., columns=...)` so Python callers can declare column order and lightweight metadata up front.
- Persist column metadata into `dataset_manifest.json` and carry it through the IPC path with a protocol version bump.
- Update manifest interpretation so resolved columns expose label, unit, hidden-by-default, and chart-axis metadata.
- Keep the existing bare `write(col=...)` flow unchanged.

## Testing
- Added Rust manifest, ingest/transport, and interpretation coverage for metadata round-tripping and schema resolution.
- Added Python integration tests for the new `Column` export, declared column metadata, schema ordering, and validation failures.
- Local validation passed: formatting, linting, Rust tests, Python tests, and stub checks.

closes #481
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
