### PR TITLE
feat: expose column metadata in desktop detail

### DIFF
--- a/.changeset/desktop-column-metadata-detail.md
+++ b/.changeset/desktop-column-metadata-detail.md
@@ -1,0 +1,8 @@
+---
+default: minor
+---
+
+# Show dataset column metadata in desktop details
+
+The desktop dataset detail view now shows column labels, units,
+hidden-by-default state, and chart-axis hints from dataset semantics.

--- a/crates/fricon-ui/frontend/src/features/charts/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.ts
@@ -1,6 +1,5 @@
 import type {
   ColumnUniqueValue,
-  ColumnInfo,
   DatasetChartDataOptions as WireChartDataOptions,
   DatasetWriteStatus,
   FilterTableOptions,
@@ -16,13 +15,19 @@ import type {
 } from "@/shared/lib/chartTypes";
 
 export type {
-  ColumnInfo,
   ColumnUniqueValue,
   DatasetStatus,
   DatasetWriteStatus,
   FilterTableOptions,
   FilterTableRow,
 };
+
+export interface ColumnInfo {
+  name: string;
+  isComplex: boolean;
+  isTrace: boolean;
+  isIndex: boolean;
+}
 
 export interface DatasetDetail {
   status: DatasetStatus;

--- a/crates/fricon-ui/frontend/src/features/datasets/api/client.test.ts
+++ b/crates/fricon-ui/frontend/src/features/datasets/api/client.test.ts
@@ -89,7 +89,18 @@ describe("dataset client", () => {
         trashedAt: "2026-01-03T04:05:06Z",
         deletedAt: null,
         payloadAvailable: true,
-        columns: [],
+        columns: [
+          {
+            name: "signal",
+            label: "Signal",
+            unit: "V",
+            isComplex: false,
+            isTrace: false,
+            isIndex: false,
+            hiddenByDefault: true,
+            isChartAxisCandidate: true,
+          },
+        ],
       },
     });
 
@@ -102,6 +113,18 @@ describe("dataset client", () => {
     expect(result.trashedAt?.toISOString()).toBe("2026-01-03T04:05:06.000Z");
     expect(result.deletedAt).toBeNull();
     expect(result.payloadAvailable).toBe(true);
+    expect(result.columns).toEqual([
+      {
+        name: "signal",
+        label: "Signal",
+        unit: "V",
+        isComplex: false,
+        isTrace: false,
+        isIndex: false,
+        hiddenByDefault: true,
+        isChartAxisCandidate: true,
+      },
+    ]);
   });
 
   it("propagates dataset command error envelopes", async () => {

--- a/crates/fricon-ui/frontend/src/features/datasets/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/datasets/api/types.ts
@@ -1,5 +1,5 @@
 import type {
-  ColumnInfo,
+  ColumnInfo as WireColumnInfo,
   DatasetDeleteResult,
   DatasetOperationError,
   DatasetTagBatchResult,
@@ -28,17 +28,30 @@ export type DatasetInfo = Omit<
 
 export type DatasetDetail = Omit<
   WireDatasetDetail,
-  "createdAt" | "trashedAt" | "deletedAt"
+  "createdAt" | "trashedAt" | "deletedAt" | "columns"
 > & {
   createdAt: Date;
   trashedAt: Date | null;
   deletedAt: Date | null;
+  columns: DatasetColumnInfo[];
 };
 
 export const DATASET_PAGE_SIZE = 200;
 
+export interface DatasetColumnInfo {
+  name: string;
+  label: string | null;
+  unit: string | null;
+  isComplex: boolean;
+  isTrace: boolean;
+  isIndex: boolean;
+  hiddenByDefault: boolean;
+  isChartAxisCandidate: boolean;
+}
+
+export type ColumnInfo = DatasetColumnInfo;
+
 export type {
-  ColumnInfo,
   DatasetDeleteResult,
   DatasetOperationError,
   DatasetInfoUpdate,
@@ -74,5 +87,22 @@ export function normalizeDataset(value: WireDatasetInfo): DatasetInfo {
 export function normalizeDatasetDetail(
   value: WireDatasetDetail,
 ): DatasetDetail {
-  return normalizeDatasetDates(value);
+  const normalized = normalizeDatasetDates(value);
+  return {
+    ...normalized,
+    columns: value.columns.map(normalizeDatasetColumnInfo),
+  };
+}
+
+function normalizeDatasetColumnInfo(value: WireColumnInfo): DatasetColumnInfo {
+  return {
+    name: value.name,
+    label: value.label,
+    unit: value.unit,
+    isComplex: value.isComplex,
+    isTrace: value.isTrace,
+    isIndex: value.isIndex,
+    hiddenByDefault: value.hiddenByDefault,
+    isChartAxisCandidate: value.isChartAxisCandidate,
+  };
 }

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.browser.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -280,5 +281,52 @@ describe("DatasetPropertiesPanel", () => {
 
     expect(await screen.findByLabelText("Name")).toHaveValue("a::b");
     expect(screen.getByLabelText("Description")).toHaveValue("c");
+  });
+
+  it("shows resolved column metadata in the columns table", async () => {
+    const { wrapper } = createWrapper();
+
+    render(
+      <DatasetPropertiesPanel
+        datasetId={1}
+        detail={makeDetail({
+          columns: [
+            {
+              name: "signal",
+              label: "Signal",
+              unit: "V",
+              isIndex: false,
+              isTrace: false,
+              isComplex: false,
+              hiddenByDefault: true,
+              isChartAxisCandidate: true,
+            },
+            {
+              name: "trace",
+              label: null,
+              unit: null,
+              isIndex: false,
+              isTrace: true,
+              isComplex: false,
+              hiddenByDefault: false,
+              isChartAxisCandidate: false,
+            },
+          ],
+        })}
+        isLoading={false}
+        loadErrorMessage={null}
+      />,
+      { wrapper },
+    );
+
+    const table = within(await screen.findByRole("table"));
+    expect(table.getByRole("columnheader", { name: "Label" })).toBeVisible();
+    expect(table.getByRole("columnheader", { name: "Unit" })).toBeVisible();
+    expect(table.getByRole("columnheader", { name: "Hints" })).toBeVisible();
+    expect(table.getByText("Signal")).toBeVisible();
+    expect(table.getByText("V")).toBeVisible();
+    expect(table.getByText("Hidden")).toBeVisible();
+    expect(table.getByText("Axis")).toBeVisible();
+    expect(table.getByText("Trace")).toBeVisible();
   });
 });

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.tsx
@@ -317,16 +317,33 @@ function DatasetDetailEditor({ datasetId, detail }: DatasetDetailEditorProps) {
                 <TableHeader className="bg-muted/40 text-muted-foreground">
                   <TableRow>
                     <TableHead>Name</TableHead>
+                    <TableHead>Label</TableHead>
+                    <TableHead>Unit</TableHead>
                     <TableHead>Index</TableHead>
                     <TableHead>Type</TableHead>
+                    <TableHead>Hints</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {detail.columns.map((column) => (
                     <TableRow key={column.name}>
-                      <TableCell>{column.name}</TableCell>
-                      <TableCell>{column.isIndex ? "✓" : ""}</TableCell>
-                      <TableCell>
+                      <TableCell className="max-w-40 truncate font-mono text-xs">
+                        {column.name}
+                      </TableCell>
+                      <TableCell className="max-w-40 truncate">
+                        {column.label ?? (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {column.unit ?? (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {column.isIndex ? "✓" : ""}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
                         {column.isTrace ? (
                           <Badge variant="secondary">Trace</Badge>
                         ) : column.isComplex ? (
@@ -334,6 +351,20 @@ function DatasetDetailEditor({ datasetId, detail }: DatasetDetailEditorProps) {
                         ) : (
                           <Badge variant="secondary">Scalar</Badge>
                         )}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {column.hiddenByDefault ? (
+                            <Badge variant="outline">Hidden</Badge>
+                          ) : null}
+                          {column.isChartAxisCandidate ? (
+                            <Badge variant="secondary">Axis</Badge>
+                          ) : null}
+                          {!column.hiddenByDefault &&
+                          !column.isChartAxisCandidate ? (
+                            <span className="text-muted-foreground">-</span>
+                          ) : null}
+                        </div>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
@@ -66,9 +66,13 @@ export type ChartCommonOptions = {
 
 export type ColumnInfo = {
 	name: string,
+	label: string | null,
+	unit: string | null,
 	isComplex: boolean,
 	isTrace: boolean,
 	isIndex: boolean,
+	hiddenByDefault: boolean,
+	isChartAxisCandidate: boolean,
 };
 
 export type ColumnUniqueValue = {

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -1,5 +1,5 @@
 use fricon::{
-    DatasetListQuery, ReadAppError, ResolvedColumn,
+    DatasetListQuery, InterpretationSource, ReadAppError, ResolvedColumn,
     dataset::{
         model::DatasetId,
         semantics::{DatasetDType, TraceValueDType},
@@ -54,12 +54,12 @@ pub(crate) async fn get_dataset_detail(
     let payload_available = record.metadata.deleted_at.is_none();
     let columns = if payload_available {
         let reader = session.dataset(id).await?;
-        reader
-            .interpret()
-            .map_err(ReadAppError::from)?
+        let interpretation = reader.interpret().map_err(ReadAppError::from)?;
+        let expose_manifest_hints = interpretation.source == InterpretationSource::Manifest;
+        interpretation
             .columns
             .iter()
-            .filter_map(column_info_from_resolved_column)
+            .filter_map(|column| column_info_from_resolved_column(column, expose_manifest_hints))
             .collect()
     } else {
         Vec::new()
@@ -80,13 +80,20 @@ pub(crate) async fn get_dataset_detail(
     })
 }
 
-fn column_info_from_resolved_column(column: &ResolvedColumn) -> Option<ColumnInfo> {
+fn column_info_from_resolved_column(
+    column: &ResolvedColumn,
+    expose_manifest_hints: bool,
+) -> Option<ColumnInfo> {
     column.visible_ordinal?;
     Some(ColumnInfo {
         name: column.name.clone(),
+        label: column.label.clone(),
+        unit: column.unit.clone(),
         is_complex: dtype_is_complex(&column.dtype),
         is_trace: matches!(column.dtype, DatasetDType::Trace { .. }),
         is_index: column.is_index,
+        hidden_by_default: column.hidden_by_default,
+        is_chart_axis_candidate: expose_manifest_hints && column.is_chart_axis_candidate,
     })
 }
 
@@ -119,7 +126,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use fricon::{
         AppManager, Client, DatasetRow, DatasetScalar, ScalarArray, WorkspaceRoot,
-        workspace::WorkspacePaths,
+        dataset::semantics::ColumnMetadata, workspace::WorkspacePaths,
     };
     use indexmap::IndexMap;
     use num::complex::Complex64;
@@ -144,17 +151,29 @@ mod tests {
 
         assert_eq!(detail.columns.len(), 3);
         assert_eq!(detail.columns[0].name, "signal");
+        assert_eq!(detail.columns[0].label.as_deref(), Some("Signal"));
+        assert_eq!(detail.columns[0].unit.as_deref(), Some("V"));
         assert!(!detail.columns[0].is_index);
         assert!(!detail.columns[0].is_trace);
         assert!(!detail.columns[0].is_complex);
+        assert!(detail.columns[0].hidden_by_default);
+        assert!(detail.columns[0].is_chart_axis_candidate);
         assert_eq!(detail.columns[1].name, "trace");
+        assert_eq!(detail.columns[1].label, None);
+        assert_eq!(detail.columns[1].unit, None);
         assert!(!detail.columns[1].is_index);
         assert!(detail.columns[1].is_trace);
         assert!(!detail.columns[1].is_complex);
+        assert!(!detail.columns[1].hidden_by_default);
+        assert!(!detail.columns[1].is_chart_axis_candidate);
         assert_eq!(detail.columns[2].name, "complex");
+        assert_eq!(detail.columns[2].label, None);
+        assert_eq!(detail.columns[2].unit, None);
         assert!(!detail.columns[2].is_index);
         assert!(!detail.columns[2].is_trace);
         assert!(detail.columns[2].is_complex);
+        assert!(!detail.columns[2].hidden_by_default);
+        assert!(!detail.columns[2].is_chart_axis_candidate);
         assert!(
             !detail
                 .columns
@@ -174,17 +193,29 @@ mod tests {
 
         assert_eq!(detail.columns.len(), 3);
         assert_eq!(detail.columns[0].name, "run");
+        assert_eq!(detail.columns[0].label, None);
+        assert_eq!(detail.columns[0].unit, None);
         assert!(detail.columns[0].is_index);
         assert!(!detail.columns[0].is_trace);
         assert!(!detail.columns[0].is_complex);
+        assert!(!detail.columns[0].hidden_by_default);
+        assert!(!detail.columns[0].is_chart_axis_candidate);
         assert_eq!(detail.columns[1].name, "step");
+        assert_eq!(detail.columns[1].label, None);
+        assert_eq!(detail.columns[1].unit, None);
         assert!(detail.columns[1].is_index);
         assert!(!detail.columns[1].is_trace);
         assert!(!detail.columns[1].is_complex);
+        assert!(!detail.columns[1].hidden_by_default);
+        assert!(!detail.columns[1].is_chart_axis_candidate);
         assert_eq!(detail.columns[2].name, "value");
+        assert_eq!(detail.columns[2].label, None);
+        assert_eq!(detail.columns[2].unit, None);
         assert!(!detail.columns[2].is_index);
         assert!(!detail.columns[2].is_trace);
         assert!(!detail.columns[2].is_complex);
+        assert!(!detail.columns[2].hidden_by_default);
+        assert!(!detail.columns[2].is_chart_axis_candidate);
 
         Ok(())
     }
@@ -206,7 +237,13 @@ mod tests {
                 String::new(),
                 vec!["test".to_string()],
                 schema,
-                Vec::new(),
+                vec![ColumnMetadata {
+                    name: "signal".to_string(),
+                    label: Some("Signal".to_string()),
+                    unit: Some("V".to_string()),
+                    hidden_by_default: true,
+                    chart_axis: true,
+                }],
             )
             .await?;
         for row in rows {

--- a/crates/fricon-ui/src/features/datasets/types.rs
+++ b/crates/fricon-ui/src/features/datasets/types.rs
@@ -86,9 +86,13 @@ impl From<DatasetRecord> for DatasetInfo {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ColumnInfo {
     pub(crate) name: String,
+    pub(crate) label: Option<String>,
+    pub(crate) unit: Option<String>,
     pub(crate) is_complex: bool,
     pub(crate) is_trace: bool,
     pub(crate) is_index: bool,
+    pub(crate) hidden_by_default: bool,
+    pub(crate) is_chart_axis_candidate: bool,
 }
 
 #[derive(Debug, Clone, Serialize, specta::Type)]

--- a/crates/fricon-ui/src/features/datasets/types.rs
+++ b/crates/fricon-ui/src/features/datasets/types.rs
@@ -83,6 +83,10 @@ impl From<DatasetRecord> for DatasetInfo {
 }
 
 #[derive(Debug, Clone, Serialize, specta::Type)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "dataset detail columns are serialized UI-facing flag projections"
+)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ColumnInfo {
     pub(crate) name: String,


### PR DESCRIPTION
## Summary
- Expose resolved column label, unit, hidden-by-default, and chart-axis metadata in the desktop dataset detail contract.
- Normalize the new fields in the frontend dataset API and render them in the dataset properties table.
- Keep chart consumers on the existing narrow column shape while adding dedicated dataset-detail metadata handling.

## Testing
- `cargo +nightly fmt --all --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `pnpm run check`
- `pnpm run test`
- `pnpm --filter fricon-ui run gen:bindings`

closes #482
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
