### PR TITLE
feat: add explicit scan semantics

### DIFF
--- a/crates/fricon-py/python/fricon/__init__.py
+++ b/crates/fricon-py/python/fricon/__init__.py
@@ -10,6 +10,7 @@ from ._core import (
     DatasetManager,
     DatasetWriter,
     FriconDatasetError,
+    IndexAxis,
     Trace,
     Workspace,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "DatasetManager",
     "DatasetWriter",
     "FriconDatasetError",
+    "IndexAxis",
     "Trace",
     "Workspace",
     "__version__",

--- a/crates/fricon-py/python/fricon/_core.pyi
+++ b/crates/fricon-py/python/fricon/_core.pyi
@@ -16,6 +16,7 @@ __all__ = [
     "DatasetManager",
     "DatasetWriter",
     "FriconDatasetError",
+    "IndexAxis",
     "ServerHandle",
     "Trace",
     "Workspace",
@@ -70,6 +71,15 @@ class Column:
     def chart_axis(self) -> bool: ...
 
 _ColumnSpec: TypeAlias = _DeclaredColumnDType | Column
+_ScanAxisValue: TypeAlias = int | float | bool | str
+
+@final
+class IndexAxis:
+    def __new__(cls, *, label: str | None = ...) -> Self: ...
+    @property
+    def label(self) -> str | None: ...
+
+_ScanAxisSpec: TypeAlias = Sequence[_ScanAxisValue] | IndexAxis | None
 
 @final
 class DatasetManager:
@@ -80,6 +90,7 @@ class DatasetManager:
         description: str | None = ...,
         tags: Iterable[str] | None = ...,
         columns: Mapping[str, _ColumnSpec] | None = ...,
+        scan: Mapping[str, _ScanAxisSpec] | None = ...,
     ) -> DatasetWriter: ...
     def open(
         self,

--- a/crates/fricon-py/src/lib.rs
+++ b/crates/fricon-py/src/lib.rs
@@ -53,7 +53,7 @@ use pyo3::{
     exceptions::{PyException, PyRuntimeError, PyTypeError, PyValueError},
     prelude::*,
     sync::PyOnceLock,
-    types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString},
+    types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString},
 };
 use pyo3_async_runtimes::tokio::get_runtime;
 
@@ -337,11 +337,12 @@ fn parse_scan_axis(py: Python<'_>, name: String, spec: Py<PyAny>) -> PyResult<Sc
         )));
     }
 
-    let iter = bound.try_iter().map_err(|_| {
+    let sequence = bound.cast::<PySequence>().map_err(|_| {
         PyValueError::new_err(format!(
             "Scan axis '{name}' must be a sequence of scalar values, IndexAxis, or None."
         ))
     })?;
+    let iter = sequence.try_iter()?;
     let values = iter
         .map(|item| parse_scan_axis_value(&item?))
         .collect::<PyResult<Vec<_>>>()?;

--- a/crates/fricon-py/src/lib.rs
+++ b/crates/fricon-py/src/lib.rs
@@ -27,8 +27,8 @@ mod convert;
 mod _core {
     #[pymodule_export]
     use super::{
-        Column, Dataset, DatasetManager, DatasetWriter, FriconDatasetError, ServerHandle, Trace,
-        Workspace, serve_workspace,
+        Column, Dataset, DatasetManager, DatasetWriter, FriconDatasetError, IndexAxis,
+        ServerHandle, Trace, Workspace, serve_workspace,
     };
     #[cfg(feature = "python-cli-entrypoints")]
     #[pymodule_export]
@@ -40,7 +40,7 @@ use std::{mem, path::PathBuf, time::Duration};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use fricon::{
-    Client, ClientError, ColumnMetadata,
+    Client, ClientError, ColumnMetadata, ScanAxis, ScanAxisMode, ScanAxisValue, ScanPlan,
     app::AppManager,
     dataset::{
         model::{DatasetMetadata, DatasetRecord, DatasetStatus},
@@ -53,7 +53,7 @@ use pyo3::{
     exceptions::{PyException, PyRuntimeError, PyTypeError, PyValueError},
     prelude::*,
     sync::PyOnceLock,
-    types::{PyDict, PyList},
+    types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString},
 };
 use pyo3_async_runtimes::tokio::get_runtime;
 
@@ -163,6 +163,27 @@ impl ColumnDeclarations {
             .iter()
             .map(|declaration| declaration.metadata.clone())
             .collect()
+    }
+}
+
+/// Unknown-length integer scan axis for dataset creation.
+#[pyclass(module = "fricon._core", skip_from_py_object)]
+#[derive(Clone)]
+pub struct IndexAxis {
+    label: Option<String>,
+}
+
+#[pymethods]
+impl IndexAxis {
+    #[new]
+    #[pyo3(signature=(*, label=None))]
+    pub fn new(label: Option<String>) -> Self {
+        Self { label }
+    }
+
+    #[getter]
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
     }
 }
 
@@ -280,6 +301,75 @@ fn parse_column_declarations(
     Ok(Some(ColumnDeclarations(declarations)))
 }
 
+fn parse_scan_plan(
+    py: Python<'_>,
+    scan: Option<IndexMap<String, Py<PyAny>>>,
+) -> PyResult<Option<ScanPlan>> {
+    let Some(scan) = scan else {
+        return Ok(None);
+    };
+    if scan.is_empty() {
+        return Err(PyValueError::new_err("scan must not be empty."));
+    }
+
+    let axes = scan
+        .into_iter()
+        .map(|(name, spec)| parse_scan_axis(py, name, spec))
+        .collect::<PyResult<Vec<_>>>()?;
+    let scan_plan = ScanPlan::new(axes);
+    scan_plan
+        .validate()
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    Ok(Some(scan_plan))
+}
+
+fn parse_scan_axis(py: Python<'_>, name: String, spec: Py<PyAny>) -> PyResult<ScanAxis> {
+    let bound = spec.bind(py);
+    if bound.is_none() {
+        return Ok(ScanAxis::implicit_index(name, None));
+    }
+    if let Ok(axis) = bound.extract::<PyRef<'_, IndexAxis>>() {
+        return Ok(ScanAxis::implicit_index(name, axis.label.clone()));
+    }
+    if bound.is_instance_of::<PyString>() || bound.is_instance_of::<PyBytes>() {
+        return Err(PyValueError::new_err(format!(
+            "Scan axis '{name}' must be a sequence of scalar values, IndexAxis, or None."
+        )));
+    }
+
+    let iter = bound.try_iter().map_err(|_| {
+        PyValueError::new_err(format!(
+            "Scan axis '{name}' must be a sequence of scalar values, IndexAxis, or None."
+        ))
+    })?;
+    let values = iter
+        .map(|item| parse_scan_axis_value(&item?))
+        .collect::<PyResult<Vec<_>>>()?;
+    Ok(ScanAxis {
+        name,
+        label: None,
+        mode: ScanAxisMode::Static { values },
+    })
+}
+
+fn parse_scan_axis_value(value: &Bound<'_, PyAny>) -> PyResult<ScanAxisValue> {
+    if value.is_instance_of::<PyBool>() {
+        return Ok(ScanAxisValue::Bool(value.extract()?));
+    }
+    if value.is_instance_of::<PyInt>() {
+        return Ok(ScanAxisValue::Int(value.extract()?));
+    }
+    if value.is_instance_of::<PyFloat>() {
+        return Ok(ScanAxisValue::Float(value.extract()?));
+    }
+    if value.is_instance_of::<PyString>() {
+        return Ok(ScanAxisValue::String(value.extract()?));
+    }
+    Err(PyValueError::new_err(
+        "Scan axis values must be int, float, bool, or str.",
+    ))
+}
+
 fn build_declared_row(
     py: Python<'_>,
     mut values: IndexMap<String, Py<PyAny>>,
@@ -382,7 +472,7 @@ impl DatasetManager {
     ///
     /// Returns:
     ///     A writer of the newly created dataset.
-    #[pyo3(signature = (name, *, description=None, tags=None, columns=None))]
+    #[pyo3(signature = (name, *, description=None, tags=None, columns=None, scan=None))]
     pub fn create(
         &self,
         py: Python<'_>,
@@ -390,10 +480,12 @@ impl DatasetManager {
         description: Option<String>,
         tags: Option<Vec<String>>,
         columns: Option<IndexMap<String, Py<PyAny>>>,
+        scan: Option<IndexMap<String, Py<PyAny>>>,
     ) -> PyResult<DatasetWriter> {
         let description = description.unwrap_or_default();
         let tags = tags.unwrap_or_default();
         let columns = parse_column_declarations(py, columns)?;
+        let scan_plan = parse_scan_plan(py, scan)?;
 
         Ok(DatasetWriter::new(
             self.workspace.client.clone(),
@@ -401,6 +493,7 @@ impl DatasetManager {
             description,
             tags,
             columns,
+            scan_plan,
         ))
     }
 
@@ -751,6 +844,7 @@ enum WriterState {
         description: String,
         tags: Vec<String>,
         columns: Option<ColumnDeclarations>,
+        scan_plan: Option<ScanPlan>,
     },
     Writing {
         writer: fricon::DatasetWriter,
@@ -776,6 +870,7 @@ impl DatasetWriter {
         description: String,
         tags: Vec<String>,
         columns: Option<ColumnDeclarations>,
+        scan_plan: Option<ScanPlan>,
     ) -> Self {
         Self {
             state: WriterState::NotStarted {
@@ -784,6 +879,7 @@ impl DatasetWriter {
                 description,
                 tags,
                 columns,
+                scan_plan,
             },
             dataset: None,
         }
@@ -813,6 +909,7 @@ impl DatasetWriter {
                 description,
                 tags,
                 columns,
+                scan_plan,
             } => {
                 self.state = WriterState::NotStarted {
                     client,
@@ -820,6 +917,7 @@ impl DatasetWriter {
                     description,
                     tags,
                     columns,
+                    scan_plan,
                 };
                 Err(generic_py_err("No data to finalize."))
             }
@@ -872,6 +970,7 @@ impl DatasetWriter {
                 description,
                 tags,
                 columns,
+                scan_plan,
             } => {
                 let row = if let Some(columns) = columns.as_ref() {
                     build_declared_row(py, values, columns)?
@@ -890,6 +989,7 @@ impl DatasetWriter {
                             tags,
                             schema,
                             column_metadata,
+                            scan_plan,
                         ))?;
                         get_runtime().block_on(writer.write(row))?;
                         Ok(writer)

--- a/crates/fricon-py/tests/integration/test_dataset_operations.py
+++ b/crates/fricon-py/tests/integration/test_dataset_operations.py
@@ -130,6 +130,85 @@ class TestDatasetOperations:
             server_handle.shutdown()
             assert not server_handle.is_running
 
+    def test_dataset_scan_metadata_round_trips_to_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_path = Path(tmpdir) / "test_workspace"
+            workspace, server_handle = fricon._core.serve_workspace(workspace_path)
+            dm = workspace.dataset_manager
+
+            with dm.create(
+                "scan_metadata",
+                scan={
+                    "gate": [-0.2, -0.1],
+                    "bias": [0, 1],
+                },
+            ) as writer:
+                writer.write(signal=1.0)
+                dataset = writer.finish()
+
+            manifest = cast(
+                "dict[str, object]",
+                json.loads((Path(dataset.path) / "dataset_manifest.json").read_text()),
+            )
+            scan_plan = cast("dict[str, object]", manifest["scan_plan"])
+            axes = cast("list[dict[str, object]]", scan_plan["axes"])
+            assert axes[0]["name"] == "gate"
+            assert axes[1]["name"] == "bias"
+            assert cast("dict[str, object]", manifest["realization"])[
+                "index_realization"
+            ] == {"kind": "implicit"}
+
+            server_handle.shutdown()
+            assert not server_handle.is_running
+
+    def test_dataset_scan_index_axis_round_trips_to_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_path = Path(tmpdir) / "test_workspace"
+            workspace, server_handle = fricon._core.serve_workspace(workspace_path)
+            dm = workspace.dataset_manager
+
+            with dm.create(
+                "index_scan",
+                scan={"step": fricon.IndexAxis(label="Step")},
+            ) as writer:
+                writer.write(loss=1.0)
+                dataset = writer.finish()
+
+            manifest = cast(
+                "dict[str, object]",
+                json.loads((Path(dataset.path) / "dataset_manifest.json").read_text()),
+            )
+            scan_plan = cast("dict[str, object]", manifest["scan_plan"])
+            axes = cast("list[dict[str, object]]", scan_plan["axes"])
+            assert axes == [
+                {
+                    "name": "step",
+                    "label": "Step",
+                    "mode": {"kind": "implicit_index"},
+                }
+            ]
+
+            server_handle.shutdown()
+            assert not server_handle.is_running
+
+    def test_dataset_scan_validation_rejects_invalid_specs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_path = Path(tmpdir) / "test_workspace"
+            workspace, server_handle = fricon._core.serve_workspace(workspace_path)
+            dm = workspace.dataset_manager
+
+            with pytest.raises(ValueError, match="scan must not be empty"):
+                dm.create("empty_scan", scan={})
+            with pytest.raises(ValueError, match="static scan axis gate"):
+                dm.create("empty_axis", scan={"gate": []})
+            with pytest.raises(ValueError, match="mixed static and unknown"):
+                dm.create("mixed_axis", scan={"gate": [0.0], "step": None})
+            with pytest.raises(ValueError, match="reserved system prefix"):
+                dm.create("reserved_axis", scan={"__ds_step": [0]})
+
+            server_handle.shutdown()
+            assert not server_handle.is_running
+
     def test_dataset_declared_columns_require_exact_first_row(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_path = Path(tmpdir) / "test_workspace"

--- a/crates/fricon-py/tests/integration/test_dataset_operations.py
+++ b/crates/fricon-py/tests/integration/test_dataset_operations.py
@@ -205,6 +205,12 @@ class TestDatasetOperations:
                 _ = dm.create("mixed_axis", scan={"gate": [0.0], "step": None})
             with pytest.raises(ValueError, match="reserved system prefix"):
                 _ = dm.create("reserved_axis", scan={"__ds_step": [0]})
+            mapping_axis = cast("list[int]", cast("object", {"k": 1}))
+            with pytest.raises(ValueError, match="must be a sequence"):
+                _ = dm.create("mapping_axis", scan={"axis": mapping_axis})
+            set_axis = cast("list[int]", cast("object", {1, 2}))
+            with pytest.raises(ValueError, match="must be a sequence"):
+                _ = dm.create("set_axis", scan={"axis": set_axis})
 
             server_handle.shutdown()
             assert not server_handle.is_running

--- a/crates/fricon-py/tests/integration/test_dataset_operations.py
+++ b/crates/fricon-py/tests/integration/test_dataset_operations.py
@@ -198,13 +198,13 @@ class TestDatasetOperations:
             dm = workspace.dataset_manager
 
             with pytest.raises(ValueError, match="scan must not be empty"):
-                dm.create("empty_scan", scan={})
+                _ = dm.create("empty_scan", scan={})
             with pytest.raises(ValueError, match="static scan axis gate"):
-                dm.create("empty_axis", scan={"gate": []})
+                _ = dm.create("empty_axis", scan={"gate": []})
             with pytest.raises(ValueError, match="mixed static and unknown"):
-                dm.create("mixed_axis", scan={"gate": [0.0], "step": None})
+                _ = dm.create("mixed_axis", scan={"gate": [0.0], "step": None})
             with pytest.raises(ValueError, match="reserved system prefix"):
-                dm.create("reserved_axis", scan={"__ds_step": [0]})
+                _ = dm.create("reserved_axis", scan={"__ds_step": [0]})
 
             server_handle.shutdown()
             assert not server_handle.is_running

--- a/crates/fricon-ui/src/bin/create-smoke-workspace.rs
+++ b/crates/fricon-ui/src/bin/create-smoke-workspace.rs
@@ -81,6 +81,7 @@ async fn seed_workspace(workspace: PathBuf) -> Result<()> {
             vec!["smoke".to_string(), "desktop".to_string()],
             schema,
             Vec::new(),
+            None,
         )
         .await
         .context("failed to create smoke dataset writer")?;

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -699,6 +699,7 @@ mod tests {
                 vec![],
                 schema,
                 Vec::new(),
+                None,
             )
             .await?;
         for row in rows {

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -244,6 +244,7 @@ mod tests {
                     hidden_by_default: true,
                     chart_axis: true,
                 }],
+                None,
             )
             .await?;
         for row in rows {

--- a/crates/fricon/proto/fricon/v1alpha/dataset.proto
+++ b/crates/fricon/proto/fricon/v1alpha/dataset.proto
@@ -50,6 +50,7 @@ message CreateMetadata {
   string description = 2;
   repeated string tags = 3;
   repeated ColumnMetadata columns = 4;
+  repeated ScanAxisMetadata scan_axes = 5;
 }
 
 message ColumnMetadata {
@@ -58,6 +59,30 @@ message ColumnMetadata {
   optional string label = 3;
   bool hidden_by_default = 4;
   bool chart_axis = 5;
+}
+
+message ScanAxisMetadata {
+  string name = 1;
+  optional string label = 2;
+  oneof axis {
+    StaticScanAxis static_axis = 3;
+    IndexScanAxis index_axis = 4;
+  }
+}
+
+message StaticScanAxis {
+  repeated ScanAxisValue values = 1;
+}
+
+message IndexScanAxis {}
+
+message ScanAxisValue {
+  oneof value {
+    int64 int_value = 1;
+    double float_value = 2;
+    bool bool_value = 3;
+    string string_value = 4;
+  }
 }
 
 message CreateAbort {}

--- a/crates/fricon/src/app.rs
+++ b/crates/fricon/src/app.rs
@@ -497,6 +497,7 @@ impl AppHandle {
             description,
             tags,
             column_metadata: Vec::new(),
+            scan_plan: None,
         };
         self.run_ingest_task(
             "failed to join dataset create task",

--- a/crates/fricon/src/client.rs
+++ b/crates/fricon/src/client.rs
@@ -323,6 +323,10 @@ pub struct DatasetWriter {
 }
 
 impl DatasetWriter {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "internal constructor mirrors dataset creation metadata plus runtime state"
+    )]
     fn new(
         client: Client,
         name: String,

--- a/crates/fricon/src/client.rs
+++ b/crates/fricon/src/client.rs
@@ -28,14 +28,16 @@ use crate::{
     dataset::{
         model::{DatasetRecord, DatasetStatus},
         schema::{DatasetArray, DatasetRow, DatasetSchema},
-        semantics::ColumnMetadata,
+        semantics::{ColumnMetadata, ScanAxis, ScanAxisMode, ScanAxisValue, ScanPlan},
     },
     proto::{
         AddTagsRequest, ColumnMetadata as ProtoColumnMetadata, CreateAbort, CreateFinish,
-        CreateMetadata, CreateRequest, CreateResponse, GetRequest, RemoveTagsRequest,
-        SearchRequest, UpdateRequest, VersionRequest, create_request::CreateMessage,
+        CreateMetadata, CreateRequest, CreateResponse, GetRequest, IndexScanAxis,
+        RemoveTagsRequest, ScanAxisMetadata as ProtoScanAxisMetadata,
+        ScanAxisValue as ProtoScanAxisValue, SearchRequest, StaticScanAxis, UpdateRequest,
+        VersionRequest, create_request::CreateMessage,
         dataset_service_client::DatasetServiceClient, fricon_service_client::FriconServiceClient,
-        get_request::IdEnum,
+        get_request::IdEnum, scan_axis_metadata, scan_axis_value,
     },
     transport::{
         grpc::{
@@ -183,6 +185,7 @@ impl Client {
         tags: Vec<String>,
         schema: DatasetSchema,
         column_metadata: Vec<ColumnMetadata>,
+        scan_plan: Option<ScanPlan>,
     ) -> Result<DatasetWriter, ClientError> {
         Ok(DatasetWriter::new(
             self.clone(),
@@ -191,6 +194,7 @@ impl Client {
             tags,
             schema,
             column_metadata,
+            scan_plan,
             tokio::runtime::Handle::current(),
         ))
     }
@@ -326,6 +330,7 @@ impl DatasetWriter {
         tags: Vec<String>,
         schema: DatasetSchema,
         column_metadata: Vec<ColumnMetadata>,
+        scan_plan: Option<ScanPlan>,
         runtime: tokio::runtime::Handle,
     ) -> Self {
         let (tx, rx) = mpsc::channel::<StreamMessage>(16);
@@ -338,6 +343,7 @@ impl DatasetWriter {
                 description,
                 tags,
                 column_metadata,
+                scan_plan,
                 arrow_schema.clone(),
                 rx,
             );
@@ -503,11 +509,40 @@ fn column_metadata_to_proto(value: ColumnMetadata) -> ProtoColumnMetadata {
     }
 }
 
+fn scan_plan_to_proto(value: ScanPlan) -> Vec<ProtoScanAxisMetadata> {
+    value.axes.into_iter().map(scan_axis_to_proto).collect()
+}
+
+fn scan_axis_to_proto(value: ScanAxis) -> ProtoScanAxisMetadata {
+    let axis = match value.mode {
+        ScanAxisMode::Static { values } => scan_axis_metadata::Axis::StaticAxis(StaticScanAxis {
+            values: values.into_iter().map(scan_axis_value_to_proto).collect(),
+        }),
+        ScanAxisMode::ImplicitIndex => scan_axis_metadata::Axis::IndexAxis(IndexScanAxis {}),
+    };
+    ProtoScanAxisMetadata {
+        name: value.name,
+        label: value.label,
+        axis: Some(axis),
+    }
+}
+
+fn scan_axis_value_to_proto(value: ScanAxisValue) -> ProtoScanAxisValue {
+    let value = match value {
+        ScanAxisValue::Int(value) => scan_axis_value::Value::IntValue(value),
+        ScanAxisValue::Float(value) => scan_axis_value::Value::FloatValue(value),
+        ScanAxisValue::Bool(value) => scan_axis_value::Value::BoolValue(value),
+        ScanAxisValue::String(value) => scan_axis_value::Value::StringValue(value),
+    };
+    ProtoScanAxisValue { value: Some(value) }
+}
+
 fn build_request_stream(
     name: String,
     description: String,
     tags: Vec<String>,
     column_metadata: Vec<ColumnMetadata>,
+    scan_plan: Option<ScanPlan>,
     arrow_schema: SchemaRef,
     message_rx: mpsc::Receiver<StreamMessage>,
 ) -> impl Stream<Item = CreateRequest> {
@@ -518,6 +553,7 @@ fn build_request_stream(
                 description,
                 tags,
                 columns: column_metadata.into_iter().map(column_metadata_to_proto).collect(),
+                scan_axes: scan_plan.map_or_else(Vec::new, scan_plan_to_proto),
             })),
         };
 
@@ -796,7 +832,8 @@ mod tests {
         split_payload_chunk,
     };
     use crate::{
-        APP_VERSION, IPC_PROTOCOL_VERSION, dataset::semantics::ColumnMetadata,
+        APP_VERSION, IPC_PROTOCOL_VERSION,
+        dataset::semantics::{ColumnMetadata, ScanAxis, ScanAxisValue, ScanPlan},
         proto::create_request::CreateMessage,
         transport::grpc::dataset_service::DATASET_ERROR_CODE_METADATA_KEY,
     };
@@ -936,6 +973,7 @@ mod tests {
             "desc".to_string(),
             vec!["tag".to_string()],
             Vec::new(),
+            None,
             schema,
             message_rx,
         );
@@ -971,6 +1009,7 @@ mod tests {
             "desc".to_string(),
             vec![],
             Vec::new(),
+            None,
             schema,
             message_rx,
         );
@@ -1002,6 +1041,7 @@ mod tests {
             "desc".to_string(),
             vec![],
             Vec::new(),
+            None,
             schema,
             message_rx,
         );
@@ -1035,6 +1075,7 @@ mod tests {
                 hidden_by_default: true,
                 chart_axis: true,
             }],
+            None,
             schema,
             message_rx,
         );
@@ -1053,6 +1094,44 @@ mod tests {
         assert_eq!(metadata.columns[0].label.as_deref(), Some("Voltage"));
         assert!(metadata.columns[0].hidden_by_default);
         assert!(metadata.columns[0].chart_axis);
+    }
+
+    #[tokio::test]
+    async fn build_request_stream_sends_scan_metadata() {
+        let (message_tx, message_rx) = mpsc::channel(2);
+        drop(message_tx);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "signal",
+            DataType::Int64,
+            false,
+        )]));
+        let stream = build_request_stream(
+            "dataset".to_string(),
+            "desc".to_string(),
+            vec![],
+            Vec::new(),
+            Some(ScanPlan::new(vec![
+                ScanAxis::static_values(
+                    "gate",
+                    vec![ScanAxisValue::Float(-0.2), ScanAxisValue::Float(-0.1)],
+                ),
+                ScanAxis::static_values("bias", vec![ScanAxisValue::Int(0), ScanAxisValue::Int(1)]),
+            ])),
+            schema,
+            message_rx,
+        );
+
+        let messages: Vec<_> = stream
+            .map(|req| req.create_message.expect("message"))
+            .collect()
+            .await;
+        let CreateMessage::Metadata(metadata) = &messages[0] else {
+            panic!("first message should be metadata");
+        };
+
+        assert_eq!(metadata.scan_axes.len(), 2);
+        assert_eq!(metadata.scan_axes[0].name, "gate");
+        assert_eq!(metadata.scan_axes[1].name, "bias");
     }
 
     #[test]

--- a/crates/fricon/src/database/dataset.rs
+++ b/crates/fricon/src/database/dataset.rs
@@ -723,6 +723,7 @@ mod tests {
             description: "existing dataset".to_string(),
             tags: vec!["old".to_string(), "stale".to_string()],
             column_metadata: Vec::new(),
+            scan_plan: None,
         };
         let existing = DatasetIngestRepository::create_dataset_record(&fixture.repo, &request, uid)
             .expect("create dataset");

--- a/crates/fricon/src/dataset.rs
+++ b/crates/fricon/src/dataset.rs
@@ -14,7 +14,8 @@ pub use self::{
     events::DatasetEvent,
     interpret::{
         ColumnMeaning, DatasetInterpretation, InterpretationSource, PhysicalColumnOrdinal,
-        ResolvedColumn, ResolvedDuplicatePolicy, VisibleColumnOrdinal,
+        ResolvedColumn, ResolvedDuplicatePolicy, ResolvedIndexRealization,
+        ResolvedLogicalIndexPoint, ResolvedScanAxis, ResolvedScanAxisMode, VisibleColumnOrdinal,
     },
     model::{
         DatasetId, DatasetListQuery, DatasetMetadata, DatasetRecord, DatasetSortBy, DatasetStatus,
@@ -26,7 +27,7 @@ pub use self::{
         DatasetArray, DatasetDataType, DatasetRow, DatasetScalar, DatasetSchema, FixedStepTrace,
         ScalarArray, ScalarKind, TraceKind, VariableStepTrace,
     },
-    semantics::ColumnMetadata,
+    semantics::{ColumnMetadata, ScanAxis, ScanAxisMode, ScanAxisValue, ScanPlan},
 };
 pub(crate) use self::{
     ingest::{CreateDatasetInput, CreateDatasetRequest},

--- a/crates/fricon/src/dataset/ingest.rs
+++ b/crates/fricon/src/dataset/ingest.rs
@@ -22,7 +22,7 @@ pub(crate) use self::{
 };
 use crate::dataset::{
     model::{DatasetId, DatasetRecord, DatasetStatus},
-    semantics::ColumnMetadata,
+    semantics::{ColumnMetadata, ScanPlan},
 };
 
 /// Persistence port for ingest-time dataset creation and status updates.
@@ -57,6 +57,7 @@ pub(crate) struct CreateDatasetRequest {
     pub(crate) description: String,
     pub(crate) tags: Vec<String>,
     pub(crate) column_metadata: Vec<ColumnMetadata>,
+    pub(crate) scan_plan: Option<ScanPlan>,
 }
 
 /// Stream input driving a dataset ingest session.

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -19,7 +19,8 @@ use crate::{
         },
         model::{DatasetId, DatasetRecord, DatasetStatus},
         semantics::{
-            ColumnMetadata, DatasetSemanticManifest, ManifestColumn, ManifestError, write_manifest,
+            ColumnMetadata, DatasetSemanticManifest, ManifestColumn, ManifestError, ScanPlan,
+            write_manifest,
         },
         storage,
     },
@@ -180,7 +181,7 @@ fn write_minimal_manifest(
     dataset_path: &std::path::Path,
     schema: &arrow_schema::Schema,
     column_metadata: &[ColumnMetadata],
-    scan_plan: Option<crate::dataset::semantics::ScanPlan>,
+    scan_plan: Option<ScanPlan>,
 ) -> Result<(), IngestError> {
     let manifest = DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata_and_scan(
         schema,
@@ -194,7 +195,7 @@ fn write_minimal_manifest(
 
 fn write_empty_manifest(
     dataset_path: &std::path::Path,
-    scan_plan: Option<crate::dataset::semantics::ScanPlan>,
+    scan_plan: Option<ScanPlan>,
 ) -> Result<(), IngestError> {
     let manifest = DatasetSemanticManifest::minimal(std::iter::empty::<(String, ManifestColumn)>())
         .with_scan_plan(scan_plan);

--- a/crates/fricon/src/dataset/ingest/create.rs
+++ b/crates/fricon/src/dataset/ingest/create.rs
@@ -82,6 +82,7 @@ where
                         &dataset_path,
                         schema.as_ref(),
                         &request.column_metadata,
+                        request.scan_plan.clone(),
                     ) {
                         debug!(error = %error, "Failed to write dataset semantic manifest");
                         let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
@@ -96,6 +97,7 @@ where
                         &dataset_path,
                         batch.schema_ref(),
                         &request.column_metadata,
+                        request.scan_plan.clone(),
                     ) {
                         debug!(error = %error, "Failed to write dataset semantic manifest");
                         let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
@@ -125,7 +127,9 @@ where
 
     match terminal {
         CreateDatasetInput::Finish => {
-            if !manifest_written && let Err(error) = write_empty_manifest(&dataset_path) {
+            if !manifest_written
+                && let Err(error) = write_empty_manifest(&dataset_path, request.scan_plan.clone())
+            {
                 debug!(error = %error, "Failed to write empty dataset semantic manifest");
                 let _ = repo.update_status(dataset_record.id, DatasetStatus::Aborted);
                 return Err(error);
@@ -176,18 +180,24 @@ fn write_minimal_manifest(
     dataset_path: &std::path::Path,
     schema: &arrow_schema::Schema,
     column_metadata: &[ColumnMetadata],
+    scan_plan: Option<crate::dataset::semantics::ScanPlan>,
 ) -> Result<(), IngestError> {
-    let manifest = DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata(
+    let manifest = DatasetSemanticManifest::minimal_from_arrow_schema_with_metadata_and_scan(
         schema,
         column_metadata.iter().cloned(),
+        scan_plan,
     )
     .map_err(ManifestError::from)?;
     write_manifest(dataset_path, &manifest)?;
     Ok(())
 }
 
-fn write_empty_manifest(dataset_path: &std::path::Path) -> Result<(), IngestError> {
-    let manifest = DatasetSemanticManifest::minimal(std::iter::empty::<(String, ManifestColumn)>());
+fn write_empty_manifest(
+    dataset_path: &std::path::Path,
+    scan_plan: Option<crate::dataset::semantics::ScanPlan>,
+) -> Result<(), IngestError> {
+    let manifest = DatasetSemanticManifest::minimal(std::iter::empty::<(String, ManifestColumn)>())
+        .with_scan_plan(scan_plan);
     write_manifest(dataset_path, &manifest)?;
     Ok(())
 }
@@ -303,6 +313,7 @@ mod tests {
             description: "desc".to_string(),
             tags: vec!["tag".to_string()],
             column_metadata: Vec::new(),
+            scan_plan: None,
         }
     }
 

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -177,7 +177,8 @@ pub(crate) fn resolve_logical_index_points(
                     let ScanAxisMode::Static { values } = &axis.mode else {
                         unreachable!("implicit axes handled earlier")
                     };
-                    values[*index as usize].clone()
+                    let index = usize::try_from(*index).expect("scan axis index should fit usize");
+                    values[index].clone()
                 })
                 .collect();
             ResolvedLogicalIndexPoint {

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -21,7 +21,6 @@ pub(crate) fn resolve_from_manifest(
     arrow_schema: &Schema,
     manifest: &DatasetSemanticManifest,
     visible_columns: &[usize],
-    record_ids: &[u64],
 ) -> DatasetInterpretation {
     let visible_ordinals: HashMap<_, _> = visible_columns
         .iter()
@@ -73,7 +72,6 @@ pub(crate) fn resolve_from_manifest(
         .filter_map(|column| column.visible_ordinal)
         .collect();
     let scan_axes = resolve_scan_axes(manifest);
-    let logical_index_points = resolve_logical_index_points(manifest, record_ids);
 
     DatasetInterpretation {
         columns,
@@ -90,7 +88,7 @@ pub(crate) fn resolve_from_manifest(
             IndexRealization::Implicit => ResolvedIndexRealization::Implicit,
         },
         scan_axes,
-        logical_index_points,
+        logical_index_points: Vec::new(),
         source: InterpretationSource::Manifest,
     }
 }
@@ -117,7 +115,7 @@ fn resolve_scan_axes(manifest: &DatasetSemanticManifest) -> Vec<ResolvedScanAxis
         })
 }
 
-fn resolve_logical_index_points(
+pub(crate) fn resolve_logical_index_points(
     manifest: &DatasetSemanticManifest,
     record_ids: &[u64],
 ) -> Vec<ResolvedLogicalIndexPoint> {
@@ -153,8 +151,10 @@ fn resolve_logical_index_points(
             ScanAxisMode::ImplicitIndex => 0,
         })
         .collect();
-    let planned_len = shapes.iter().copied().product::<u64>();
-    if planned_len == 0 {
+    let planned_len = shapes
+        .iter()
+        .try_fold(1_u64, |acc, len| acc.checked_mul(*len));
+    if planned_len == Some(0) {
         return Vec::new();
     }
 
@@ -162,7 +162,8 @@ fn resolve_logical_index_points(
         .iter()
         .copied()
         .map(|record_id| {
-            let mut remainder = record_id % planned_len;
+            let mut remainder =
+                planned_len.map_or(record_id, |planned_len| record_id % planned_len);
             let mut indices = vec![0; shapes.len()];
             for axis_index in (0..shapes.len()).rev() {
                 let len = shapes[axis_index];
@@ -282,7 +283,7 @@ mod tests {
     use super::{
         ColumnMeaning, InterpretationSource, PhysicalColumnOrdinal, ResolvedDuplicatePolicy,
         ResolvedIndexRealization, ResolvedLogicalIndexPoint, ResolvedScanAxisMode,
-        VisibleColumnOrdinal, resolve_from_manifest,
+        VisibleColumnOrdinal, resolve_from_manifest, resolve_logical_index_points,
     };
     use crate::dataset::{
         DatasetReader,
@@ -312,7 +313,7 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[]);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
         assert_eq!(
@@ -362,7 +363,7 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[]);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
         let signal = &interpretation.columns[1];
 
         assert_eq!(signal.unit.as_deref(), Some("V"));
@@ -390,7 +391,7 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[0, 1, 2, 3, 4]);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
 
         assert_eq!(
             interpretation.index_realization,
@@ -401,8 +402,10 @@ mod tests {
             interpretation.scan_axes[0].mode,
             ResolvedScanAxisMode::Static { .. }
         ));
+        assert_eq!(interpretation.logical_index_points, Vec::new());
+        let logical_index_points = resolve_logical_index_points(&manifest, &[0, 1, 2, 3, 4]);
         assert_eq!(
-            interpretation.logical_index_points,
+            logical_index_points,
             vec![
                 ResolvedLogicalIndexPoint {
                     record_id: 0,
@@ -434,6 +437,28 @@ mod tests {
     }
 
     #[test]
+    fn implicit_scan_index_derivation_handles_shape_larger_than_u64() {
+        let axes = (0..64)
+            .map(|index| {
+                ScanAxis::static_values(
+                    format!("axis_{index}"),
+                    vec![ScanAxisValue::Int(0), ScanAxisValue::Int(1)],
+                )
+            })
+            .collect();
+        let manifest = DatasetSemanticManifest::minimal([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )])
+        .with_scan_plan(Some(ScanPlan::new(axes)));
+
+        let points = resolve_logical_index_points(&manifest, &[u64::MAX]);
+
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].indices, vec![1; 64]);
+    }
+
+    #[test]
     fn manifest_interpretation_derives_unknown_length_index_from_record_ids() {
         let manifest = DatasetSemanticManifest::minimal([(
             "loss".to_string(),
@@ -447,15 +472,17 @@ mod tests {
             Field::new("loss", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[0, 1, 2]);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
 
         assert_eq!(interpretation.scan_axes[0].name, "step");
         assert!(matches!(
             interpretation.scan_axes[0].mode,
             ResolvedScanAxisMode::ImplicitIndex
         ));
+        assert_eq!(interpretation.logical_index_points, Vec::new());
+        let logical_index_points = resolve_logical_index_points(&manifest, &[0, 1, 2]);
         assert_eq!(
-            interpretation.logical_index_points,
+            logical_index_points,
             vec![
                 ResolvedLogicalIndexPoint {
                     record_id: 0,
@@ -656,9 +683,10 @@ mod tests {
             interpretation.duplicate_policy,
             ResolvedDuplicatePolicy::LatestByRecordId
         );
+        assert_eq!(interpretation.logical_index_points, Vec::new());
+        let logical_index_points = reader.logical_index_points().expect("logical index points");
         assert_eq!(
-            interpretation
-                .logical_index_points
+            logical_index_points
                 .iter()
                 .map(|point| point.indices.clone())
                 .collect::<Vec<_>>(),
@@ -699,9 +727,10 @@ mod tests {
         let reader = DatasetReader::open_dir(dir.path()).expect("reader");
         let interpretation = reader.interpret().expect("interpretation");
 
+        assert_eq!(interpretation.logical_index_points, Vec::new());
+        let logical_index_points = reader.logical_index_points().expect("logical index points");
         assert_eq!(
-            interpretation
-                .logical_index_points
+            logical_index_points
                 .iter()
                 .map(|point| point.coordinates.clone())
                 .collect::<Vec<_>>(),

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -6,13 +6,14 @@ use arrow_schema::Schema;
 
 pub use self::model::{
     ColumnMeaning, DatasetInterpretation, InterpretationSource, PhysicalColumnOrdinal,
-    ResolvedColumn, ResolvedDuplicatePolicy, VisibleColumnOrdinal,
+    ResolvedColumn, ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedLogicalIndexPoint,
+    ResolvedScanAxis, ResolvedScanAxisMode, VisibleColumnOrdinal,
 };
 use crate::dataset::{
     schema::{DatasetDataType, DatasetSchema, ScalarKind, TraceKind},
     semantics::{
-        DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault, SystemColumn,
-        TraceAxisDType, TraceLayout, TraceValueDType,
+        DatasetDType, DatasetSemanticManifest, DuplicateResolutionDefault, IndexRealization,
+        ScanAxisMode, ScanAxisValue, SystemColumn, TraceAxisDType, TraceLayout, TraceValueDType,
     },
 };
 
@@ -20,6 +21,7 @@ pub(crate) fn resolve_from_manifest(
     arrow_schema: &Schema,
     manifest: &DatasetSemanticManifest,
     visible_columns: &[usize],
+    record_ids: &[u64],
 ) -> DatasetInterpretation {
     let visible_ordinals: HashMap<_, _> = visible_columns
         .iter()
@@ -70,6 +72,8 @@ pub(crate) fn resolve_from_manifest(
         .filter(|column| column.is_chart_axis_candidate)
         .filter_map(|column| column.visible_ordinal)
         .collect();
+    let scan_axes = resolve_scan_axes(manifest);
+    let logical_index_points = resolve_logical_index_points(manifest, record_ids);
 
     DatasetInterpretation {
         columns,
@@ -78,11 +82,110 @@ pub(crate) fn resolve_from_manifest(
         chart_axis_candidate_columns,
         duplicate_policy: match manifest.realization.duplicate_resolution_default {
             DuplicateResolutionDefault::LatestByRecordId => {
-                ResolvedDuplicatePolicy::LatestByRecordIdPlaceholder
+                ResolvedDuplicatePolicy::LatestByRecordId
             }
         },
+        index_realization: match manifest.realization.index_realization {
+            IndexRealization::None => ResolvedIndexRealization::None,
+            IndexRealization::Implicit => ResolvedIndexRealization::Implicit,
+        },
+        scan_axes,
+        logical_index_points,
         source: InterpretationSource::Manifest,
     }
+}
+
+fn resolve_scan_axes(manifest: &DatasetSemanticManifest) -> Vec<ResolvedScanAxis> {
+    manifest
+        .scan_plan
+        .as_ref()
+        .map_or_else(Vec::new, |scan_plan| {
+            scan_plan
+                .axes
+                .iter()
+                .map(|axis| ResolvedScanAxis {
+                    name: axis.name.clone(),
+                    label: axis.label.clone(),
+                    mode: match &axis.mode {
+                        ScanAxisMode::Static { values } => ResolvedScanAxisMode::Static {
+                            values: values.clone(),
+                        },
+                        ScanAxisMode::ImplicitIndex => ResolvedScanAxisMode::ImplicitIndex,
+                    },
+                })
+                .collect()
+        })
+}
+
+fn resolve_logical_index_points(
+    manifest: &DatasetSemanticManifest,
+    record_ids: &[u64],
+) -> Vec<ResolvedLogicalIndexPoint> {
+    let Some(scan_plan) = &manifest.scan_plan else {
+        return Vec::new();
+    };
+    if scan_plan.axes.is_empty() {
+        return Vec::new();
+    }
+    if scan_plan
+        .axes
+        .iter()
+        .any(|axis| matches!(axis.mode, ScanAxisMode::ImplicitIndex))
+    {
+        return record_ids
+            .iter()
+            .copied()
+            .map(|record_id| ResolvedLogicalIndexPoint {
+                record_id,
+                indices: vec![record_id],
+                coordinates: vec![ScanAxisValue::Int(
+                    i64::try_from(record_id).unwrap_or(i64::MAX),
+                )],
+            })
+            .collect();
+    }
+
+    let shapes: Vec<_> = scan_plan
+        .axes
+        .iter()
+        .map(|axis| match &axis.mode {
+            ScanAxisMode::Static { values } => values.len() as u64,
+            ScanAxisMode::ImplicitIndex => 0,
+        })
+        .collect();
+    let planned_len = shapes.iter().copied().product::<u64>();
+    if planned_len == 0 {
+        return Vec::new();
+    }
+
+    record_ids
+        .iter()
+        .copied()
+        .map(|record_id| {
+            let mut remainder = record_id % planned_len;
+            let mut indices = vec![0; shapes.len()];
+            for axis_index in (0..shapes.len()).rev() {
+                let len = shapes[axis_index];
+                indices[axis_index] = remainder % len;
+                remainder /= len;
+            }
+            let coordinates = indices
+                .iter()
+                .zip(&scan_plan.axes)
+                .map(|(index, axis)| {
+                    let ScanAxisMode::Static { values } = &axis.mode else {
+                        unreachable!("implicit axes handled earlier")
+                    };
+                    values[*index as usize].clone()
+                })
+                .collect();
+            ResolvedLogicalIndexPoint {
+                record_id,
+                indices,
+                coordinates,
+            }
+        })
+        .collect()
 }
 
 pub(crate) fn resolve_from_compatibility_inference(
@@ -135,6 +238,9 @@ pub(crate) fn resolve_from_compatibility_inference(
         logical_index_columns: index_columns.clone(),
         chart_axis_candidate_columns: index_columns,
         duplicate_policy: ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder,
+        index_realization: ResolvedIndexRealization::None,
+        scan_axes: Vec::new(),
+        logical_index_points: Vec::new(),
         source: InterpretationSource::CompatibilityInference,
     }
 }
@@ -175,6 +281,7 @@ mod tests {
 
     use super::{
         ColumnMeaning, InterpretationSource, PhysicalColumnOrdinal, ResolvedDuplicatePolicy,
+        ResolvedIndexRealization, ResolvedLogicalIndexPoint, ResolvedScanAxisMode,
         VisibleColumnOrdinal, resolve_from_manifest,
     };
     use crate::dataset::{
@@ -184,7 +291,8 @@ mod tests {
         read::{ReadError, SelectOptions},
         schema::DatasetSchema,
         semantics::{
-            DatasetDType, DatasetSemanticManifest, ManifestColumn, RECORD_ID_COLUMN, write_manifest,
+            DatasetDType, DatasetSemanticManifest, ManifestColumn, RECORD_ID_COLUMN, ScanAxis,
+            ScanAxisValue, ScanPlan, write_manifest,
         },
         storage::ChunkWriter,
     };
@@ -204,12 +312,12 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[]);
 
         assert_eq!(interpretation.source, InterpretationSource::Manifest);
         assert_eq!(
             interpretation.duplicate_policy,
-            ResolvedDuplicatePolicy::LatestByRecordIdPlaceholder
+            ResolvedDuplicatePolicy::LatestByRecordId
         );
         assert_eq!(interpretation.value_columns, visible(&[0]));
         assert_eq!(
@@ -254,7 +362,7 @@ mod tests {
             Field::new("signal", DataType::Float64, false),
         ]);
 
-        let interpretation = resolve_from_manifest(&schema, &manifest, &[1]);
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[]);
         let signal = &interpretation.columns[1];
 
         assert_eq!(signal.unit.as_deref(), Some("V"));
@@ -262,6 +370,110 @@ mod tests {
         assert!(signal.hidden_by_default);
         assert!(signal.is_chart_axis_candidate);
         assert_eq!(interpretation.chart_axis_candidate_columns, visible(&[0]));
+    }
+
+    #[test]
+    fn manifest_interpretation_derives_regular_scan_indices_from_record_ids() {
+        let manifest = DatasetSemanticManifest::minimal([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )])
+        .with_scan_plan(Some(ScanPlan::new(vec![
+            ScanAxis::static_values(
+                "gate",
+                vec![ScanAxisValue::Float(-0.2), ScanAxisValue::Float(-0.1)],
+            ),
+            ScanAxis::static_values("bias", vec![ScanAxisValue::Int(0), ScanAxisValue::Int(1)]),
+        ])));
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]);
+
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[0, 1, 2, 3, 4]);
+
+        assert_eq!(
+            interpretation.index_realization,
+            ResolvedIndexRealization::Implicit
+        );
+        assert_eq!(interpretation.scan_axes.len(), 2);
+        assert!(matches!(
+            interpretation.scan_axes[0].mode,
+            ResolvedScanAxisMode::Static { .. }
+        ));
+        assert_eq!(
+            interpretation.logical_index_points,
+            vec![
+                ResolvedLogicalIndexPoint {
+                    record_id: 0,
+                    indices: vec![0, 0],
+                    coordinates: vec![ScanAxisValue::Float(-0.2), ScanAxisValue::Int(0)],
+                },
+                ResolvedLogicalIndexPoint {
+                    record_id: 1,
+                    indices: vec![0, 1],
+                    coordinates: vec![ScanAxisValue::Float(-0.2), ScanAxisValue::Int(1)],
+                },
+                ResolvedLogicalIndexPoint {
+                    record_id: 2,
+                    indices: vec![1, 0],
+                    coordinates: vec![ScanAxisValue::Float(-0.1), ScanAxisValue::Int(0)],
+                },
+                ResolvedLogicalIndexPoint {
+                    record_id: 3,
+                    indices: vec![1, 1],
+                    coordinates: vec![ScanAxisValue::Float(-0.1), ScanAxisValue::Int(1)],
+                },
+                ResolvedLogicalIndexPoint {
+                    record_id: 4,
+                    indices: vec![0, 0],
+                    coordinates: vec![ScanAxisValue::Float(-0.2), ScanAxisValue::Int(0)],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn manifest_interpretation_derives_unknown_length_index_from_record_ids() {
+        let manifest = DatasetSemanticManifest::minimal([(
+            "loss".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )])
+        .with_scan_plan(Some(ScanPlan::new(vec![ScanAxis::implicit_index(
+            "step", None,
+        )])));
+        let schema = Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("loss", DataType::Float64, false),
+        ]);
+
+        let interpretation = resolve_from_manifest(&schema, &manifest, &[1], &[0, 1, 2]);
+
+        assert_eq!(interpretation.scan_axes[0].name, "step");
+        assert!(matches!(
+            interpretation.scan_axes[0].mode,
+            ResolvedScanAxisMode::ImplicitIndex
+        ));
+        assert_eq!(
+            interpretation.logical_index_points,
+            vec![
+                ResolvedLogicalIndexPoint {
+                    record_id: 0,
+                    indices: vec![0],
+                    coordinates: vec![ScanAxisValue::Int(0)],
+                },
+                ResolvedLogicalIndexPoint {
+                    record_id: 1,
+                    indices: vec![1],
+                    coordinates: vec![ScanAxisValue::Int(1)],
+                },
+                ResolvedLogicalIndexPoint {
+                    record_id: 2,
+                    indices: vec![2],
+                    coordinates: vec![ScanAxisValue::Int(2)],
+                },
+            ]
+        );
     }
 
     #[test]
@@ -398,6 +610,107 @@ mod tests {
             .expect("select value columns from interpretation");
         assert_eq!(selected_schema.fields().len(), 2);
         assert_eq!(selected_batches[0].num_columns(), 2);
+    }
+
+    #[test]
+    fn reader_interpretation_resolves_implicit_regular_scan_after_reopen() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("signal", DataType::Float64, false),
+        ]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(UInt64Array::from(vec![0, 1, 2, 3, 4])),
+                        Arc::new(Float64Array::from(vec![10.0, 20.0, 30.0, 40.0, 50.0])),
+                    ],
+                )
+                .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+        let manifest = DatasetSemanticManifest::minimal([(
+            "signal".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )])
+        .with_scan_plan(Some(ScanPlan::new(vec![
+            ScanAxis::static_values(
+                "gate",
+                vec![
+                    ScanAxisValue::String("low".to_string()),
+                    ScanAxisValue::String("high".to_string()),
+                ],
+            ),
+            ScanAxis::static_values("bias", vec![ScanAxisValue::Int(0), ScanAxisValue::Int(1)]),
+        ])));
+        write_manifest(dir.path(), &manifest).expect("write manifest");
+
+        let reader = DatasetReader::open_dir(dir.path()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(
+            interpretation.duplicate_policy,
+            ResolvedDuplicatePolicy::LatestByRecordId
+        );
+        assert_eq!(
+            interpretation
+                .logical_index_points
+                .iter()
+                .map(|point| point.indices.clone())
+                .collect::<Vec<_>>(),
+            vec![vec![0, 0], vec![0, 1], vec![1, 0], vec![1, 1], vec![0, 0]]
+        );
+    }
+
+    #[test]
+    fn reader_interpretation_resolves_unknown_length_scan_after_reopen() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(RECORD_ID_COLUMN, DataType::UInt64, false),
+            Field::new("loss", DataType::Float64, false),
+        ]));
+        let mut writer = ChunkWriter::new(schema.clone(), dir.path().to_owned());
+        writer
+            .write(
+                RecordBatch::try_new(
+                    schema,
+                    vec![
+                        Arc::new(UInt64Array::from(vec![0, 1, 2])),
+                        Arc::new(Float64Array::from(vec![3.0, 2.0, 1.0])),
+                    ],
+                )
+                .expect("batch"),
+            )
+            .expect("write batch");
+        writer.finish().expect("finish writer");
+        let manifest = DatasetSemanticManifest::minimal([(
+            "loss".to_string(),
+            ManifestColumn::new(DatasetDType::Float64),
+        )])
+        .with_scan_plan(Some(ScanPlan::new(vec![ScanAxis::implicit_index(
+            "step", None,
+        )])));
+        write_manifest(dir.path(), &manifest).expect("write manifest");
+
+        let reader = DatasetReader::open_dir(dir.path()).expect("reader");
+        let interpretation = reader.interpret().expect("interpretation");
+
+        assert_eq!(
+            interpretation
+                .logical_index_points
+                .iter()
+                .map(|point| point.coordinates.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                vec![ScanAxisValue::Int(0)],
+                vec![ScanAxisValue::Int(1)],
+                vec![ScanAxisValue::Int(2)]
+            ]
+        );
     }
 
     #[test]

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -88,7 +88,6 @@ pub(crate) fn resolve_from_manifest(
             IndexRealization::Implicit => ResolvedIndexRealization::Implicit,
         },
         scan_axes,
-        logical_index_points: Vec::new(),
         source: InterpretationSource::Manifest,
     }
 }
@@ -242,7 +241,6 @@ pub(crate) fn resolve_from_compatibility_inference(
         duplicate_policy: ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder,
         index_realization: ResolvedIndexRealization::None,
         scan_axes: Vec::new(),
-        logical_index_points: Vec::new(),
         source: InterpretationSource::CompatibilityInference,
     }
 }
@@ -403,7 +401,6 @@ mod tests {
             interpretation.scan_axes[0].mode,
             ResolvedScanAxisMode::Static { .. }
         ));
-        assert_eq!(interpretation.logical_index_points, Vec::new());
         let logical_index_points = resolve_logical_index_points(&manifest, &[0, 1, 2, 3, 4]);
         assert_eq!(
             logical_index_points,
@@ -480,7 +477,6 @@ mod tests {
             interpretation.scan_axes[0].mode,
             ResolvedScanAxisMode::ImplicitIndex
         ));
-        assert_eq!(interpretation.logical_index_points, Vec::new());
         let logical_index_points = resolve_logical_index_points(&manifest, &[0, 1, 2]);
         assert_eq!(
             logical_index_points,
@@ -684,7 +680,6 @@ mod tests {
             interpretation.duplicate_policy,
             ResolvedDuplicatePolicy::LatestByRecordId
         );
-        assert_eq!(interpretation.logical_index_points, Vec::new());
         let logical_index_points = reader.logical_index_points().expect("logical index points");
         assert_eq!(
             logical_index_points
@@ -728,7 +723,7 @@ mod tests {
         let reader = DatasetReader::open_dir(dir.path()).expect("reader");
         let interpretation = reader.interpret().expect("interpretation");
 
-        assert_eq!(interpretation.logical_index_points, Vec::new());
+        assert_eq!(interpretation.scan_axes[0].name, "step");
         let logical_index_points = reader.logical_index_points().expect("logical index points");
         assert_eq!(
             logical_index_points

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -9,7 +9,6 @@ pub struct DatasetInterpretation {
     pub duplicate_policy: ResolvedDuplicatePolicy,
     pub index_realization: ResolvedIndexRealization,
     pub scan_axes: Vec<ResolvedScanAxis>,
-    pub logical_index_points: Vec<ResolvedLogicalIndexPoint>,
     pub source: InterpretationSource,
 }
 

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -1,12 +1,15 @@
-use crate::dataset::semantics::DatasetDType;
+use crate::dataset::semantics::{DatasetDType, ScanAxisValue};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DatasetInterpretation {
     pub columns: Vec<ResolvedColumn>,
     pub value_columns: Vec<VisibleColumnOrdinal>,
     pub logical_index_columns: Vec<VisibleColumnOrdinal>,
     pub chart_axis_candidate_columns: Vec<VisibleColumnOrdinal>,
     pub duplicate_policy: ResolvedDuplicatePolicy,
+    pub index_realization: ResolvedIndexRealization,
+    pub scan_axes: Vec<ResolvedScanAxis>,
+    pub logical_index_points: Vec<ResolvedLogicalIndexPoint>,
     pub source: InterpretationSource,
 }
 
@@ -43,6 +46,32 @@ pub enum ColumnMeaning {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedIndexRealization {
+    None,
+    Implicit,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedScanAxis {
+    pub name: String,
+    pub label: Option<String>,
+    pub mode: ResolvedScanAxisMode,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedScanAxisMode {
+    Static { values: Vec<ScanAxisValue> },
+    ImplicitIndex,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedLogicalIndexPoint {
+    pub record_id: u64,
+    pub indices: Vec<u64>,
+    pub coordinates: Vec<ScanAxisValue>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterpretationSource {
     Manifest,
     CompatibilityInference,
@@ -50,6 +79,6 @@ pub enum InterpretationSource {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResolvedDuplicatePolicy {
-    LatestByRecordIdPlaceholder,
+    LatestByRecordId,
     CompatibilityRowOrderPlaceholder,
 }

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, cmp::Ordering, ops::RangeBounds, path::Path, sync::Arc};
 
 use arrow_arith::boolean::and;
-use arrow_array::{ArrayRef, BooleanArray, RecordBatch, RecordBatchOptions, Scalar};
+use arrow_array::{ArrayRef, BooleanArray, RecordBatch, RecordBatchOptions, Scalar, UInt64Array};
 use arrow_ord::{cmp::eq, ord::make_comparator};
 use arrow_schema::{Schema, SchemaRef, SortOptions};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
@@ -15,7 +15,8 @@ use crate::dataset::{
     read::{ReadError, SelectOptions},
     schema::{DatasetDataType, DatasetError, DatasetSchema},
     semantics::{
-        DatasetSemanticManifest, ManifestError, is_hidden_system_column, read_manifest_optional,
+        DatasetSemanticManifest, ManifestError, RECORD_ID_COLUMN, is_hidden_system_column,
+        read_manifest_optional,
     },
     storage::ChunkReader,
 };
@@ -359,10 +360,16 @@ impl DatasetReader {
             manifest
                 .validate_against_arrow_schema(self.physical_arrow_schema.as_ref())
                 .map_err(ManifestError::from)?;
+            let record_ids = if manifest.scan_plan.is_some() {
+                self.record_ids()?
+            } else {
+                Vec::new()
+            };
             return Ok(resolve_from_manifest(
                 self.physical_arrow_schema.as_ref(),
                 manifest,
                 &self.visible_columns,
+                &record_ids,
             ));
         }
 
@@ -370,6 +377,28 @@ impl DatasetReader {
             self.schema()?,
             self.try_index_columns()?,
         ))
+    }
+
+    fn record_ids(&self) -> Result<Vec<u64>, ReadError> {
+        let record_id_index = self
+            .physical_arrow_schema
+            .column_with_name(RECORD_ID_COLUMN)
+            .ok_or_else(|| {
+                DatasetError::Arrow(arrow_schema::ArrowError::SchemaError(format!(
+                    "missing record id column {RECORD_ID_COLUMN}"
+                )))
+            })?
+            .0;
+        let mut record_ids = Vec::new();
+        for batch in self.source.range(..) {
+            let column = batch
+                .column(record_id_index)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or(DatasetError::IncompatibleType)?;
+            record_ids.extend(column.values().iter().copied());
+        }
+        Ok(record_ids)
     }
 
     #[must_use]

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -10,7 +10,8 @@ use itertools::Itertools;
 use crate::dataset::{
     ingest::WriteSessionHandle,
     interpret::{
-        DatasetInterpretation, resolve_from_compatibility_inference, resolve_from_manifest,
+        DatasetInterpretation, ResolvedLogicalIndexPoint, resolve_from_compatibility_inference,
+        resolve_from_manifest, resolve_logical_index_points,
     },
     read::{ReadError, SelectOptions},
     schema::{DatasetDataType, DatasetError, DatasetSchema},
@@ -360,16 +361,10 @@ impl DatasetReader {
             manifest
                 .validate_against_arrow_schema(self.physical_arrow_schema.as_ref())
                 .map_err(ManifestError::from)?;
-            let record_ids = if manifest.scan_plan.is_some() {
-                self.record_ids()?
-            } else {
-                Vec::new()
-            };
             return Ok(resolve_from_manifest(
                 self.physical_arrow_schema.as_ref(),
                 manifest,
                 &self.visible_columns,
-                &record_ids,
             ));
         }
 
@@ -377,6 +372,19 @@ impl DatasetReader {
             self.schema()?,
             self.try_index_columns()?,
         ))
+    }
+
+    pub fn logical_index_points(&self) -> Result<Vec<ResolvedLogicalIndexPoint>, ReadError> {
+        let Some(manifest) = &self.manifest else {
+            return Ok(Vec::new());
+        };
+        manifest
+            .validate_against_arrow_schema(self.physical_arrow_schema.as_ref())
+            .map_err(ManifestError::from)?;
+        if manifest.scan_plan.is_none() {
+            return Ok(Vec::new());
+        }
+        Ok(resolve_logical_index_points(manifest, &self.record_ids()?))
     }
 
     fn record_ids(&self) -> Result<Vec<u64>, ReadError> {

--- a/crates/fricon/src/dataset/semantics.rs
+++ b/crates/fricon/src/dataset/semantics.rs
@@ -12,7 +12,7 @@ pub use self::{
     model::{
         ColumnMetadata, Compatibility, DatasetDType, DatasetSemanticManifest,
         DuplicateResolutionDefault, IndexRealization, MANIFEST_VERSION_V1, ManifestColumn,
-        RECORD_ID_COLUMN, Realization, SystemColumn, TraceAxisDType, TraceDType, TraceLayout,
-        TraceValueDType,
+        RECORD_ID_COLUMN, Realization, ScanAxis, ScanAxisMode, ScanAxisValue, ScanPlan,
+        SystemColumn, TraceAxisDType, TraceDType, TraceLayout, TraceValueDType,
     },
 };

--- a/crates/fricon/src/dataset/semantics/error.rs
+++ b/crates/fricon/src/dataset/semantics/error.rs
@@ -34,6 +34,8 @@ pub enum ManifestValidationError {
     InvalidSystemColumnMetadata { name: String },
     #[error("Dataset semantic manifest v1 requires append_only=true")]
     AppendOnlyRequired,
+    #[error("Dataset semantic manifest scan plan must contain at least one axis")]
+    EmptyScanPlan,
     #[error("Dataset semantic manifest scan axis name must not be empty")]
     EmptyScanAxisName,
     #[error("Dataset semantic manifest scan axis {name} uses reserved system prefix")]

--- a/crates/fricon/src/dataset/semantics/error.rs
+++ b/crates/fricon/src/dataset/semantics/error.rs
@@ -34,6 +34,22 @@ pub enum ManifestValidationError {
     InvalidSystemColumnMetadata { name: String },
     #[error("Dataset semantic manifest v1 requires append_only=true")]
     AppendOnlyRequired,
+    #[error("Dataset semantic manifest scan axis name must not be empty")]
+    EmptyScanAxisName,
+    #[error("Dataset semantic manifest scan axis {name} uses reserved system prefix")]
+    ReservedScanAxisName { name: String },
+    #[error("Dataset semantic manifest contains duplicate scan axis: {name}")]
+    DuplicateScanAxis { name: String },
+    #[error("Dataset semantic manifest static scan axis {name} must contain at least one value")]
+    EmptyStaticScanAxis { name: String },
+    #[error("Dataset semantic manifest v1 supports only one unknown-length scan axis")]
+    MultipleUnknownScanAxes,
+    #[error("Dataset semantic manifest v1 does not support mixed static and unknown scan axes")]
+    MixedStaticAndUnknownScanAxes,
+    #[error("Dataset semantic manifest scan plan requires implicit index realization")]
+    ScanPlanRequiresImplicitRealization,
+    #[error("Dataset semantic manifest implicit index realization requires a scan plan")]
+    ImplicitRealizationRequiresScanPlan,
     #[error("Column metadata names a column that is not in the Arrow schema: {name}")]
     UnknownColumnMetadata { name: String },
     #[error("Column metadata was declared more than once: {name}")]

--- a/crates/fricon/src/dataset/semantics/error.rs
+++ b/crates/fricon/src/dataset/semantics/error.rs
@@ -42,6 +42,8 @@ pub enum ManifestValidationError {
     DuplicateScanAxis { name: String },
     #[error("Dataset semantic manifest static scan axis {name} must contain at least one value")]
     EmptyStaticScanAxis { name: String },
+    #[error("Dataset semantic manifest static scan axis {name} contains a non-finite float value")]
+    NonFiniteScanAxisValue { name: String },
     #[error("Dataset semantic manifest v1 supports only one unknown-length scan axis")]
     MultipleUnknownScanAxes,
     #[error("Dataset semantic manifest v1 does not support mixed static and unknown scan axes")]

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -9,10 +9,12 @@ pub const MANIFEST_VERSION_V1: u32 = 1;
 pub const RECORD_ID_COLUMN: &str = "__ds_record_id";
 const SYSTEM_COLUMN_PREFIX: &str = "__ds_";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DatasetSemanticManifest {
     pub manifest_version: u32,
     pub columns: BTreeMap<String, ManifestColumn>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_plan: Option<ScanPlan>,
     pub realization: Realization,
     pub compatibility: Compatibility,
 }
@@ -25,6 +27,7 @@ impl DatasetSemanticManifest {
         Self {
             manifest_version: MANIFEST_VERSION_V1,
             columns,
+            scan_plan: None,
             realization: Realization::default(),
             compatibility: Compatibility::default(),
         }
@@ -38,6 +41,14 @@ impl DatasetSemanticManifest {
         schema: &Schema,
         metadata: impl IntoIterator<Item = ColumnMetadata>,
     ) -> Result<Self, ManifestValidationError> {
+        Self::minimal_from_arrow_schema_with_metadata_and_scan(schema, metadata, None)
+    }
+
+    pub fn minimal_from_arrow_schema_with_metadata_and_scan(
+        schema: &Schema,
+        metadata: impl IntoIterator<Item = ColumnMetadata>,
+        scan_plan: Option<ScanPlan>,
+    ) -> Result<Self, ManifestValidationError> {
         let columns = schema
             .fields()
             .iter()
@@ -49,8 +60,24 @@ impl DatasetSemanticManifest {
             .collect::<Result<Vec<_>, ManifestValidationError>>()?;
         let mut manifest = Self::minimal(columns);
         manifest.apply_column_metadata(metadata)?;
+        manifest.apply_scan_plan(scan_plan);
         manifest.validate()?;
         Ok(manifest)
+    }
+
+    #[must_use]
+    pub fn with_scan_plan(mut self, scan_plan: Option<ScanPlan>) -> Self {
+        self.apply_scan_plan(scan_plan);
+        self
+    }
+
+    fn apply_scan_plan(&mut self, scan_plan: Option<ScanPlan>) {
+        self.scan_plan = scan_plan;
+        self.realization.index_realization = if self.scan_plan.is_some() {
+            IndexRealization::Implicit
+        } else {
+            IndexRealization::None
+        };
     }
 
     fn apply_column_metadata(
@@ -100,6 +127,7 @@ impl DatasetSemanticManifest {
         if !self.realization.append_only {
             return Err(ManifestValidationError::AppendOnlyRequired);
         }
+        self.validate_scan_plan()?;
         self.validate_columns()
     }
 
@@ -186,6 +214,134 @@ impl DatasetSemanticManifest {
 
         Ok(())
     }
+
+    fn validate_scan_plan(&self) -> Result<(), ManifestValidationError> {
+        match (&self.scan_plan, &self.realization.index_realization) {
+            (Some(_), IndexRealization::Implicit) | (None, IndexRealization::None) => {}
+            (Some(_), IndexRealization::None) => {
+                return Err(ManifestValidationError::ScanPlanRequiresImplicitRealization);
+            }
+            (None, IndexRealization::Implicit) => {
+                return Err(ManifestValidationError::ImplicitRealizationRequiresScanPlan);
+            }
+        }
+
+        let Some(scan_plan) = &self.scan_plan else {
+            return Ok(());
+        };
+        scan_plan.validate()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScanPlan {
+    pub axes: Vec<ScanAxis>,
+}
+
+impl ScanPlan {
+    #[must_use]
+    pub fn new(axes: Vec<ScanAxis>) -> Self {
+        Self { axes }
+    }
+
+    pub fn validate(&self) -> Result<(), ManifestValidationError> {
+        if self.axes.is_empty() {
+            return Err(ManifestValidationError::EmptyScanAxisName);
+        }
+
+        let mut seen = BTreeSet::new();
+        let mut static_count = 0;
+        let mut implicit_count = 0;
+        for axis in &self.axes {
+            axis.validate()?;
+            if !seen.insert(axis.name.clone()) {
+                return Err(ManifestValidationError::DuplicateScanAxis {
+                    name: axis.name.clone(),
+                });
+            }
+            match &axis.mode {
+                ScanAxisMode::Static { .. } => static_count += 1,
+                ScanAxisMode::ImplicitIndex => implicit_count += 1,
+            }
+        }
+
+        if implicit_count > 1 {
+            return Err(ManifestValidationError::MultipleUnknownScanAxes);
+        }
+        if implicit_count > 0 && static_count > 0 {
+            return Err(ManifestValidationError::MixedStaticAndUnknownScanAxes);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScanAxis {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub mode: ScanAxisMode,
+}
+
+impl ScanAxis {
+    #[must_use]
+    pub fn static_values(name: impl Into<String>, values: Vec<ScanAxisValue>) -> Self {
+        Self {
+            name: name.into(),
+            label: None,
+            mode: ScanAxisMode::Static { values },
+        }
+    }
+
+    #[must_use]
+    pub fn implicit_index(name: impl Into<String>, label: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            label,
+            mode: ScanAxisMode::ImplicitIndex,
+        }
+    }
+
+    fn validate(&self) -> Result<(), ManifestValidationError> {
+        if self.name.is_empty() {
+            return Err(ManifestValidationError::EmptyScanAxisName);
+        }
+        if self.name.starts_with(SYSTEM_COLUMN_PREFIX) {
+            return Err(ManifestValidationError::ReservedScanAxisName {
+                name: self.name.clone(),
+            });
+        }
+        match &self.mode {
+            ScanAxisMode::Static { values } if values.is_empty() => {
+                Err(ManifestValidationError::EmptyStaticScanAxis {
+                    name: self.name.clone(),
+                })
+            }
+            ScanAxisMode::Static { .. } | ScanAxisMode::ImplicitIndex => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum ScanAxisMode {
+    #[serde(rename = "static")]
+    Static { values: Vec<ScanAxisValue> },
+    #[serde(rename = "implicit_index")]
+    ImplicitIndex,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value")]
+pub enum ScanAxisValue {
+    #[serde(rename = "int")]
+    Int(i64),
+    #[serde(rename = "float")]
+    Float(f64),
+    #[serde(rename = "bool")]
+    Bool(bool),
+    #[serde(rename = "string")]
+    String(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -465,6 +621,8 @@ pub enum IndexRealization {
     #[default]
     #[serde(rename = "none")]
     None,
+    #[serde(rename = "implicit")]
+    Implicit,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -651,8 +809,8 @@ mod tests {
     use super::{
         ColumnMetadata, Compatibility, DatasetDType, DatasetSemanticManifest,
         DuplicateResolutionDefault, IndexRealization, ManifestColumn, ManifestValidationError,
-        RECORD_ID_COLUMN, Realization, SystemColumn, TraceAxisDType, TraceDType, TraceLayout,
-        TraceValueDType,
+        RECORD_ID_COLUMN, Realization, ScanAxis, ScanAxisMode, ScanAxisValue, ScanPlan,
+        SystemColumn, TraceAxisDType, TraceDType, TraceLayout, TraceValueDType,
     };
 
     fn signal_columns() -> BTreeMap<String, ManifestColumn> {
@@ -711,6 +869,141 @@ mod tests {
     }
 
     #[test]
+    fn scan_plan_serializes_static_axes_with_implicit_realization() {
+        let manifest = DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(
+            ScanPlan::new(vec![
+                ScanAxis::static_values(
+                    "gate",
+                    vec![ScanAxisValue::Float(-0.2), ScanAxisValue::Float(-0.1)],
+                ),
+                ScanAxis::static_values("bias", vec![ScanAxisValue::Int(0), ScanAxisValue::Int(1)]),
+            ]),
+        ));
+        let value = serde_json::to_value(&manifest).expect("serialize manifest");
+
+        assert_eq!(
+            value["scan_plan"],
+            json!({
+                "axes": [
+                    {
+                        "name": "gate",
+                        "mode": {
+                            "kind": "static",
+                            "values": [
+                                { "kind": "float", "value": -0.2 },
+                                { "kind": "float", "value": -0.1 }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "bias",
+                        "mode": {
+                            "kind": "static",
+                            "values": [
+                                { "kind": "int", "value": 0 },
+                                { "kind": "int", "value": 1 }
+                            ]
+                        }
+                    }
+                ]
+            })
+        );
+        assert_eq!(
+            value["realization"]["index_realization"],
+            json!({ "kind": "implicit" })
+        );
+
+        let parsed: DatasetSemanticManifest =
+            serde_json::from_value(value).expect("deserialize manifest");
+        assert_eq!(parsed, manifest);
+        parsed.validate().expect("manifest should be valid");
+    }
+
+    #[test]
+    fn scan_plan_serializes_unknown_length_index_axis() {
+        let manifest =
+            DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(ScanPlan::new(
+                vec![ScanAxis::implicit_index("step", Some("Step".to_string()))],
+            )));
+        let value = serde_json::to_value(&manifest).expect("serialize manifest");
+
+        assert_eq!(
+            value["scan_plan"],
+            json!({
+                "axes": [
+                    {
+                        "name": "step",
+                        "label": "Step",
+                        "mode": { "kind": "implicit_index" }
+                    }
+                ]
+            })
+        );
+        manifest.validate().expect("manifest should be valid");
+    }
+
+    #[test]
+    fn validate_scan_plan_rejects_unsupported_v1_shapes() {
+        let mixed = DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(
+            ScanPlan::new(vec![
+                ScanAxis::static_values("gate", vec![ScanAxisValue::Float(0.0)]),
+                ScanAxis::implicit_index("step", None),
+            ]),
+        ));
+        assert_eq!(
+            mixed.validate(),
+            Err(ManifestValidationError::MixedStaticAndUnknownScanAxes)
+        );
+
+        let duplicate = DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(
+            ScanPlan::new(vec![
+                ScanAxis::static_values("gate", vec![ScanAxisValue::Float(0.0)]),
+                ScanAxis::static_values("gate", vec![ScanAxisValue::Float(1.0)]),
+            ]),
+        ));
+        assert_eq!(
+            duplicate.validate(),
+            Err(ManifestValidationError::DuplicateScanAxis {
+                name: "gate".to_string()
+            })
+        );
+
+        let empty = DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(
+            ScanPlan::new(vec![ScanAxis {
+                name: "gate".to_string(),
+                label: None,
+                mode: ScanAxisMode::Static { values: vec![] },
+            }]),
+        ));
+        assert_eq!(
+            empty.validate(),
+            Err(ManifestValidationError::EmptyStaticScanAxis {
+                name: "gate".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn validate_scan_plan_requires_matching_index_realization() {
+        let mut missing_implicit = DatasetSemanticManifest::minimal(signal_columns());
+        missing_implicit.scan_plan = Some(ScanPlan::new(vec![ScanAxis::static_values(
+            "gate",
+            vec![ScanAxisValue::Float(0.0)],
+        )]));
+        assert_eq!(
+            missing_implicit.validate(),
+            Err(ManifestValidationError::ScanPlanRequiresImplicitRealization)
+        );
+
+        let mut missing_scan = DatasetSemanticManifest::minimal(signal_columns());
+        missing_scan.realization.index_realization = IndexRealization::Implicit;
+        assert_eq!(
+            missing_scan.validate(),
+            Err(ManifestValidationError::ImplicitRealizationRequiresScanPlan)
+        );
+    }
+
+    #[test]
     fn validate_rejects_invalid_version() {
         let mut manifest = DatasetSemanticManifest::minimal(signal_columns());
         manifest.manifest_version = 2;
@@ -726,6 +1019,7 @@ mod tests {
         let manifest = DatasetSemanticManifest {
             manifest_version: 1,
             columns: signal_columns(),
+            scan_plan: None,
             realization: Realization::default(),
             compatibility: Compatibility::default(),
         };

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -317,7 +317,19 @@ impl ScanAxis {
                     name: self.name.clone(),
                 })
             }
-            ScanAxisMode::Static { .. } | ScanAxisMode::ImplicitIndex => Ok(()),
+            ScanAxisMode::Static { values } => {
+                if values
+                    .iter()
+                    .any(|value| matches!(value, ScanAxisValue::Float(value) if !value.is_finite()))
+                {
+                    Err(ManifestValidationError::NonFiniteScanAxisValue {
+                        name: self.name.clone(),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+            ScanAxisMode::ImplicitIndex => Ok(()),
         }
     }
 }
@@ -978,6 +990,19 @@ mod tests {
         assert_eq!(
             empty.validate(),
             Err(ManifestValidationError::EmptyStaticScanAxis {
+                name: "gate".to_string()
+            })
+        );
+
+        let non_finite = DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(
+            ScanPlan::new(vec![ScanAxis::static_values(
+                "gate",
+                vec![ScanAxisValue::Float(f64::NAN)],
+            )]),
+        ));
+        assert_eq!(
+            non_finite.validate(),
+            Err(ManifestValidationError::NonFiniteScanAxisValue {
                 name: "gate".to_string()
             })
         );

--- a/crates/fricon/src/dataset/semantics/model.rs
+++ b/crates/fricon/src/dataset/semantics/model.rs
@@ -246,7 +246,7 @@ impl ScanPlan {
 
     pub fn validate(&self) -> Result<(), ManifestValidationError> {
         if self.axes.is_empty() {
-            return Err(ManifestValidationError::EmptyScanAxisName);
+            return Err(ManifestValidationError::EmptyScanPlan);
         }
 
         let mut seen = BTreeSet::new();
@@ -956,6 +956,13 @@ mod tests {
 
     #[test]
     fn validate_scan_plan_rejects_unsupported_v1_shapes() {
+        let empty_plan = DatasetSemanticManifest::minimal(signal_columns())
+            .with_scan_plan(Some(ScanPlan::new(vec![])));
+        assert_eq!(
+            empty_plan.validate(),
+            Err(ManifestValidationError::EmptyScanPlan)
+        );
+
         let mixed = DatasetSemanticManifest::minimal(signal_columns()).with_scan_plan(Some(
             ScanPlan::new(vec![
                 ScanAxis::static_values("gate", vec![ScanAxisValue::Float(0.0)]),

--- a/crates/fricon/src/lib.rs
+++ b/crates/fricon/src/lib.rs
@@ -23,8 +23,10 @@ pub use self::{
         DatasetInterpretation, DatasetListQuery, DatasetMetadata, DatasetReader, DatasetRecord,
         DatasetRow, DatasetScalar, DatasetSchema, DatasetSortBy, DatasetStatus, DatasetUpdate,
         FixedStepTrace, InterpretationSource, PhysicalColumnOrdinal, ResolvedColumn,
-        ResolvedDuplicatePolicy, ScalarArray, ScalarKind, SelectOptions, SortDirection, TraceKind,
-        VariableStepTrace, VisibleColumnOrdinal,
+        ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedLogicalIndexPoint,
+        ResolvedScanAxis, ResolvedScanAxisMode, ScalarArray, ScalarKind, ScanAxis, ScanAxisMode,
+        ScanAxisValue, ScanPlan, SelectOptions, SortDirection, TraceKind, VariableStepTrace,
+        VisibleColumnOrdinal,
     },
     workspace::{WorkspaceError, WorkspaceRoot, get_log_dir},
 };
@@ -35,4 +37,4 @@ const DEFAULT_DATASET_LIST_LIMIT: i64 = 200;
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Version of the IPC/gRPC protocol between clients and the workspace server.
-const IPC_PROTOCOL_VERSION: u32 = 2;
+const IPC_PROTOCOL_VERSION: u32 = 3;

--- a/crates/fricon/src/transport/grpc/create_stream.rs
+++ b/crates/fricon/src/transport/grpc/create_stream.rs
@@ -51,6 +51,8 @@ pub(crate) async fn parse_create_stream(
         ));
     };
 
+    let scan_plan = scan_plan_from_proto(scan_axes)?;
+
     let (events_tx, events_rx) = mpsc::channel(16);
     let events_task = tokio::spawn(produce_create_events(stream, shutdown_token, events_tx));
 
@@ -63,7 +65,7 @@ pub(crate) async fn parse_create_stream(
                 .into_iter()
                 .map(column_metadata_from_proto)
                 .collect(),
-            scan_plan: scan_plan_from_proto(scan_axes)?,
+            scan_plan,
         },
         events_rx,
         events_task,

--- a/crates/fricon/src/transport/grpc/create_stream.rs
+++ b/crates/fricon/src/transport/grpc/create_stream.rs
@@ -7,10 +7,14 @@ use tonic::{Code, Status, Streaming};
 use tracing::{error, instrument, warn};
 
 use crate::{
-    dataset::{CreateDatasetInput, CreateDatasetRequest, semantics::ColumnMetadata},
+    dataset::{
+        CreateDatasetInput, CreateDatasetRequest,
+        semantics::{ColumnMetadata, ScanAxis, ScanAxisMode, ScanAxisValue, ScanPlan},
+    },
     proto::{
         ColumnMetadata as ProtoColumnMetadata, CreateMetadata, CreateRequest,
-        create_request::CreateMessage,
+        ScanAxisMetadata as ProtoScanAxisMetadata, ScanAxisValue as ProtoScanAxisValue,
+        create_request::CreateMessage, scan_axis_metadata, scan_axis_value,
     },
 };
 
@@ -38,6 +42,7 @@ pub(crate) async fn parse_create_stream(
         description,
         tags,
         columns,
+        scan_axes,
     })) = first_message.create_message
     else {
         warn!("First create stream message must be metadata");
@@ -58,10 +63,58 @@ pub(crate) async fn parse_create_stream(
                 .into_iter()
                 .map(column_metadata_from_proto)
                 .collect(),
+            scan_plan: scan_plan_from_proto(scan_axes)?,
         },
         events_rx,
         events_task,
     })
+}
+
+fn scan_plan_from_proto(axes: Vec<ProtoScanAxisMetadata>) -> Result<Option<ScanPlan>, Status> {
+    if axes.is_empty() {
+        return Ok(None);
+    }
+    let axes = axes
+        .into_iter()
+        .map(scan_axis_from_proto)
+        .collect::<Result<Vec<_>, _>>()?;
+    let scan_plan = ScanPlan::new(axes);
+    scan_plan
+        .validate()
+        .map_err(|error| Status::invalid_argument(error.to_string()))?;
+    Ok(Some(scan_plan))
+}
+
+fn scan_axis_from_proto(value: ProtoScanAxisMetadata) -> Result<ScanAxis, Status> {
+    let mode = match value.axis.ok_or_else(|| {
+        Status::invalid_argument(format!("scan axis {} is missing a mode", value.name))
+    })? {
+        scan_axis_metadata::Axis::StaticAxis(axis) => {
+            let values = axis
+                .values
+                .into_iter()
+                .map(scan_axis_value_from_proto)
+                .collect::<Result<Vec<_>, _>>()?;
+            ScanAxisMode::Static { values }
+        }
+        scan_axis_metadata::Axis::IndexAxis(_) => ScanAxisMode::ImplicitIndex,
+    };
+    Ok(ScanAxis {
+        name: value.name,
+        label: value.label,
+        mode,
+    })
+}
+
+fn scan_axis_value_from_proto(value: ProtoScanAxisValue) -> Result<ScanAxisValue, Status> {
+    match value.value.ok_or_else(|| {
+        Status::invalid_argument("scan axis static value is missing a scalar value")
+    })? {
+        scan_axis_value::Value::IntValue(value) => Ok(ScanAxisValue::Int(value)),
+        scan_axis_value::Value::FloatValue(value) => Ok(ScanAxisValue::Float(value)),
+        scan_axis_value::Value::BoolValue(value) => Ok(ScanAxisValue::Bool(value)),
+        scan_axis_value::Value::StringValue(value) => Ok(ScanAxisValue::String(value)),
+    }
 }
 
 fn column_metadata_from_proto(value: ProtoColumnMetadata) -> ColumnMetadata {
@@ -245,7 +298,9 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::proto::{ColumnMetadata as ProtoColumnMetadata, CreateAbort, CreateFinish};
+    use crate::proto::{
+        ColumnMetadata as ProtoColumnMetadata, CreateAbort, CreateFinish, StaticScanAxis,
+    };
 
     fn payload_message(payload: bytes::Bytes) -> CreateRequest {
         CreateRequest {
@@ -272,6 +327,7 @@ mod tests {
                 description: "desc".to_string(),
                 tags: vec![],
                 columns: vec![],
+                scan_axes: vec![],
             })),
         }
     }
@@ -288,6 +344,32 @@ mod tests {
                     label: Some("Voltage".to_string()),
                     hidden_by_default: true,
                     chart_axis: true,
+                }],
+                scan_axes: vec![],
+            })),
+        }
+    }
+
+    fn metadata_message_with_scan() -> CreateRequest {
+        CreateRequest {
+            create_message: Some(CreateMessage::Metadata(CreateMetadata {
+                name: "name".to_string(),
+                description: "desc".to_string(),
+                tags: vec![],
+                columns: vec![],
+                scan_axes: vec![ProtoScanAxisMetadata {
+                    name: "gate".to_string(),
+                    label: None,
+                    axis: Some(scan_axis_metadata::Axis::StaticAxis(StaticScanAxis {
+                        values: vec![
+                            ProtoScanAxisValue {
+                                value: Some(scan_axis_value::Value::FloatValue(-0.2)),
+                            },
+                            ProtoScanAxisValue {
+                                value: Some(scan_axis_value::Value::FloatValue(-0.1)),
+                            },
+                        ],
+                    })),
                 }],
             })),
         }
@@ -355,6 +437,29 @@ mod tests {
         assert_eq!(column.label.as_deref(), Some("Voltage"));
         assert!(column.hidden_by_default);
         assert!(column.chart_axis);
+    }
+
+    #[test]
+    fn scan_metadata_conversion_preserves_fields() {
+        let CreateMessage::Metadata(metadata) = metadata_message_with_scan()
+            .create_message
+            .expect("metadata message")
+        else {
+            panic!("expected metadata");
+        };
+        let scan_plan = scan_plan_from_proto(metadata.scan_axes)
+            .expect("scan conversion")
+            .expect("scan plan");
+
+        assert_eq!(scan_plan.axes.len(), 1);
+        assert_eq!(scan_plan.axes[0].name, "gate");
+        let ScanAxisMode::Static { values } = &scan_plan.axes[0].mode else {
+            panic!("expected static axis");
+        };
+        assert_eq!(
+            values,
+            &[ScanAxisValue::Float(-0.2), ScanAxisValue::Float(-0.1)]
+        );
     }
 
     #[tokio::test]

--- a/crates/fricon/tests/integration_test.rs
+++ b/crates/fricon/tests/integration_test.rs
@@ -224,6 +224,7 @@ async fn test_dataset_create_metadata_payload_finish_completes() -> anyhow::Resu
             vec!["test".to_string(), "integration".to_string()],
             test_schema.clone(),
             Vec::new(),
+            None,
         )
         .await?;
 
@@ -337,6 +338,7 @@ async fn test_dataset_create_abort_returns_aborted_metadata() -> anyhow::Result<
             vec!["test".to_string(), "abort".to_string()],
             test_schema,
             Vec::new(),
+            None,
         )
         .await?;
 
@@ -399,6 +401,7 @@ async fn test_dataset_create_without_finish_is_aborted() -> anyhow::Result<()> {
             vec!["test".to_string(), "abort".to_string()],
             test_schema.clone(),
             Vec::new(),
+            None,
         )
         .await?;
 
@@ -559,6 +562,7 @@ async fn test_deleted_dataset_returns_typed_deleted_error() -> anyhow::Result<()
             vec!["test".to_string()],
             test_schema,
             Vec::new(),
+            None,
         )
         .await?;
     writer.write(create_test_rows().remove(0)).await?;

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -57,10 +57,10 @@ directory. A dataset is modeled as one logical Arrow table split across
 
 New datasets created through ingest also store `dataset_manifest.json` beside
 the chunk files. The manifest records v1 dataset semantic columns, realization
-defaults, and compatibility settings. New semantic datasets physically
-materialize the Fricon-owned `__ds_record_id: uint64` system column as the
-first Arrow column. Earlier transition snapshots may contain manifests that
-declare `__ds_record_id` before the Arrow chunks materialized that column.
+defaults, optional scan plans, and compatibility settings. New semantic datasets
+physically materialize the Fricon-owned `__ds_record_id: uint64` system column
+as the first Arrow column. Earlier transition snapshots may contain manifests
+that declare `__ds_record_id` before the Arrow chunks materialized that column.
 
 The physical storage layout is an implementation detail. User-facing docs may
 mention Arrow-compatible tables, but should avoid promising exact file names,
@@ -72,8 +72,9 @@ Current dataset catalog metadata lives in SQLite. This includes dataset name,
 description, favorite state, status, timestamps, and tags as represented by
 `DatasetRecord` / `DatasetMetadata`.
 
-Dataset payload facts live in Arrow chunk files. Dataset semantic defaults and
-compatibility settings for new ingested datasets live in `dataset_manifest.json`.
+Dataset payload facts live in Arrow chunk files. Dataset semantic defaults,
+optional scan plans, and compatibility settings for new ingested datasets live
+in `dataset_manifest.json`.
 
 Dataset archives store catalog metadata in `metadata.json`, Arrow payload chunks
 under `data/data_chunk_<n>.arrow`, and `dataset_manifest.json` as an optional


### PR DESCRIPTION
## Summary
- Add Python `scan=` creation metadata with `IndexAxis` support and round-trip it through the Rust client, gRPC transport, and dataset manifest
- Resolve implicit logical indices from `__ds_record_id` for ordered scans and single unknown-length scans
- Keep legacy manifests and non-scan datasets on the existing interpretation path

closes #483

## Testing
- Rust formatting, clippy, and `cargo nextest` passed
- Python bindings rebuilt with `uv run maturin develop`
- Python integration tests and `stubtest fricon._core` passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kahojyun/fricon/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
