### PR TITLE
feat: migrate charts to resolved dataset semantics

### DIFF
--- a/.changeset/desktop-chart-semantics.md
+++ b/.changeset/desktop-chart-semantics.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Resolve desktop charts from dataset scan semantics
+
+Desktop charts now use explicit dataset scan semantics for default axes,
+filters, heatmaps, and live views, while preserving legacy inferred-index chart
+behavior for older datasets.

--- a/crates/fricon-ui/frontend/src/app/ui/DatasetInspector.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/app/ui/DatasetInspector.browser.test.tsx
@@ -51,6 +51,7 @@ function makeDetail(overrides: Partial<DatasetDetail> = {}): DatasetDetail {
     deletedAt: null,
     payloadAvailable: true,
     columns: [],
+    chartSemantics: null,
     ...overrides,
   };
 }

--- a/crates/fricon-ui/frontend/src/features/charts/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/api/types.ts
@@ -24,21 +24,58 @@ export type {
 
 export interface ColumnInfo {
   name: string;
+  label?: string | null;
   isComplex: boolean;
   isTrace: boolean;
   isIndex: boolean;
+  hiddenByDefault?: boolean;
+  isChartAxisCandidate?: boolean;
+}
+
+export type ChartSemanticAxisKind = "logical_index" | "column";
+
+export interface ChartSemanticColumn {
+  id: string;
+  name: string;
+  label: string | null;
+  isComplex: boolean;
+  isTrace: boolean;
+  hiddenByDefault: boolean;
+}
+
+export interface ChartSemanticAxis {
+  id: string;
+  name: string;
+  label: string | null;
+  kind: ChartSemanticAxisKind;
+  numeric: boolean;
+  isCompatibility: boolean;
+  physicalColumn: string | null;
+}
+
+export interface ChartSemantics {
+  source: "manifest" | "compatibility_inference";
+  duplicatePolicy:
+    | "latest_by_record_id"
+    | "compatibility_row_order_placeholder";
+  indexRealization: "none" | "implicit" | "sidecar";
+  axes: ChartSemanticAxis[];
+  valueColumns: ChartSemanticColumn[];
+  chartAxisCandidates: ChartSemanticAxis[];
 }
 
 export interface DatasetDetail {
   status: DatasetStatus;
   payloadAvailable: boolean;
   columns: ColumnInfo[];
+  chartSemantics?: ChartSemantics | null;
 }
 
 export type ChartViewerAvailability = "loading" | "available" | "tombstone";
 
 export interface FilterTableData {
   fields: string[];
+  fieldLabels: Record<string, string>;
   rows: FilterTableRow[];
   columnUniqueValues: Record<string, ColumnUniqueValue[]>;
 }
@@ -198,6 +235,7 @@ export function normalizeFilterTableData(
   );
   return {
     fields: result.fields,
+    fieldLabels: result.fieldLabels ?? {},
     rows: result.rows,
     columnUniqueValues,
   };

--- a/crates/fricon-ui/frontend/src/features/charts/hooks/useChartViewerSelection.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/hooks/useChartViewerSelection.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ColumnInfo, DatasetStatus } from "../api/types";
+import type { ChartSemantics, ColumnInfo, DatasetStatus } from "../api/types";
 import type {
   ChartView,
   ComplexViewOption,
@@ -48,6 +48,7 @@ export interface ChartViewerControlActions {
 export function useChartViewerSelection(
   columns: ColumnInfo[],
   datasetStatus?: DatasetStatus,
+  chartSemantics?: ChartSemantics | null,
 ) {
   const [view, setView] = useState<ChartView>("xy");
   const [plotMode, setPlotMode] = useState<XYPlotMode>("quantity_vs_sweep");
@@ -91,20 +92,24 @@ export function useChartViewerSelection(
   const isLiveMode =
     currentLiveModeSelection?.value ?? datasetStatus === "Writing";
 
-  const derived = deriveChartViewerState(columns, {
-    view,
-    plotMode,
-    drawStyle,
-    sweepQuantityName,
-    heatmapQuantityName,
-    complexPlaneQuantityName,
-    xyXName,
-    xyYName,
-    heatmapXName,
-    heatmapYName,
-    traceGroupIndexColumnNames,
-    sweepIndexColumnName,
-  });
+  const derived = deriveChartViewerState(
+    columns,
+    {
+      view,
+      plotMode,
+      drawStyle,
+      sweepQuantityName,
+      heatmapQuantityName,
+      complexPlaneQuantityName,
+      xyXName,
+      xyYName,
+      heatmapXName,
+      heatmapYName,
+      traceGroupIndexColumnNames,
+      sweepIndexColumnName,
+    },
+    chartSemantics,
+  );
 
   const controlState: ChartViewerControlState = {
     selectedComplexView,

--- a/crates/fricon-ui/frontend/src/features/charts/model/cascadeReducer.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/cascadeReducer.test.ts
@@ -8,6 +8,7 @@ import {
 
 const data: FilterTableData = {
   fields: ["A", "B"],
+  fieldLabels: {},
   rows: [
     { index: 1, displayValues: ["A1", "B1"], valueIndices: [1, 1] },
     { index: 2, displayValues: ["A2", "B1"], valueIndices: [2, 1] },

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
@@ -55,6 +55,7 @@ function makeDatasetDetail(columns: ColumnInfo[]): DatasetDetail {
 function makeFilterTableData(): FilterTableData {
   return {
     fields: ["idxA"],
+    fieldLabels: {},
     rows: [{ index: 1, displayValues: ["1"], valueIndices: [1] }],
     columnUniqueValues: {
       idxA: [{ index: 1, displayValue: "1" }],
@@ -267,5 +268,69 @@ describe("chartViewerLogic", () => {
       indexFilters: undefined,
       excludeColumns: [],
     });
+  });
+
+  it("uses resolved chart semantics for value and logical axis defaults", () => {
+    const columns = [
+      makeColumn({ name: "legacyGuess", isIndex: true }),
+      makeColumn({ name: "hiddenValue" }),
+      makeColumn({ name: "signal" }),
+    ];
+    const derived = deriveChartViewerState(
+      columns,
+      makeState({ view: "heatmap" }),
+      {
+        source: "manifest",
+        duplicatePolicy: "latest_by_record_id",
+        indexRealization: "implicit",
+        axes: [
+          {
+            id: "logicalIndex:gate",
+            name: "gate",
+            label: "Gate",
+            kind: "logical_index",
+            numeric: true,
+            isCompatibility: false,
+            physicalColumn: null,
+          },
+          {
+            id: "logicalIndex:bias",
+            name: "bias",
+            label: "Bias",
+            kind: "logical_index",
+            numeric: true,
+            isCompatibility: false,
+            physicalColumn: null,
+          },
+        ],
+        valueColumns: [
+          {
+            id: "column:hiddenValue",
+            name: "hiddenValue",
+            label: "Hidden",
+            isComplex: false,
+            isTrace: false,
+            hiddenByDefault: true,
+          },
+          {
+            id: "column:signal",
+            name: "signal",
+            label: "Signal",
+            isComplex: false,
+            isTrace: false,
+            hiddenByDefault: false,
+          },
+        ],
+        chartAxisCandidates: [],
+      },
+    );
+
+    expect(derived.effectiveHeatmapQuantityName).toBe("column:signal");
+    expect(derived.effectiveHeatmapXName).toBe("logicalIndex:bias");
+    expect(derived.effectiveHeatmapYName).toBe("logicalIndex:gate");
+    expect(derived.excludeColumns).toEqual([
+      "logicalIndex:bias",
+      "logicalIndex:gate",
+    ]);
   });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
@@ -336,10 +336,9 @@ describe("chartViewerLogic", () => {
     );
 
     expect(derived.effectiveHeatmapQuantityName).toBe("column:signal");
-    expect(derived.heatmapQuantityOptions.map((column) => column.name)).toEqual([
-      "column:signal",
-      "column:hiddenValue",
-    ]);
+    expect(derived.heatmapQuantityOptions.map((column) => column.name)).toEqual(
+      ["column:signal", "column:hiddenValue"],
+    );
     expect(derived.heatmapXOptions.map((column) => column.name)).toEqual([
       "column:physicalAxis",
       "logicalIndex:gate",
@@ -545,6 +544,8 @@ describe("chartViewerLogic", () => {
       "column:step",
     ]);
     expect(derived.effectiveSweepIndexColumnName).toBe("column:step");
-    expect(derived.liveMonitorTraceGroupIndexColumnNames).toEqual(["column:run"]);
+    expect(derived.liveMonitorTraceGroupIndexColumnNames).toEqual([
+      "column:run",
+    ]);
   });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
@@ -418,6 +418,66 @@ describe("chartViewerLogic", () => {
     );
   });
 
+  it("keeps categorical logical axes available for grouping roles", () => {
+    const columns = [
+      makeColumn({ name: "gate" }),
+      makeColumn({ name: "signal" }),
+    ];
+    const derived = deriveChartViewerState(
+      columns,
+      makeState({
+        traceGroupIndexColumnNames: ["logicalIndex:gate"],
+      }),
+      {
+        source: "manifest",
+        duplicatePolicy: "latest_by_record_id",
+        indexRealization: "implicit",
+        axes: [
+          {
+            id: "logicalIndex:gate",
+            name: "gate",
+            label: "Gate",
+            kind: "logical_index",
+            numeric: false,
+            isCompatibility: false,
+            physicalColumn: null,
+          },
+          {
+            id: "logicalIndex:bias",
+            name: "bias",
+            label: "Bias",
+            kind: "logical_index",
+            numeric: true,
+            isCompatibility: false,
+            physicalColumn: null,
+          },
+        ],
+        valueColumns: [
+          {
+            id: "column:signal",
+            name: "signal",
+            label: "Signal",
+            isComplex: false,
+            isTrace: false,
+            hiddenByDefault: false,
+          },
+        ],
+        chartAxisCandidates: [],
+      },
+    );
+
+    expect(derived.heatmapXOptions.map((column) => column.name)).toEqual([
+      "logicalIndex:bias",
+    ]);
+    expect(derived.traceGroupOptions.map((column) => column.name)).toContain(
+      "logicalIndex:gate",
+    );
+    expect(derived.effectiveTraceGroupIndexColumnNames).toEqual([
+      "logicalIndex:gate",
+    ]);
+    expect(derived.effectiveSweepIndexColumnName).toBe("logicalIndex:bias");
+  });
+
   it("keeps compatibility index axes available for sweep/group roles", () => {
     const columns = [
       makeColumn({ name: "run", isIndex: true }),

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
@@ -321,16 +321,100 @@ describe("chartViewerLogic", () => {
             hiddenByDefault: false,
           },
         ],
-        chartAxisCandidates: [],
+        chartAxisCandidates: [
+          {
+            id: "column:physicalAxis",
+            name: "physicalAxis",
+            label: "Physical Axis",
+            kind: "column",
+            numeric: true,
+            isCompatibility: false,
+            physicalColumn: "physicalAxis",
+          },
+        ],
       },
     );
 
     expect(derived.effectiveHeatmapQuantityName).toBe("column:signal");
+    expect(derived.heatmapQuantityOptions.map((column) => column.name)).toEqual([
+      "column:signal",
+      "column:hiddenValue",
+    ]);
+    expect(derived.heatmapXOptions.map((column) => column.name)).toEqual([
+      "column:physicalAxis",
+      "logicalIndex:gate",
+      "logicalIndex:bias",
+    ]);
     expect(derived.effectiveHeatmapXName).toBe("logicalIndex:bias");
     expect(derived.effectiveHeatmapYName).toBe("logicalIndex:gate");
     expect(derived.excludeColumns).toEqual([
       "logicalIndex:bias",
       "logicalIndex:gate",
     ]);
+  });
+
+  it("excludes physical chart-axis candidates from sweep/group roles", () => {
+    const columns = [
+      makeColumn({ name: "physicalAxis" }),
+      makeColumn({ name: "signal" }),
+    ];
+    const derived = deriveChartViewerState(columns, makeState(), {
+      source: "manifest",
+      duplicatePolicy: "latest_by_record_id",
+      indexRealization: "implicit",
+      axes: [
+        {
+          id: "logicalIndex:gate",
+          name: "gate",
+          label: "Gate",
+          kind: "logical_index",
+          numeric: true,
+          isCompatibility: false,
+          physicalColumn: null,
+        },
+        {
+          id: "logicalIndex:bias",
+          name: "bias",
+          label: "Bias",
+          kind: "logical_index",
+          numeric: true,
+          isCompatibility: false,
+          physicalColumn: null,
+        },
+      ],
+      valueColumns: [
+        {
+          id: "column:signal",
+          name: "signal",
+          label: "Signal",
+          isComplex: false,
+          isTrace: false,
+          hiddenByDefault: false,
+        },
+      ],
+      chartAxisCandidates: [
+        {
+          id: "column:physicalAxis",
+          name: "physicalAxis",
+          label: "Physical Axis",
+          kind: "column",
+          numeric: true,
+          isCompatibility: false,
+          physicalColumn: "physicalAxis",
+        },
+      ],
+    });
+
+    expect(derived.liveMonitorTraceGroupIndexColumnNames).toEqual([
+      "logicalIndex:gate",
+    ]);
+    expect(derived.liveMonitorSweepIndexColumnName).toBe("logicalIndex:bias");
+    expect(derived.sweepAxisOptions.map((column) => column.name)).toEqual([
+      "logicalIndex:gate",
+      "logicalIndex:bias",
+    ]);
+    expect(derived.heatmapXOptions.map((column) => column.name)).toContain(
+      "column:physicalAxis",
+    );
   });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.test.ts
@@ -417,4 +417,74 @@ describe("chartViewerLogic", () => {
       "column:physicalAxis",
     );
   });
+
+  it("keeps compatibility index axes available for sweep/group roles", () => {
+    const columns = [
+      makeColumn({ name: "run", isIndex: true }),
+      makeColumn({ name: "step", isIndex: true }),
+      makeColumn({ name: "signal" }),
+    ];
+    const derived = deriveChartViewerState(columns, makeState(), {
+      source: "compatibility_inference",
+      duplicatePolicy: "compatibility_row_order_placeholder",
+      indexRealization: "none",
+      axes: [
+        {
+          id: "column:run",
+          name: "run",
+          label: null,
+          kind: "column",
+          numeric: true,
+          isCompatibility: true,
+          physicalColumn: "run",
+        },
+        {
+          id: "column:step",
+          name: "step",
+          label: null,
+          kind: "column",
+          numeric: true,
+          isCompatibility: true,
+          physicalColumn: "step",
+        },
+      ],
+      valueColumns: [
+        {
+          id: "column:signal",
+          name: "signal",
+          label: null,
+          isComplex: false,
+          isTrace: false,
+          hiddenByDefault: false,
+        },
+      ],
+      chartAxisCandidates: [
+        {
+          id: "column:run",
+          name: "run",
+          label: null,
+          kind: "column",
+          numeric: true,
+          isCompatibility: false,
+          physicalColumn: "run",
+        },
+        {
+          id: "column:step",
+          name: "step",
+          label: null,
+          kind: "column",
+          numeric: true,
+          isCompatibility: false,
+          physicalColumn: "step",
+        },
+      ],
+    });
+
+    expect(derived.sweepAxisOptions.map((column) => column.name)).toEqual([
+      "column:run",
+      "column:step",
+    ]);
+    expect(derived.effectiveSweepIndexColumnName).toBe("column:step");
+    expect(derived.liveMonitorTraceGroupIndexColumnNames).toEqual(["column:run"]);
+  });
 });

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
@@ -40,6 +40,7 @@ export interface ChartViewerSelectionState {
 export interface ChartColumnOption extends ColumnInfo {
   label: string | null;
   hiddenByDefault: boolean;
+  numeric: boolean;
 }
 
 export function columnOptionLabel(option: Pick<ChartColumnOption, "label" | "name">) {
@@ -61,6 +62,7 @@ function semanticValueOptions(
         ...column,
         label: column.label ?? null,
         hiddenByDefault: column.hiddenByDefault ?? false,
+        numeric: true,
       }));
   }
 
@@ -71,6 +73,7 @@ function semanticValueOptions(
     isTrace: column.isTrace,
     isIndex: false,
     hiddenByDefault: column.hiddenByDefault,
+    numeric: false,
   }));
   const visibleValues = values.filter((column) => !column.hiddenByDefault);
   const hiddenValues = values.filter((column) => column.hiddenByDefault);
@@ -90,6 +93,7 @@ function semanticAxisOptions(
         ...column,
         label: column.label ?? null,
         hiddenByDefault: column.hiddenByDefault ?? false,
+        numeric: true,
       }));
   }
 
@@ -104,7 +108,6 @@ function semanticAxisOptions(
     ...chartSemantics.axes,
   ];
   return orderedAxes
-    .filter((axis) => axis.numeric)
     .filter((axis) => {
       if (seen.has(axis.id)) return false;
       seen.add(axis.id);
@@ -118,6 +121,7 @@ function semanticAxisOptions(
       isIndex: true,
       hiddenByDefault: false,
       isChartAxisCandidate: axis.kind === "column" && !axis.isCompatibility,
+      numeric: axis.numeric,
     }));
 }
 
@@ -158,9 +162,13 @@ export function deriveChartViewerState(
   chartSemantics?: ChartSemantics | null,
 ) {
   const indexColumns = semanticAxisOptions(columns, chartSemantics);
+  const plottedIndexColumns = indexColumns.filter((column) => column.numeric);
   const roleIndexColumns = chartSemantics
     ? indexColumns.filter((column) => !column.isChartAxisCandidate)
     : indexColumns;
+  const sweepRoleIndexColumns = roleIndexColumns.filter(
+    (column) => column.numeric,
+  );
   const valueColumns = semanticValueOptions(columns, chartSemantics);
   const allColumns = [...valueColumns, ...indexColumns];
   const sweepQuantityOptions = valueColumns;
@@ -178,7 +186,7 @@ export function deriveChartViewerState(
   const availableViews = (() => {
     const views: ChartView[] = [];
     if (valueColumns.length > 0) views.push("xy");
-    if (valueColumns.length > 0 && indexColumns.length > 0)
+    if (valueColumns.length > 0 && plottedIndexColumns.length > 0)
       views.push("heatmap");
     return views;
   })();
@@ -252,8 +260,8 @@ export function deriveChartViewerState(
   );
   const xyYColumn = allColumns.find((column) => column.name === effectiveXYYName);
 
-  const heatmapXOptions = indexColumns;
-  const heatmapYOptions = indexColumns;
+  const heatmapXOptions = plottedIndexColumns;
+  const heatmapYOptions = plottedIndexColumns;
   const effectiveHeatmapXName = pickSelection(
     heatmapXOptions,
     state.heatmapXName,
@@ -294,11 +302,13 @@ export function deriveChartViewerState(
     activeXYSource !== undefined &&
     roleIndexColumns.length > 0;
   const liveMonitorSweepIndexColumnName = liveMonitorUsesForcedRoles
-    ? (roleIndexColumns[roleIndexColumns.length - 1]?.name ?? null)
+    ? (sweepRoleIndexColumns[sweepRoleIndexColumns.length - 1]?.name ?? null)
     : null;
   const liveMonitorTraceGroupIndexColumnNames =
     liveMonitorUsesForcedRoles && roleIndexColumns.length > 1
-      ? roleIndexColumns.slice(0, -1).map((column) => column.name)
+      ? roleIndexColumns
+          .filter((column) => column.name !== liveMonitorSweepIndexColumnName)
+          .map((column) => column.name)
       : [];
 
   const xyRoleControlsVisible =
@@ -308,7 +318,7 @@ export function deriveChartViewerState(
     activeXYSource !== undefined;
 
   const sweepAxisOptions = xyRoleControlsVisible
-    ? roleIndexColumns.filter(
+    ? sweepRoleIndexColumns.filter(
         (column) => !state.traceGroupIndexColumnNames.includes(column.name),
       )
     : [];

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
@@ -73,7 +73,10 @@ function semanticValueOptions(
     hiddenByDefault: column.hiddenByDefault,
   }));
   const visibleValues = values.filter((column) => !column.hiddenByDefault);
-  return visibleValues.length > 0 ? visibleValues : values;
+  const hiddenValues = values.filter((column) => column.hiddenByDefault);
+  return visibleValues.length > 0
+    ? [...visibleValues, ...hiddenValues]
+    : values;
 }
 
 function semanticAxisOptions(
@@ -105,6 +108,7 @@ function semanticAxisOptions(
       isTrace: false,
       isIndex: true,
       hiddenByDefault: false,
+      isChartAxisCandidate: axis.kind === "column" && !axis.isCompatibility,
     }));
 }
 
@@ -145,6 +149,9 @@ export function deriveChartViewerState(
   chartSemantics?: ChartSemantics | null,
 ) {
   const indexColumns = semanticAxisOptions(columns, chartSemantics);
+  const roleIndexColumns = chartSemantics
+    ? indexColumns.filter((column) => !column.isChartAxisCandidate)
+    : indexColumns;
   const valueColumns = semanticValueOptions(columns, chartSemantics);
   const allColumns = [...valueColumns, ...indexColumns];
   const sweepQuantityOptions = valueColumns;
@@ -276,23 +283,23 @@ export function deriveChartViewerState(
     effectiveView === "xy" &&
     !xyUsesTraceSource &&
     activeXYSource !== undefined &&
-    indexColumns.length > 0;
+    roleIndexColumns.length > 0;
   const liveMonitorSweepIndexColumnName = liveMonitorUsesForcedRoles
-    ? (indexColumns[indexColumns.length - 1]?.name ?? null)
+    ? (roleIndexColumns[roleIndexColumns.length - 1]?.name ?? null)
     : null;
   const liveMonitorTraceGroupIndexColumnNames =
-    liveMonitorUsesForcedRoles && indexColumns.length > 1
-      ? indexColumns.slice(0, -1).map((column) => column.name)
+    liveMonitorUsesForcedRoles && roleIndexColumns.length > 1
+      ? roleIndexColumns.slice(0, -1).map((column) => column.name)
       : [];
 
   const xyRoleControlsVisible =
     effectiveView === "xy" &&
     !xyUsesTraceSource &&
-    indexColumns.length > 0 &&
+    roleIndexColumns.length > 0 &&
     activeXYSource !== undefined;
 
   const sweepAxisOptions = xyRoleControlsVisible
-    ? indexColumns.filter(
+    ? roleIndexColumns.filter(
         (column) => !state.traceGroupIndexColumnNames.includes(column.name),
       )
     : [];
@@ -310,7 +317,7 @@ export function deriveChartViewerState(
   );
 
   const traceGroupOptions = xyRoleControlsVisible
-    ? indexColumns.filter(
+    ? roleIndexColumns.filter(
         (column) => column.name !== effectiveSweepIndexColumnName,
       )
     : [];

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
@@ -43,7 +43,9 @@ export interface ChartColumnOption extends ColumnInfo {
   numeric: boolean;
 }
 
-export function columnOptionLabel(option: Pick<ChartColumnOption, "label" | "name">) {
+export function columnOptionLabel(
+  option: Pick<ChartColumnOption, "label" | "name">,
+) {
   return option.label ?? stripSemanticPrefix(option.name);
 }
 
@@ -250,7 +252,9 @@ export function deriveChartViewerState(
         ? scalarXYColumnOptions
         : traceXYColumnOptions;
   const effectiveXYXName = pickSelection(xyXOptions, state.xyXName);
-  const xyXColumn = allColumns.find((column) => column.name === effectiveXYXName);
+  const xyXColumn = allColumns.find(
+    (column) => column.name === effectiveXYXName,
+  );
   const xyYOptions = xyXColumn?.isTrace
     ? traceXYColumnOptions
     : scalarXYColumnOptions;
@@ -258,7 +262,9 @@ export function deriveChartViewerState(
     xyYOptions.filter((column) => column.name !== effectiveXYXName),
     state.xyYName,
   );
-  const xyYColumn = allColumns.find((column) => column.name === effectiveXYYName);
+  const xyYColumn = allColumns.find(
+    (column) => column.name === effectiveXYYName,
+  );
 
   const heatmapXOptions = plottedIndexColumns;
   const heatmapYOptions = plottedIndexColumns;

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
@@ -94,7 +94,16 @@ function semanticAxisOptions(
   }
 
   const seen = new Set<string>();
-  return [...chartSemantics.chartAxisCandidates, ...chartSemantics.axes]
+  const semanticAxisById = new Map(
+    chartSemantics.axes.map((axis) => [axis.id, axis]),
+  );
+  const orderedAxes = [
+    ...chartSemantics.chartAxisCandidates.map(
+      (axis) => semanticAxisById.get(axis.id) ?? axis,
+    ),
+    ...chartSemantics.axes,
+  ];
+  return orderedAxes
     .filter((axis) => axis.numeric)
     .filter((axis) => {
       if (seen.has(axis.id)) return false;

--- a/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
+++ b/crates/fricon-ui/frontend/src/features/charts/model/chartViewerLogic.ts
@@ -1,4 +1,4 @@
-import type { ColumnInfo, DatasetDetail } from "../api/types";
+import type { ChartSemantics, ColumnInfo, DatasetDetail } from "../api/types";
 import type {
   ChartDataOptions,
   FilterTableData,
@@ -37,8 +37,79 @@ export interface ChartViewerSelectionState {
   sweepIndexColumnName: string | null;
 }
 
+export interface ChartColumnOption extends ColumnInfo {
+  label: string | null;
+  hiddenByDefault: boolean;
+}
+
+export function columnOptionLabel(option: Pick<ChartColumnOption, "label" | "name">) {
+  return option.label ?? stripSemanticPrefix(option.name);
+}
+
+function stripSemanticPrefix(value: string) {
+  return value.replace(/^column:/, "").replace(/^logicalIndex:/, "");
+}
+
+function semanticValueOptions(
+  columns: ColumnInfo[],
+  chartSemantics?: ChartSemantics | null,
+): ChartColumnOption[] {
+  if (!chartSemantics) {
+    return columns
+      .filter((column) => !column.isIndex)
+      .map((column) => ({
+        ...column,
+        label: column.label ?? null,
+        hiddenByDefault: column.hiddenByDefault ?? false,
+      }));
+  }
+
+  const values = chartSemantics.valueColumns.map((column) => ({
+    name: column.id,
+    label: column.label ?? column.name,
+    isComplex: column.isComplex,
+    isTrace: column.isTrace,
+    isIndex: false,
+    hiddenByDefault: column.hiddenByDefault,
+  }));
+  const visibleValues = values.filter((column) => !column.hiddenByDefault);
+  return visibleValues.length > 0 ? visibleValues : values;
+}
+
+function semanticAxisOptions(
+  columns: ColumnInfo[],
+  chartSemantics?: ChartSemantics | null,
+): ChartColumnOption[] {
+  if (!chartSemantics) {
+    return columns
+      .filter((column) => column.isIndex)
+      .map((column) => ({
+        ...column,
+        label: column.label ?? null,
+        hiddenByDefault: column.hiddenByDefault ?? false,
+      }));
+  }
+
+  const seen = new Set<string>();
+  return [...chartSemantics.chartAxisCandidates, ...chartSemantics.axes]
+    .filter((axis) => axis.numeric)
+    .filter((axis) => {
+      if (seen.has(axis.id)) return false;
+      seen.add(axis.id);
+      return true;
+    })
+    .map((axis) => ({
+      name: axis.id,
+      label: axis.label ?? axis.name,
+      isComplex: false,
+      isTrace: false,
+      isIndex: true,
+      hiddenByDefault: false,
+    }));
+}
+
 function pickSelection(
-  options: ColumnInfo[],
+  options: ChartColumnOption[],
   current: string | null,
   defaultIndex = 0,
 ): string | null {
@@ -49,7 +120,7 @@ function pickSelection(
 }
 
 function pickOptionalSelection(
-  options: ColumnInfo[],
+  options: ChartColumnOption[],
   current: string | null,
   fallback: "last" | null,
 ): string | null {
@@ -71,25 +142,27 @@ const drawStyleOptions: { label: string; value: XYDrawStyle }[] = [
 export function deriveChartViewerState(
   columns: ColumnInfo[],
   state: ChartViewerSelectionState,
+  chartSemantics?: ChartSemantics | null,
 ) {
-  const indexColumns = columns.filter((column) => column.isIndex);
-  const nonIndexColumns = columns.filter((column) => !column.isIndex);
-  const sweepQuantityOptions = nonIndexColumns;
-  const heatmapQuantityOptions = nonIndexColumns;
-  const complexPlaneQuantityOptions = nonIndexColumns.filter(
+  const indexColumns = semanticAxisOptions(columns, chartSemantics);
+  const valueColumns = semanticValueOptions(columns, chartSemantics);
+  const allColumns = [...valueColumns, ...indexColumns];
+  const sweepQuantityOptions = valueColumns;
+  const heatmapQuantityOptions = valueColumns;
+  const complexPlaneQuantityOptions = valueColumns.filter(
     (column) => column.isComplex,
   );
-  const scalarXYColumnOptions = nonIndexColumns.filter(
+  const scalarXYColumnOptions = valueColumns.filter(
     (column) => !column.isComplex && !column.isTrace,
   );
-  const traceXYColumnOptions = nonIndexColumns.filter(
+  const traceXYColumnOptions = valueColumns.filter(
     (column) => !column.isComplex && column.isTrace,
   );
 
   const availableViews = (() => {
     const views: ChartView[] = [];
-    if (nonIndexColumns.length > 0) views.push("xy");
-    if (nonIndexColumns.length > 0 && indexColumns.length > 0)
+    if (valueColumns.length > 0) views.push("xy");
+    if (valueColumns.length > 0 && indexColumns.length > 0)
       views.push("heatmap");
     return views;
   })();
@@ -126,7 +199,7 @@ export function deriveChartViewerState(
     sweepQuantityOptions,
     state.sweepQuantityName,
   );
-  const sweepQuantity = columns.find(
+  const sweepQuantity = allColumns.find(
     (column) => column.name === effectiveSweepQuantityName,
   );
 
@@ -134,7 +207,7 @@ export function deriveChartViewerState(
     heatmapQuantityOptions,
     state.heatmapQuantityName,
   );
-  const heatmapQuantity = columns.find(
+  const heatmapQuantity = allColumns.find(
     (column) => column.name === effectiveHeatmapQuantityName,
   );
 
@@ -142,7 +215,7 @@ export function deriveChartViewerState(
     complexPlaneQuantityOptions,
     state.complexPlaneQuantityName,
   );
-  const complexPlaneQuantity = columns.find(
+  const complexPlaneQuantity = allColumns.find(
     (column) => column.name === effectiveComplexPlaneQuantityName,
   );
 
@@ -153,7 +226,7 @@ export function deriveChartViewerState(
         ? scalarXYColumnOptions
         : traceXYColumnOptions;
   const effectiveXYXName = pickSelection(xyXOptions, state.xyXName);
-  const xyXColumn = columns.find((column) => column.name === effectiveXYXName);
+  const xyXColumn = allColumns.find((column) => column.name === effectiveXYXName);
   const xyYOptions = xyXColumn?.isTrace
     ? traceXYColumnOptions
     : scalarXYColumnOptions;
@@ -161,7 +234,7 @@ export function deriveChartViewerState(
     xyYOptions.filter((column) => column.name !== effectiveXYXName),
     state.xyYName,
   );
-  const xyYColumn = columns.find((column) => column.name === effectiveXYYName);
+  const xyYColumn = allColumns.find((column) => column.name === effectiveXYYName);
 
   const heatmapXOptions = indexColumns;
   const heatmapYOptions = indexColumns;
@@ -179,10 +252,10 @@ export function deriveChartViewerState(
     state.heatmapYName,
     heatmapYDefaultIndex,
   );
-  const heatmapXColumn = columns.find(
+  const heatmapXColumn = allColumns.find(
     (column) => column.name === effectiveHeatmapXName,
   );
-  const heatmapYColumn = columns.find(
+  const heatmapYColumn = allColumns.find(
     (column) => column.name === effectiveHeatmapYName,
   );
 
@@ -232,7 +305,7 @@ export function deriveChartViewerState(
         sweepAxisFallback,
       )
     : null;
-  const sweepAxisColumn = columns.find(
+  const sweepAxisColumn = allColumns.find(
     (column) => column.name === effectiveSweepIndexColumnName,
   );
 

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewer.tsx
@@ -26,7 +26,11 @@ export function ChartViewer({ datasetId, datasetDetail }: ChartViewerProps) {
         : "tombstone";
 
   const columns = datasetDetail?.columns ?? [];
-  const selection = useChartViewerSelection(columns, datasetDetail?.status);
+  const selection = useChartViewerSelection(
+    columns,
+    datasetDetail?.status,
+    datasetDetail?.chartSemantics,
+  );
   const isLiveMode = selection.controlState.isLiveMode;
   const { chartData, chartError, chartInteractionKey, filterTableProps } =
     useChartViewerData({

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewerControls.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewerControls.tsx
@@ -241,11 +241,13 @@ export function ChartViewerControls({
                 </SelectValue>
               </SelectTrigger>
               <SelectContent>
-                {derived.sweepQuantityOptions.map((option: ChartColumnOption) => (
-                  <SelectItem key={option.name} value={option.name}>
-                    {columnOptionLabel(option)}
-                  </SelectItem>
-                ))}
+                {derived.sweepQuantityOptions.map(
+                  (option: ChartColumnOption) => (
+                    <SelectItem key={option.name} value={option.name}>
+                      {columnOptionLabel(option)}
+                    </SelectItem>
+                  ),
+                )}
               </SelectContent>
             </Select>
           </div>
@@ -263,12 +265,12 @@ export function ChartViewerControls({
                 }
               >
                 <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select X">
+                  <SelectValue placeholder="Select X">
                     {selectedOptionLabel(
                       derived.xyXOptions,
                       derived.effectiveXYXName,
                     )}
-                </SelectValue>
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {derived.xyXOptions.map((option: ChartColumnOption) => (
@@ -288,12 +290,12 @@ export function ChartViewerControls({
                 }
               >
                 <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select Y">
+                  <SelectValue placeholder="Select Y">
                     {selectedOptionLabel(
                       derived.xyYOptions,
                       derived.effectiveXYYName,
                     )}
-                </SelectValue>
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {derived.xyYOptions.map((option: ChartColumnOption) => (
@@ -357,11 +359,13 @@ export function ChartViewerControls({
                   </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {derived.heatmapQuantityOptions.map((option: ChartColumnOption) => (
-                    <SelectItem key={option.name} value={option.name}>
-                      {columnOptionLabel(option)}
-                    </SelectItem>
-                  ))}
+                  {derived.heatmapQuantityOptions.map(
+                    (option: ChartColumnOption) => (
+                      <SelectItem key={option.name} value={option.name}>
+                        {columnOptionLabel(option)}
+                      </SelectItem>
+                    ),
+                  )}
                 </SelectContent>
               </Select>
             </div>
@@ -502,11 +506,13 @@ export function ChartViewerControls({
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    {derived.heatmapXOptions.map((option: ChartColumnOption) => (
-                      <SelectItem key={option.name} value={option.name}>
-                        {columnOptionLabel(option)}
-                      </SelectItem>
-                    ))}
+                    {derived.heatmapXOptions.map(
+                      (option: ChartColumnOption) => (
+                        <SelectItem key={option.name} value={option.name}>
+                          {columnOptionLabel(option)}
+                        </SelectItem>
+                      ),
+                    )}
                   </SelectContent>
                 </Select>
               </div>
@@ -527,11 +533,13 @@ export function ChartViewerControls({
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    {derived.heatmapYOptions.map((option: ChartColumnOption) => (
-                      <SelectItem key={option.name} value={option.name}>
-                        {columnOptionLabel(option)}
-                      </SelectItem>
-                    ))}
+                    {derived.heatmapYOptions.map(
+                      (option: ChartColumnOption) => (
+                        <SelectItem key={option.name} value={option.name}>
+                          {columnOptionLabel(option)}
+                        </SelectItem>
+                      ),
+                    )}
                   </SelectContent>
                 </Select>
               </div>

--- a/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewerControls.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/ChartViewerControls.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
-import type { ColumnInfo, DatasetStatus } from "../api/types";
+import type { DatasetStatus } from "../api/types";
 import {
+  columnOptionLabel,
   complexSeriesOptions,
   deriveChartViewerState,
   isComplexViewOption,
+  type ChartColumnOption,
 } from "../model/chartViewerLogic";
 import type {
   ChartViewerControlActions,
@@ -70,6 +72,14 @@ const numericLabelFormatLabels = {
 } as const;
 
 const liveWindowOptions = [1, 3, 5, 10, 20] as const;
+
+function selectedOptionLabel(
+  options: ChartColumnOption[],
+  selectedName: string | null,
+) {
+  const option = options.find((item) => item.name === selectedName);
+  return option ? columnOptionLabel(option) : undefined;
+}
 
 export function ChartViewerControls({
   derived,
@@ -224,13 +234,16 @@ export function ChartViewerControls({
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select quantity">
-                  {derived.effectiveSweepQuantityName ?? undefined}
+                  {selectedOptionLabel(
+                    derived.sweepQuantityOptions,
+                    derived.effectiveSweepQuantityName,
+                  )}
                 </SelectValue>
               </SelectTrigger>
               <SelectContent>
-                {derived.sweepQuantityOptions.map((option: ColumnInfo) => (
+                {derived.sweepQuantityOptions.map((option: ChartColumnOption) => (
                   <SelectItem key={option.name} value={option.name}>
-                    {option.name}
+                    {columnOptionLabel(option)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -250,14 +263,17 @@ export function ChartViewerControls({
                 }
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select X">
-                    {derived.effectiveXYXName ?? undefined}
-                  </SelectValue>
+                <SelectValue placeholder="Select X">
+                    {selectedOptionLabel(
+                      derived.xyXOptions,
+                      derived.effectiveXYXName,
+                    )}
+                </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {derived.xyXOptions.map((option: ColumnInfo) => (
+                  {derived.xyXOptions.map((option: ChartColumnOption) => (
                     <SelectItem key={option.name} value={option.name}>
-                      {option.name}
+                      {columnOptionLabel(option)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -272,14 +288,17 @@ export function ChartViewerControls({
                 }
               >
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select Y">
-                    {derived.effectiveXYYName ?? undefined}
-                  </SelectValue>
+                <SelectValue placeholder="Select Y">
+                    {selectedOptionLabel(
+                      derived.xyYOptions,
+                      derived.effectiveXYYName,
+                    )}
+                </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {derived.xyYOptions.map((option: ColumnInfo) => (
+                  {derived.xyYOptions.map((option: ChartColumnOption) => (
                     <SelectItem key={option.name} value={option.name}>
-                      {option.name}
+                      {columnOptionLabel(option)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -300,14 +319,17 @@ export function ChartViewerControls({
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select quantity">
-                  {derived.effectiveComplexPlaneQuantityName ?? undefined}
+                  {selectedOptionLabel(
+                    derived.complexPlaneQuantityOptions,
+                    derived.effectiveComplexPlaneQuantityName,
+                  )}
                 </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {derived.complexPlaneQuantityOptions.map(
-                  (option: ColumnInfo) => (
+                  (option: ChartColumnOption) => (
                     <SelectItem key={option.name} value={option.name}>
-                      {option.name}
+                      {columnOptionLabel(option)}
                     </SelectItem>
                   ),
                 )}
@@ -328,13 +350,16 @@ export function ChartViewerControls({
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select quantity">
-                    {derived.effectiveHeatmapQuantityName ?? undefined}
+                    {selectedOptionLabel(
+                      derived.heatmapQuantityOptions,
+                      derived.effectiveHeatmapQuantityName,
+                    )}
                   </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {derived.heatmapQuantityOptions.map((option: ColumnInfo) => (
+                  {derived.heatmapQuantityOptions.map((option: ChartColumnOption) => (
                     <SelectItem key={option.name} value={option.name}>
-                      {option.name}
+                      {columnOptionLabel(option)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -362,17 +387,19 @@ export function ChartViewerControls({
                     allowEmptySweepAxis ? "No sweep axis" : "Select sweep axis"
                   }
                 >
-                  {derived.effectiveSweepIndexColumnName ??
-                    (allowEmptySweepAxis ? "None" : undefined)}
+                  {selectedOptionLabel(
+                    derived.sweepAxisOptions,
+                    derived.effectiveSweepIndexColumnName,
+                  ) ?? (allowEmptySweepAxis ? "None" : undefined)}
                 </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {allowEmptySweepAxis ? (
                   <SelectItem value="__none__">None</SelectItem>
                 ) : null}
-                {derived.sweepAxisOptions.map((option: ColumnInfo) => (
+                {derived.sweepAxisOptions.map((option: ChartColumnOption) => (
                   <SelectItem key={option.name} value={option.name}>
-                    {option.name}
+                    {columnOptionLabel(option)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -468,13 +495,16 @@ export function ChartViewerControls({
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder="Select X index">
-                      {derived.effectiveHeatmapXName ?? undefined}
+                      {selectedOptionLabel(
+                        derived.heatmapXOptions,
+                        derived.effectiveHeatmapXName,
+                      )}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    {derived.heatmapXOptions.map((option: ColumnInfo) => (
+                    {derived.heatmapXOptions.map((option: ChartColumnOption) => (
                       <SelectItem key={option.name} value={option.name}>
-                        {option.name}
+                        {columnOptionLabel(option)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -490,13 +520,16 @@ export function ChartViewerControls({
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder="Select Y index">
-                      {derived.effectiveHeatmapYName ?? undefined}
+                      {selectedOptionLabel(
+                        derived.heatmapYOptions,
+                        derived.effectiveHeatmapYName,
+                      )}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    {derived.heatmapYOptions.map((option: ColumnInfo) => (
+                    {derived.heatmapYOptions.map((option: ChartColumnOption) => (
                       <SelectItem key={option.name} value={option.name}>
-                        {option.name}
+                        {columnOptionLabel(option)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -514,7 +547,7 @@ export function ChartViewerControls({
                     No remaining grouping axes
                   </span>
                 ) : (
-                  derived.traceGroupOptions.map((option: ColumnInfo) => {
+                  derived.traceGroupOptions.map((option: ChartColumnOption) => {
                     const checked =
                       derived.effectiveTraceGroupIndexColumnNames.includes(
                         option.name,
@@ -530,7 +563,7 @@ export function ChartViewerControls({
                             toggleTraceGroupIndexColumnName(option.name)
                           }
                         />
-                        <span>{option.name}</span>
+                        <span>{columnOptionLabel(option)}</span>
                       </label>
                     );
                   })

--- a/crates/fricon-ui/frontend/src/features/charts/ui/FilterTable.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/FilterTable.browser.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@tanstack/react-virtual", () => ({
 function makeData(): FilterTableData {
   return {
     fields: ["A", "B"],
+    fieldLabels: {},
     rows: [
       { index: 1, displayValues: ["A1", "B1"], valueIndices: [1, 1] },
       { index: 2, displayValues: ["A2", "B2"], valueIndices: [2, 2] },

--- a/crates/fricon-ui/frontend/src/features/charts/ui/FilterTable.tsx
+++ b/crates/fricon-ui/frontend/src/features/charts/ui/FilterTable.tsx
@@ -26,6 +26,7 @@ interface FilterTableProps {
 interface FilterTableColumnProps {
   columnIndex: number;
   field: string;
+  label: string;
   items: ColumnUniqueValue[];
   selectedIndex?: number;
   onSelect: (index: number) => void;
@@ -108,6 +109,7 @@ function handleColumnBoundaryKeyDown(
 function FilterTableColumn({
   columnIndex,
   field,
+  label,
   items,
   selectedIndex,
   onSelect,
@@ -222,7 +224,7 @@ function FilterTableColumn({
         <Table withContainer={false}>
           <TableHeader className="sticky top-0 z-10 border-b bg-background shadow-sm">
             <TableRow>
-              <TableHead className="text-muted-foreground">{field}</TableHead>
+              <TableHead className="text-muted-foreground">{label}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -443,7 +445,7 @@ export function FilterTable({
               <TableRow>
                 {data.fields.map((field) => (
                   <TableHead key={field} className="text-muted-foreground">
-                    {field}
+                    {data.fieldLabels[field] ?? field}
                   </TableHead>
                 ))}
               </TableRow>
@@ -533,6 +535,7 @@ export function FilterTable({
               <FilterTableColumn
                 columnIndex={index}
                 field={field}
+                label={data.fieldLabels[field] ?? field}
                 items={columnUniqueValues[field] ?? []}
                 selectedIndex={selectedValueIndices?.[index]}
                 onSelect={(selectedIndex) =>

--- a/crates/fricon-ui/frontend/src/features/datasets/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/datasets/api/types.ts
@@ -28,12 +28,13 @@ export type DatasetInfo = Omit<
 
 export type DatasetDetail = Omit<
   WireDatasetDetail,
-  "createdAt" | "trashedAt" | "deletedAt" | "columns"
+  "createdAt" | "trashedAt" | "deletedAt" | "columns" | "chartSemantics"
 > & {
   createdAt: Date;
   trashedAt: Date | null;
   deletedAt: Date | null;
   columns: DatasetColumnInfo[];
+  chartSemantics: ChartSemantics | null;
 };
 
 export const DATASET_PAGE_SIZE = 200;
@@ -47,6 +48,43 @@ export interface DatasetColumnInfo {
   isIndex: boolean;
   hiddenByDefault: boolean;
   isChartAxisCandidate: boolean;
+}
+
+export type ChartInterpretationSource =
+  | "manifest"
+  | "compatibility_inference";
+export type ChartDuplicatePolicy =
+  | "latest_by_record_id"
+  | "compatibility_row_order_placeholder";
+export type ChartIndexRealization = "none" | "implicit" | "sidecar";
+export type ChartSemanticAxisKind = "logical_index" | "column";
+
+export interface ChartSemanticColumn {
+  id: string;
+  name: string;
+  label: string | null;
+  isComplex: boolean;
+  isTrace: boolean;
+  hiddenByDefault: boolean;
+}
+
+export interface ChartSemanticAxis {
+  id: string;
+  name: string;
+  label: string | null;
+  kind: ChartSemanticAxisKind;
+  numeric: boolean;
+  isCompatibility: boolean;
+  physicalColumn: string | null;
+}
+
+export interface ChartSemantics {
+  source: ChartInterpretationSource;
+  duplicatePolicy: ChartDuplicatePolicy;
+  indexRealization: ChartIndexRealization;
+  axes: ChartSemanticAxis[];
+  valueColumns: ChartSemanticColumn[];
+  chartAxisCandidates: ChartSemanticAxis[];
 }
 
 export type ColumnInfo = DatasetColumnInfo;
@@ -91,6 +129,7 @@ export function normalizeDatasetDetail(
   return {
     ...normalized,
     columns: value.columns.map(normalizeDatasetColumnInfo),
+    chartSemantics: value.chartSemantics ?? null,
   };
 }
 

--- a/crates/fricon-ui/frontend/src/features/datasets/api/types.ts
+++ b/crates/fricon-ui/frontend/src/features/datasets/api/types.ts
@@ -50,9 +50,7 @@ export interface DatasetColumnInfo {
   isChartAxisCandidate: boolean;
 }
 
-export type ChartInterpretationSource =
-  | "manifest"
-  | "compatibility_inference";
+export type ChartInterpretationSource = "manifest" | "compatibility_inference";
 export type ChartDuplicatePolicy =
   | "latest_by_record_id"
   | "compatibility_row_order_placeholder";

--- a/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.browser.test.tsx
+++ b/crates/fricon-ui/frontend/src/features/datasets/ui/DatasetPropertiesPanel.browser.test.tsx
@@ -91,6 +91,7 @@ function makeDetail(overrides: Partial<DatasetDetail> = {}): DatasetDetail {
     trashedAt: null,
     deletedAt: null,
     payloadAvailable: true,
+    chartSemantics: null,
     columns: [],
     ...overrides,
   };

--- a/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
+++ b/crates/fricon-ui/frontend/src/shared/lib/bindings.ts
@@ -64,6 +64,42 @@ export type ChartCommonOptions = {
 	excludeColumns: string[] | null,
 };
 
+export type ChartDuplicatePolicy = "latest_by_record_id" | "compatibility_row_order_placeholder";
+
+export type ChartIndexRealization = "none" | "implicit" | "sidecar";
+
+export type ChartInterpretationSource = "manifest" | "compatibility_inference";
+
+export type ChartSemanticAxis = {
+	id: string,
+	name: string,
+	label: string | null,
+	kind: ChartSemanticAxisKind,
+	numeric: boolean,
+	isCompatibility: boolean,
+	physicalColumn: string | null,
+};
+
+export type ChartSemanticAxisKind = "logical_index" | "column";
+
+export type ChartSemanticColumn = {
+	id: string,
+	name: string,
+	label: string | null,
+	isComplex: boolean,
+	isTrace: boolean,
+	hiddenByDefault: boolean,
+};
+
+export type ChartSemantics = {
+	source: ChartInterpretationSource,
+	duplicatePolicy: ChartDuplicatePolicy,
+	indexRealization: ChartIndexRealization,
+	axes: ChartSemanticAxis[],
+	valueColumns: ChartSemanticColumn[],
+	chartAxisCandidates: ChartSemanticAxis[],
+};
+
 export type ColumnInfo = {
 	name: string,
 	label: string | null,
@@ -132,6 +168,7 @@ export type DatasetDetail = {
 	deletedAt: string | null,
 	payloadAvailable: boolean,
 	columns: ColumnInfo[],
+	chartSemantics: ChartSemantics | null,
 };
 
 export type DatasetFavoriteUpdate = {
@@ -223,6 +260,7 @@ export type Row = {
 
 export type TableData = {
 	fields: string[],
+	fieldLabels: { [key in string]: string },
 	rows: Row[],
 	columnUniqueValues: { [key in string]: ColumnUniqueValue[] },
 };

--- a/crates/fricon-ui/src/features/charts.rs
+++ b/crates/fricon-ui/src/features/charts.rs
@@ -1,5 +1,6 @@
 mod chart_data;
 mod filter_table;
+mod semantic_source;
 pub(crate) mod tauri;
 pub(crate) mod transform;
 pub(crate) mod types;

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -1,47 +1,29 @@
-use std::ops::Bound;
-
 use anyhow::Context;
 use arrow_array::RecordBatch;
-use arrow_select::concat::concat_batches;
-use fricon::{DatasetDataType, DatasetReader, DatasetSchema, SelectOptions};
+use fricon::DatasetSchema;
 use tracing::{debug, error, instrument};
 
-use super::{filter_table::build_filter_batch, types::DatasetChartDataOptions};
+use super::{
+    filter_table::build_semantic_filters, semantic_source, types::DatasetChartDataOptions,
+};
+#[cfg(test)]
+use crate::features::charts::transform::compute_group_starts;
 use crate::{
     desktop_runtime::session::WorkspaceSession,
     features::charts::{
         transform::{
             build_heatmap_series, build_live_heatmap_series, build_live_xy_series, build_xy_series,
-            compute_group_starts,
-            mapping::{build_chart_selected_columns, build_live_chart_selected_columns},
-            resolve_xy_trace_roles,
         },
         types::{
-            ChartSnapshot, FlatSeries, FlatXYSeries, HeatmapChartSnapshot,
-            LiveChartAppendOperation, LiveChartDataOptions, LiveChartDataResponse,
-            XYPlotModeOptions,
+            ChartCommonOptions, ChartSnapshot, FlatSeries, FlatXYSeries, HeatmapChartDataOptions,
+            HeatmapChartSnapshot, LiveChartAppendOperation, LiveChartDataOptions,
+            LiveChartDataResponse, LiveHeatmapOptions, LiveXYOptions, XYChartDataOptions,
+            XYPlotModeOptions, XYTraceRoleOptions,
         },
     },
 };
 
-fn select_live_range(
-    dataset: &DatasetReader,
-    start: usize,
-    end: usize,
-    selected_columns: Vec<usize>,
-) -> anyhow::Result<RecordBatch> {
-    let (output_schema, batches) = dataset
-        .select_data(&SelectOptions {
-            start: Bound::Included(start),
-            end: Bound::Excluded(end),
-            index_filters: None,
-            selected_columns: Some(selected_columns),
-        })
-        .context("Failed to select live data")?;
-
-    concat_batches(&output_schema, &batches).context("Failed to concat batches")
-}
-
+#[cfg(test)]
 fn recent_group_starts_in_scan_batch(
     batch: &RecordBatch,
     schema: &DatasetSchema,
@@ -56,6 +38,7 @@ fn recent_group_starts_in_scan_batch(
         .collect()
 }
 
+#[cfg(test)]
 fn resolve_group_tail_start_in_scan_batch(
     batch: &RecordBatch,
     schema: &DatasetSchema,
@@ -74,218 +57,48 @@ fn resolve_group_tail_start_in_scan_batch(
     (starts.len() >= required_groups).then(|| starts[starts.len() - required_groups])
 }
 
-fn resolve_group_tail_start(
-    dataset: &DatasetReader,
-    schema: &DatasetSchema,
-    grouping_index_columns: &[usize],
-    total_rows: usize,
-    required_groups: usize,
-) -> anyhow::Result<usize> {
-    if total_rows == 0 || required_groups == 0 {
-        return Ok(0);
-    }
-
-    let mut window_rows = required_groups.max(1);
-    loop {
-        let range_start = total_rows.saturating_sub(window_rows);
-        let scan_start = range_start.saturating_sub(1);
-        let batch = select_live_range(
-            dataset,
-            scan_start,
-            total_rows,
-            grouping_index_columns.to_vec(),
-        )?;
-
-        if let Some(start) = resolve_group_tail_start_in_scan_batch(
-            &batch,
-            schema,
-            grouping_index_columns,
-            scan_start,
-            range_start,
-            required_groups,
-        ) {
-            return Ok(start);
-        }
-
-        if range_start == 0 {
-            return Ok(0);
-        }
-
-        window_rows = window_rows.saturating_mul(2).min(total_rows);
-    }
-}
-
-fn plot_mode_is_trace(
-    schema: &DatasetSchema,
-    plot_mode: &XYPlotModeOptions,
-) -> anyhow::Result<bool> {
-    match plot_mode {
-        XYPlotModeOptions::QuantityVsSweep { quantity, .. }
-        | XYPlotModeOptions::ComplexPlane { quantity } => Ok(matches!(
-            schema.columns().get(quantity).context("Column not found")?,
-            DatasetDataType::Trace(_, _)
-        )),
-        XYPlotModeOptions::Xy { x_column, y_column } => {
-            let x_type = *schema
-                .columns()
-                .get(x_column)
-                .context("X column not found")?;
-            let y_type = *schema
-                .columns()
-                .get(y_column)
-                .context("Y column not found")?;
-            Ok(matches!(x_type, DatasetDataType::Trace(_, _))
-                && matches!(y_type, DatasetDataType::Trace(_, _)))
-        }
-    }
-}
-
-fn resolve_live_row_start(
-    dataset: &DatasetReader,
-    schema: &DatasetSchema,
-    index_columns: Option<&[usize]>,
-    total_rows: usize,
-    options: &LiveChartDataOptions,
-) -> anyhow::Result<usize> {
-    if total_rows == 0 {
-        return Ok(0);
-    }
-
-    match options {
-        LiveChartDataOptions::Xy(opts) => {
-            let tail_count = opts.tail_count.max(1);
-            if plot_mode_is_trace(schema, &opts.plot_mode)? {
-                return Ok(total_rows.saturating_sub(tail_count));
-            }
-
-            let roles =
-                resolve_xy_trace_roles(schema, index_columns, &opts.trace_roles, opts.draw_style)?;
-            if roles.trace_group.is_empty() {
-                Ok(total_rows.saturating_sub(tail_count))
-            } else {
-                resolve_group_tail_start(
-                    dataset,
-                    schema,
-                    &roles.trace_group,
-                    total_rows,
-                    tail_count,
-                )
-            }
-        }
-        LiveChartDataOptions::Heatmap(opts) => {
-            let data_type = *schema
-                .columns()
-                .get(&opts.quantity)
-                .context("Column not found")?;
-            if matches!(data_type, DatasetDataType::Trace(_, _)) {
-                match index_columns {
-                    Some(idx_cols) if idx_cols.len() >= 2 => resolve_group_tail_start(
-                        dataset,
-                        schema,
-                        &idx_cols[..idx_cols.len() - 1],
-                        total_rows,
-                        1,
-                    ),
-                    _ => Ok(total_rows.saturating_sub(1)),
-                }
-            } else if let Some(idx_cols) = index_columns {
-                if idx_cols.len() >= 3 {
-                    resolve_group_tail_start(
-                        dataset,
-                        schema,
-                        &idx_cols[..idx_cols.len() - 2],
-                        total_rows,
-                        1,
-                    )
-                } else {
-                    Ok(0)
-                }
-            } else {
-                Ok(0)
-            }
-        }
-    }
-}
-
 #[instrument(level = "debug", skip(session, options), fields(dataset_id = id))]
 pub(crate) async fn dataset_chart_data(
     session: &WorkspaceSession,
     id: i32,
     options: &DatasetChartDataOptions,
 ) -> anyhow::Result<ChartSnapshot> {
-    let dataset = session.dataset(id).await?;
-    let schema = dataset.schema()?;
-    let index_columns = dataset.try_index_columns()?;
     let common = options.common();
-    let start = common.start.map_or(Bound::Unbounded, Bound::Included);
-    let end = common.end.map_or(Bound::Unbounded, Bound::Excluded);
-    let index_filters = if let Some(indices) = common.index_filters.clone() {
-        build_filter_batch(
-            session,
-            id,
-            common.exclude_columns.clone(),
-            &indices,
-            dataset.arrow_schema().clone(),
-        )
-        .await
-        .context("Failed to build index filters")?
+    let filters = if let Some(indices) = common.index_filters.as_deref() {
+        build_semantic_filters(session, id, common.exclude_columns.clone(), indices)
+            .await
+            .context("Failed to build semantic index filters")?
     } else {
-        None
+        Vec::new()
     };
-
-    let selected_columns = build_chart_selected_columns(schema, index_columns.as_deref(), options)?;
+    let prepared = semantic_source::prepare_chart_data(session, id, common, &filters).await?;
+    let resolved_options = resolve_dataset_chart_options(options);
     let chart_type = options.view_name();
     debug!(
         dataset_id = id,
         chart_type,
-        ?selected_columns,
-        "Selecting chart source data"
-    );
-    let (output_schema, batches) = dataset
-        .select_data(&SelectOptions {
-            start,
-            end,
-            index_filters,
-            selected_columns: Some(selected_columns),
-        })
-        .inspect_err(|err| {
-            error!(
-                dataset_id = id,
-                chart_type,
-                error = %err,
-                "Failed to select chart source data"
-            );
-        })
-        .context("Failed to select data.")?;
-
-    let batch = concat_batches(&output_schema, &batches).inspect_err(|err| {
-        error!(
-            dataset_id = id,
-            chart_type,
-            error = %err,
-            "Failed to concat chart batches"
-        );
-    })?;
-    debug!(
-        dataset_id = id,
-        chart_type,
-        rows = batch.num_rows(),
-        cols = batch.num_columns(),
+        rows = prepared.batch.num_rows(),
+        cols = prepared.batch.num_columns(),
         "Building dataset chart data"
     );
 
-    let result = match options {
-        DatasetChartDataOptions::Xy(options) => {
-            build_xy_series(&batch, schema, index_columns.as_deref(), options)
+    let result = match &resolved_options {
+        DatasetChartDataOptions::Xy(options) => build_xy_series(
+            &prepared.batch,
+            &prepared.schema,
+            prepared.index_columns.as_deref(),
+            options,
+        ),
+        DatasetChartDataOptions::Heatmap(options) => {
+            build_heatmap_series(&prepared.batch, &prepared.schema, options)
         }
-        DatasetChartDataOptions::Heatmap(options) => build_heatmap_series(&batch, schema, options),
     };
     if let Err(err) = &result {
         error!(
             dataset_id = id,
             chart_type,
-            rows = batch.num_rows(),
-            cols = batch.num_columns(),
+            rows = prepared.batch.num_rows(),
+            cols = prepared.batch.num_columns(),
             error = %err,
             "Failed to build dataset chart data"
         );
@@ -300,34 +113,35 @@ pub(crate) async fn dataset_live_chart_data(
     options: &LiveChartDataOptions,
 ) -> anyhow::Result<LiveChartDataResponse> {
     let dataset = session.dataset(id).await?;
-    let schema = dataset.schema()?;
-    let index_columns = dataset.try_index_columns()?;
     let total_rows = dataset.num_rows();
-    let selected_columns =
-        build_live_chart_selected_columns(schema, index_columns.as_deref(), options)?;
-    let start = resolve_live_row_start(
-        &dataset,
-        schema,
-        index_columns.as_deref(),
-        total_rows,
-        options,
-    )?;
-
-    let batch = select_live_range(&dataset, start, total_rows, selected_columns.clone())?;
+    let resolved_options = resolve_live_chart_options(options);
+    let current_common = ChartCommonOptions {
+        start: Some(0),
+        end: Some(total_rows),
+        index_filters: None,
+        exclude_columns: None,
+    };
+    let prepared = semantic_source::prepare_chart_data(session, id, &current_common, &[]).await?;
     debug!(
         dataset_id = id,
-        start,
+        start = 0,
         end = total_rows,
-        rows = batch.num_rows(),
-        cols = batch.num_columns(),
+        rows = prepared.batch.num_rows(),
+        cols = prepared.batch.num_columns(),
         "Building live chart data"
     );
 
-    let snapshot = build_live_snapshot(&batch, schema, index_columns.as_deref(), start, options);
+    let snapshot = build_live_snapshot(
+        &prepared.batch,
+        &prepared.schema,
+        prepared.index_columns.as_deref(),
+        0,
+        &resolved_options,
+    );
     if let Err(err) = &snapshot {
         error!(
             dataset_id = id,
-            rows = batch.num_rows(),
+            rows = prepared.batch.num_rows(),
             error = %err,
             "Failed to build live chart data"
         );
@@ -355,28 +169,20 @@ pub(crate) async fn dataset_live_chart_data(
         });
     }
 
-    let previous_start = resolve_live_row_start(
-        &dataset,
-        schema,
-        index_columns.as_deref(),
-        known_row_count,
-        options,
-    )?;
-    if previous_start != start {
-        return Ok(LiveChartDataResponse::Reset {
-            row_count: total_rows,
-            snapshot,
-        });
-    }
-
-    let previous_batch =
-        select_live_range(&dataset, previous_start, known_row_count, selected_columns)?;
+    let previous_common = ChartCommonOptions {
+        start: Some(0),
+        end: Some(known_row_count),
+        index_filters: None,
+        exclude_columns: None,
+    };
+    let previous_prepared =
+        semantic_source::prepare_chart_data(session, id, &previous_common, &[]).await?;
     let previous_snapshot = build_live_snapshot(
-        &previous_batch,
-        schema,
-        index_columns.as_deref(),
-        previous_start,
-        options,
+        &previous_prepared.batch,
+        &previous_prepared.schema,
+        previous_prepared.index_columns.as_deref(),
+        0,
+        &resolved_options,
     )?;
 
     let Some(ops) = diff_live_snapshots(&previous_snapshot, &snapshot) else {
@@ -406,6 +212,88 @@ fn build_live_snapshot(
         LiveChartDataOptions::Heatmap(opts) => {
             build_live_heatmap_series(batch, schema, index_columns, opts)
         }
+    }
+}
+
+fn resolve_dataset_chart_options(options: &DatasetChartDataOptions) -> DatasetChartDataOptions {
+    match options {
+        DatasetChartDataOptions::Xy(options) => {
+            DatasetChartDataOptions::Xy(resolve_xy_chart_options(options))
+        }
+        DatasetChartDataOptions::Heatmap(options) => {
+            DatasetChartDataOptions::Heatmap(HeatmapChartDataOptions {
+                quantity: semantic_source::resolve_column_name(&options.quantity),
+                x_column: options
+                    .x_column
+                    .as_deref()
+                    .map(semantic_source::resolve_axis_column_name),
+                y_column: semantic_source::resolve_axis_column_name(&options.y_column),
+                complex_view_single: options.complex_view_single,
+                common: options.common.clone(),
+            })
+        }
+    }
+}
+
+fn resolve_live_chart_options(options: &LiveChartDataOptions) -> LiveChartDataOptions {
+    match options {
+        LiveChartDataOptions::Xy(options) => LiveChartDataOptions::Xy(LiveXYOptions {
+            draw_style: options.draw_style,
+            tail_count: options.tail_count,
+            known_row_count: options.known_row_count,
+            plot_mode: resolve_xy_plot_mode_options(&options.plot_mode),
+            trace_roles: resolve_trace_roles(&options.trace_roles),
+        }),
+        LiveChartDataOptions::Heatmap(options) => {
+            LiveChartDataOptions::Heatmap(LiveHeatmapOptions {
+                quantity: semantic_source::resolve_column_name(&options.quantity),
+                complex_view_single: options.complex_view_single,
+                known_row_count: options.known_row_count,
+            })
+        }
+    }
+}
+
+fn resolve_xy_chart_options(options: &XYChartDataOptions) -> XYChartDataOptions {
+    XYChartDataOptions {
+        draw_style: options.draw_style,
+        plot_mode: resolve_xy_plot_mode_options(&options.plot_mode),
+        trace_roles: resolve_trace_roles(&options.trace_roles),
+        common: options.common.clone(),
+    }
+}
+
+fn resolve_xy_plot_mode_options(options: &XYPlotModeOptions) -> XYPlotModeOptions {
+    match options {
+        XYPlotModeOptions::QuantityVsSweep {
+            quantity,
+            complex_views,
+        } => XYPlotModeOptions::QuantityVsSweep {
+            quantity: semantic_source::resolve_column_name(quantity),
+            complex_views: complex_views.clone(),
+        },
+        XYPlotModeOptions::Xy { x_column, y_column } => XYPlotModeOptions::Xy {
+            x_column: semantic_source::resolve_column_name(x_column),
+            y_column: semantic_source::resolve_column_name(y_column),
+        },
+        XYPlotModeOptions::ComplexPlane { quantity } => XYPlotModeOptions::ComplexPlane {
+            quantity: semantic_source::resolve_column_name(quantity),
+        },
+    }
+}
+
+fn resolve_trace_roles(options: &XYTraceRoleOptions) -> XYTraceRoleOptions {
+    XYTraceRoleOptions {
+        trace_group_index_columns: options.trace_group_index_columns.as_ref().map(|columns| {
+            columns
+                .iter()
+                .map(|column| semantic_source::resolve_axis_column_name(column))
+                .collect()
+        }),
+        sweep_index_column: options
+            .sweep_index_column
+            .as_deref()
+            .map(semantic_source::resolve_axis_column_name),
     }
 }
 

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -11,7 +11,9 @@ use crate::{
     features::charts::{
         transform::{
             build_heatmap_series, build_live_heatmap_series, build_live_xy_series, build_xy_series,
-            compute_group_starts, resolve_xy_trace_roles,
+            compute_group_starts,
+            mapping::{build_chart_selected_columns, build_live_chart_selected_columns},
+            resolve_xy_trace_roles,
         },
         types::{
             ChartCommonOptions, ChartSnapshot, FlatSeries, FlatXYSeries, HeatmapChartDataOptions,
@@ -59,6 +61,7 @@ async fn prepare_live_range(
     id: i32,
     start: usize,
     end: usize,
+    selected_columns: Option<&[usize]>,
 ) -> anyhow::Result<semantic_source::PreparedChartData> {
     let common = ChartCommonOptions {
         start: Some(start),
@@ -66,12 +69,13 @@ async fn prepare_live_range(
         index_filters: None,
         exclude_columns: None,
     };
-    semantic_source::prepare_chart_data(session, id, &common, &[]).await
+    semantic_source::prepare_chart_data(session, id, &common, &[], selected_columns).await
 }
 
 async fn resolve_group_tail_start(
     session: &WorkspaceSession,
     id: i32,
+    schema: &DatasetSchema,
     grouping_index_columns: &[usize],
     total_rows: usize,
     required_groups: usize,
@@ -80,16 +84,26 @@ async fn resolve_group_tail_start(
         return Ok(0);
     }
 
+    let grouping_column_names = column_names(schema, grouping_index_columns)?;
     let mut window_rows = required_groups.max(1);
     loop {
         let range_start = total_rows.saturating_sub(window_rows);
         let scan_start = range_start.saturating_sub(1);
-        let prepared = prepare_live_range(session, id, scan_start, total_rows).await?;
+        let prepared = prepare_live_range(
+            session,
+            id,
+            scan_start,
+            total_rows,
+            Some(grouping_index_columns),
+        )
+        .await?;
+        let projected_grouping_index_columns =
+            column_indices(&prepared.schema, &grouping_column_names)?;
 
         if let Some(start) = resolve_group_tail_start_in_scan_batch(
             &prepared.batch,
             &prepared.schema,
-            grouping_index_columns,
+            &projected_grouping_index_columns,
             scan_start,
             range_start,
             required_groups,
@@ -103,6 +117,32 @@ async fn resolve_group_tail_start(
 
         window_rows = window_rows.saturating_mul(2).min(total_rows);
     }
+}
+
+fn column_names(schema: &DatasetSchema, columns: &[usize]) -> anyhow::Result<Vec<String>> {
+    columns
+        .iter()
+        .map(|&index| {
+            schema
+                .columns()
+                .get_index(index)
+                .map(|(name, _)| name.clone())
+                .with_context(|| format!("Column index '{index}' not found"))
+        })
+        .collect()
+}
+
+fn column_indices(schema: &DatasetSchema, columns: &[String]) -> anyhow::Result<Vec<usize>> {
+    columns
+        .iter()
+        .map(|name| {
+            schema
+                .columns()
+                .get_full(name)
+                .map(|(index, _, _)| index)
+                .with_context(|| format!("Column '{name}' not found"))
+        })
+        .collect()
 }
 
 fn plot_mode_is_trace(
@@ -140,7 +180,7 @@ async fn resolve_live_row_start(
         return Ok(0);
     }
 
-    let prepared = prepare_live_range(session, id, 0, 0).await?;
+    let prepared = prepare_live_range(session, id, 0, 0, None).await?;
     let schema = &prepared.schema;
     let index_columns = prepared.index_columns.as_deref();
     match options {
@@ -155,8 +195,15 @@ async fn resolve_live_row_start(
             if roles.trace_group.is_empty() {
                 Ok(total_rows.saturating_sub(tail_count))
             } else {
-                resolve_group_tail_start(session, id, &roles.trace_group, total_rows, tail_count)
-                    .await
+                resolve_group_tail_start(
+                    session,
+                    id,
+                    schema,
+                    &roles.trace_group,
+                    total_rows,
+                    tail_count,
+                )
+                .await
             }
         }
         LiveChartDataOptions::Heatmap(opts) => {
@@ -170,6 +217,7 @@ async fn resolve_live_row_start(
                         resolve_group_tail_start(
                             session,
                             id,
+                            schema,
                             &idx_cols[..idx_cols.len() - 1],
                             total_rows,
                             1,
@@ -183,6 +231,7 @@ async fn resolve_live_row_start(
                     resolve_group_tail_start(
                         session,
                         id,
+                        schema,
                         &idx_cols[..idx_cols.len() - 2],
                         total_rows,
                         1,
@@ -212,8 +261,16 @@ pub(crate) async fn dataset_chart_data(
     } else {
         Vec::new()
     };
-    let prepared = semantic_source::prepare_chart_data(session, id, common, &filters).await?;
     let resolved_options = resolve_dataset_chart_options(options);
+    let metadata = prepare_live_range(session, id, 0, 0, None).await?;
+    let selected_columns = build_chart_selected_columns(
+        &metadata.schema,
+        metadata.index_columns.as_deref(),
+        &resolved_options,
+    )?;
+    let prepared =
+        semantic_source::prepare_chart_data(session, id, common, &filters, Some(&selected_columns))
+            .await?;
     let chart_type = options.view_name();
     debug!(
         dataset_id = id,
@@ -257,7 +314,14 @@ pub(crate) async fn dataset_live_chart_data(
     let total_rows = dataset.num_rows();
     let resolved_options = resolve_live_chart_options(options);
     let start = resolve_live_row_start(session, id, total_rows, &resolved_options).await?;
-    let prepared = prepare_live_range(session, id, start, total_rows).await?;
+    let metadata = prepare_live_range(session, id, 0, 0, None).await?;
+    let selected_columns = build_live_chart_selected_columns(
+        &metadata.schema,
+        metadata.index_columns.as_deref(),
+        &resolved_options,
+    )?;
+    let prepared =
+        prepare_live_range(session, id, start, total_rows, Some(&selected_columns)).await?;
     debug!(
         dataset_id = id,
         start,
@@ -314,8 +378,14 @@ pub(crate) async fn dataset_live_chart_data(
         });
     }
 
-    let previous_prepared =
-        prepare_live_range(session, id, previous_start, known_row_count).await?;
+    let previous_prepared = prepare_live_range(
+        session,
+        id,
+        previous_start,
+        known_row_count,
+        Some(&selected_columns),
+    )
+    .await?;
     let previous_snapshot = build_live_snapshot(
         &previous_prepared.batch,
         &previous_prepared.schema,

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -28,12 +28,12 @@ fn recent_group_starts_in_scan_batch(
     batch: &RecordBatch,
     schema: &DatasetSchema,
     grouping_index_columns: &[usize],
-    scan_start: usize,
+    row_indices: &[usize],
     range_start: usize,
 ) -> Vec<usize> {
     compute_group_starts(batch, schema, grouping_index_columns)
         .into_iter()
-        .map(|offset| scan_start + offset)
+        .filter_map(|offset| row_indices.get(offset).copied())
         .filter(|&row| row >= range_start)
         .collect()
 }
@@ -42,7 +42,7 @@ fn resolve_group_tail_start_in_scan_batch(
     batch: &RecordBatch,
     schema: &DatasetSchema,
     grouping_index_columns: &[usize],
-    scan_start: usize,
+    row_indices: &[usize],
     range_start: usize,
     required_groups: usize,
 ) -> Option<usize> {
@@ -50,7 +50,7 @@ fn resolve_group_tail_start_in_scan_batch(
         batch,
         schema,
         grouping_index_columns,
-        scan_start,
+        row_indices,
         range_start,
     );
     (starts.len() >= required_groups).then(|| starts[starts.len() - required_groups])
@@ -104,7 +104,7 @@ async fn resolve_group_tail_start(
             &prepared.batch,
             &prepared.schema,
             &projected_grouping_index_columns,
-            scan_start,
+            &prepared.row_indices,
             range_start,
             required_groups,
         ) {
@@ -636,11 +636,12 @@ mod tests {
             ("freq", &[10.0, 20.0, 10.0, 20.0, 10.0, 20.0]),
         ]);
         let schema = numeric_schema(&["sweep", "freq"]);
+        let row_indices = (4..10).collect::<Vec<_>>();
 
-        let starts = recent_group_starts_in_scan_batch(&batch, &schema, &[0], 4, 5);
+        let starts = recent_group_starts_in_scan_batch(&batch, &schema, &[0], &row_indices, 5);
         assert_eq!(starts, vec![6, 8]);
         assert_eq!(
-            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], 4, 5, 2),
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], &row_indices, 5, 2),
             Some(6)
         );
     }
@@ -652,10 +653,26 @@ mod tests {
             ("freq", &[10.0, 20.0, 10.0, 20.0]),
         ]);
         let schema = numeric_schema(&["sweep", "freq"]);
+        let row_indices = (5..9).collect::<Vec<_>>();
 
         assert_eq!(
-            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], 5, 6, 2),
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], &row_indices, 6, 2),
             None
+        );
+    }
+
+    #[test]
+    fn resolve_group_tail_start_uses_original_rows_after_projection() {
+        let batch = numeric_batch(&[
+            ("sweep", &[1.0, 2.0, 2.0, 3.0]),
+            ("freq", &[10.0, 10.0, 20.0, 10.0]),
+        ]);
+        let schema = numeric_schema(&["sweep", "freq"]);
+        let row_indices = vec![4, 6, 7, 9];
+
+        assert_eq!(
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], &row_indices, 5, 2),
+            Some(6)
         );
     }
 
@@ -667,13 +684,14 @@ mod tests {
             ("x", &[0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
         ]);
         let schema = numeric_schema(&["cycle", "y", "x"]);
+        let row_indices = (0..10).collect::<Vec<_>>();
 
         assert_eq!(
-            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], 0, 0, 1),
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], &row_indices, 0, 1),
             Some(4)
         );
         assert_eq!(
-            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0, 1], 0, 0, 1),
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0, 1], &row_indices, 0, 1),
             Some(8)
         );
     }
@@ -685,13 +703,14 @@ mod tests {
             ("row", &[0.0, 1.0, 2.0, 0.0, 1.0, 2.0]),
         ]);
         let schema = numeric_schema(&["outer", "row"]);
+        let row_indices = (0..6).collect::<Vec<_>>();
 
         assert_eq!(
-            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], 0, 0, 1),
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0], &row_indices, 0, 1),
             Some(3)
         );
         assert_eq!(
-            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0, 1], 0, 0, 1),
+            resolve_group_tail_start_in_scan_batch(&batch, &schema, &[0, 1], &row_indices, 0, 1),
             Some(5)
         );
     }

--- a/crates/fricon-ui/src/features/charts/chart_data.rs
+++ b/crates/fricon-ui/src/features/charts/chart_data.rs
@@ -1,18 +1,17 @@
 use anyhow::Context;
 use arrow_array::RecordBatch;
-use fricon::DatasetSchema;
+use fricon::{DatasetDataType, DatasetSchema};
 use tracing::{debug, error, instrument};
 
 use super::{
     filter_table::build_semantic_filters, semantic_source, types::DatasetChartDataOptions,
 };
-#[cfg(test)]
-use crate::features::charts::transform::compute_group_starts;
 use crate::{
     desktop_runtime::session::WorkspaceSession,
     features::charts::{
         transform::{
             build_heatmap_series, build_live_heatmap_series, build_live_xy_series, build_xy_series,
+            compute_group_starts, resolve_xy_trace_roles,
         },
         types::{
             ChartCommonOptions, ChartSnapshot, FlatSeries, FlatXYSeries, HeatmapChartDataOptions,
@@ -23,7 +22,6 @@ use crate::{
     },
 };
 
-#[cfg(test)]
 fn recent_group_starts_in_scan_batch(
     batch: &RecordBatch,
     schema: &DatasetSchema,
@@ -38,7 +36,6 @@ fn recent_group_starts_in_scan_batch(
         .collect()
 }
 
-#[cfg(test)]
 fn resolve_group_tail_start_in_scan_batch(
     batch: &RecordBatch,
     schema: &DatasetSchema,
@@ -55,6 +52,150 @@ fn resolve_group_tail_start_in_scan_batch(
         range_start,
     );
     (starts.len() >= required_groups).then(|| starts[starts.len() - required_groups])
+}
+
+async fn prepare_live_range(
+    session: &WorkspaceSession,
+    id: i32,
+    start: usize,
+    end: usize,
+) -> anyhow::Result<semantic_source::PreparedChartData> {
+    let common = ChartCommonOptions {
+        start: Some(start),
+        end: Some(end),
+        index_filters: None,
+        exclude_columns: None,
+    };
+    semantic_source::prepare_chart_data(session, id, &common, &[]).await
+}
+
+async fn resolve_group_tail_start(
+    session: &WorkspaceSession,
+    id: i32,
+    grouping_index_columns: &[usize],
+    total_rows: usize,
+    required_groups: usize,
+) -> anyhow::Result<usize> {
+    if total_rows == 0 || required_groups == 0 {
+        return Ok(0);
+    }
+
+    let mut window_rows = required_groups.max(1);
+    loop {
+        let range_start = total_rows.saturating_sub(window_rows);
+        let scan_start = range_start.saturating_sub(1);
+        let prepared = prepare_live_range(session, id, scan_start, total_rows).await?;
+
+        if let Some(start) = resolve_group_tail_start_in_scan_batch(
+            &prepared.batch,
+            &prepared.schema,
+            grouping_index_columns,
+            scan_start,
+            range_start,
+            required_groups,
+        ) {
+            return Ok(start);
+        }
+
+        if range_start == 0 {
+            return Ok(0);
+        }
+
+        window_rows = window_rows.saturating_mul(2).min(total_rows);
+    }
+}
+
+fn plot_mode_is_trace(
+    schema: &DatasetSchema,
+    plot_mode: &XYPlotModeOptions,
+) -> anyhow::Result<bool> {
+    match plot_mode {
+        XYPlotModeOptions::QuantityVsSweep { quantity, .. }
+        | XYPlotModeOptions::ComplexPlane { quantity } => Ok(matches!(
+            schema.columns().get(quantity).context("Column not found")?,
+            DatasetDataType::Trace(_, _)
+        )),
+        XYPlotModeOptions::Xy { x_column, y_column } => {
+            let x_type = *schema
+                .columns()
+                .get(x_column)
+                .context("X column not found")?;
+            let y_type = *schema
+                .columns()
+                .get(y_column)
+                .context("Y column not found")?;
+            Ok(matches!(x_type, DatasetDataType::Trace(_, _))
+                && matches!(y_type, DatasetDataType::Trace(_, _)))
+        }
+    }
+}
+
+async fn resolve_live_row_start(
+    session: &WorkspaceSession,
+    id: i32,
+    total_rows: usize,
+    options: &LiveChartDataOptions,
+) -> anyhow::Result<usize> {
+    if total_rows == 0 {
+        return Ok(0);
+    }
+
+    let prepared = prepare_live_range(session, id, 0, 0).await?;
+    let schema = &prepared.schema;
+    let index_columns = prepared.index_columns.as_deref();
+    match options {
+        LiveChartDataOptions::Xy(opts) => {
+            let tail_count = opts.tail_count.max(1);
+            if plot_mode_is_trace(schema, &opts.plot_mode)? {
+                return Ok(total_rows.saturating_sub(tail_count));
+            }
+
+            let roles =
+                resolve_xy_trace_roles(schema, index_columns, &opts.trace_roles, opts.draw_style)?;
+            if roles.trace_group.is_empty() {
+                Ok(total_rows.saturating_sub(tail_count))
+            } else {
+                resolve_group_tail_start(session, id, &roles.trace_group, total_rows, tail_count)
+                    .await
+            }
+        }
+        LiveChartDataOptions::Heatmap(opts) => {
+            let data_type = *schema
+                .columns()
+                .get(&opts.quantity)
+                .context("Column not found")?;
+            if matches!(data_type, DatasetDataType::Trace(_, _)) {
+                match index_columns {
+                    Some(idx_cols) if idx_cols.len() >= 2 => {
+                        resolve_group_tail_start(
+                            session,
+                            id,
+                            &idx_cols[..idx_cols.len() - 1],
+                            total_rows,
+                            1,
+                        )
+                        .await
+                    }
+                    _ => Ok(total_rows.saturating_sub(1)),
+                }
+            } else if let Some(idx_cols) = index_columns {
+                if idx_cols.len() >= 3 {
+                    resolve_group_tail_start(
+                        session,
+                        id,
+                        &idx_cols[..idx_cols.len() - 2],
+                        total_rows,
+                        1,
+                    )
+                    .await
+                } else {
+                    Ok(0)
+                }
+            } else {
+                Ok(0)
+            }
+        }
+    }
 }
 
 #[instrument(level = "debug", skip(session, options), fields(dataset_id = id))]
@@ -115,16 +256,11 @@ pub(crate) async fn dataset_live_chart_data(
     let dataset = session.dataset(id).await?;
     let total_rows = dataset.num_rows();
     let resolved_options = resolve_live_chart_options(options);
-    let current_common = ChartCommonOptions {
-        start: Some(0),
-        end: Some(total_rows),
-        index_filters: None,
-        exclude_columns: None,
-    };
-    let prepared = semantic_source::prepare_chart_data(session, id, &current_common, &[]).await?;
+    let start = resolve_live_row_start(session, id, total_rows, &resolved_options).await?;
+    let prepared = prepare_live_range(session, id, start, total_rows).await?;
     debug!(
         dataset_id = id,
-        start = 0,
+        start,
         end = total_rows,
         rows = prepared.batch.num_rows(),
         cols = prepared.batch.num_columns(),
@@ -135,7 +271,7 @@ pub(crate) async fn dataset_live_chart_data(
         &prepared.batch,
         &prepared.schema,
         prepared.index_columns.as_deref(),
-        0,
+        start,
         &resolved_options,
     );
     if let Err(err) = &snapshot {
@@ -169,19 +305,22 @@ pub(crate) async fn dataset_live_chart_data(
         });
     }
 
-    let previous_common = ChartCommonOptions {
-        start: Some(0),
-        end: Some(known_row_count),
-        index_filters: None,
-        exclude_columns: None,
-    };
+    let previous_start =
+        resolve_live_row_start(session, id, known_row_count, &resolved_options).await?;
+    if previous_start != start {
+        return Ok(LiveChartDataResponse::Reset {
+            row_count: total_rows,
+            snapshot,
+        });
+    }
+
     let previous_prepared =
-        semantic_source::prepare_chart_data(session, id, &previous_common, &[]).await?;
+        prepare_live_range(session, id, previous_start, known_row_count).await?;
     let previous_snapshot = build_live_snapshot(
         &previous_prepared.batch,
         &previous_prepared.schema,
         previous_prepared.index_columns.as_deref(),
-        0,
+        previous_start,
         &resolved_options,
     )?;
 

--- a/crates/fricon-ui/src/features/charts/filter_table.rs
+++ b/crates/fricon-ui/src/features/charts/filter_table.rs
@@ -1,20 +1,13 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Bound,
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 
-use anyhow::{Context, Result, anyhow, bail};
-use arrow_array::{
-    Array, ArrayRef, Float64Array, RecordBatch, StructArray, cast::AsArray, types::Float64Type,
-};
-use arrow_buffer::NullBuffer;
-use arrow_schema::{DataType, Fields, SchemaRef};
-use fricon::{DatasetDataType, ScalarKind, SelectOptions};
+use anyhow::Result;
 
 use crate::{
     desktop_runtime::session::WorkspaceSession,
-    features::charts::types::{ColumnUniqueValue, Row, TableData},
+    features::charts::{
+        semantic_source,
+        types::{ColumnUniqueValue, Row, TableData},
+    },
 };
 
 pub(crate) struct ProcessedFilterRows {
@@ -25,6 +18,7 @@ pub(crate) struct ProcessedFilterRows {
 
 pub(crate) struct DataInternal {
     pub(crate) fields: Vec<String>,
+    pub(crate) field_labels: HashMap<String, String>,
     pub(crate) unique_rows: Vec<Row>,
     pub(crate) column_unique_values: HashMap<String, Vec<ColumnUniqueValue>>,
     pub(crate) column_raw_values: HashMap<String, Vec<serde_json::Value>>,
@@ -34,6 +28,7 @@ impl DataInternal {
     fn empty() -> Self {
         Self {
             fields: vec![],
+            field_labels: HashMap::new(),
             unique_rows: vec![],
             column_unique_values: HashMap::new(),
             column_raw_values: HashMap::new(),
@@ -49,167 +44,30 @@ pub(crate) fn format_json_value(value: &serde_json::Value) -> String {
     }
 }
 
-fn extract_scalar_value(
-    array: &dyn Array,
-    data_type: DatasetDataType,
-    row: usize,
-) -> Result<serde_json::Value> {
-    if array.is_null(row) {
-        return Ok(serde_json::Value::Null);
-    }
-
-    match data_type {
-        DatasetDataType::Scalar(ScalarKind::Numeric) => Ok(serde_json::Value::from(
-            array.as_primitive::<Float64Type>().value(row),
-        )),
-        DatasetDataType::Scalar(ScalarKind::Complex) => {
-            let array = array
-                .as_struct_opt()
-                .context("Complex filter columns must use Arrow struct arrays")?;
-            Ok(serde_json::json!({
-                "real": array.column(0).as_primitive::<Float64Type>().value(row),
-                "imag": array.column(1).as_primitive::<Float64Type>().value(row),
-            }))
-        }
-        DatasetDataType::Trace(_, _) => {
-            bail!("Filter table only supports scalar index columns")
-        }
-    }
-}
-
-fn collect_filter_rows(
-    batches: &[RecordBatch],
-    field_types: &[DatasetDataType],
-) -> Result<Vec<Vec<serde_json::Value>>> {
-    let mut rows = Vec::new();
-    for batch in batches {
-        for row_index in 0..batch.num_rows() {
-            let row = batch
-                .columns()
-                .iter()
-                .zip(field_types.iter().copied())
-                .map(|(column, data_type)| {
-                    extract_scalar_value(column.as_ref(), data_type, row_index)
-                })
-                .collect::<Result<Vec<_>>>()?;
-            rows.push(row);
-        }
-    }
-    Ok(rows)
-}
-
-fn build_float64_array(value: &serde_json::Value) -> Result<ArrayRef> {
-    let value = match value {
-        serde_json::Value::Null => None,
-        serde_json::Value::Number(number) => Some(
-            number
-                .as_f64()
-                .ok_or_else(|| anyhow!("Filter value is not a valid f64: {number}"))?,
-        ),
-        other => bail!("Expected numeric filter value, got {other}"),
-    };
-    Ok(Arc::new(Float64Array::from(vec![value])))
-}
-
-fn is_complex_fields(fields: &Fields) -> bool {
-    fields.as_ref().as_array::<2>().is_some_and(|[real, imag]| {
-        real.name() == "real"
-            && imag.name() == "imag"
-            && matches!(real.data_type(), DataType::Float64)
-            && matches!(imag.data_type(), DataType::Float64)
-    })
-}
-
-fn build_complex_array(fields: &Fields, value: &serde_json::Value) -> Result<ArrayRef> {
-    let (real, imag, nulls) = match value {
-        serde_json::Value::Null => (
-            Arc::new(Float64Array::from(vec![None])) as ArrayRef,
-            Arc::new(Float64Array::from(vec![None])) as ArrayRef,
-            Some(NullBuffer::from(vec![false])),
-        ),
-        serde_json::Value::Object(values) => {
-            let read_component = |name: &str| -> Result<f64> {
-                values
-                    .get(name)
-                    .and_then(serde_json::Value::as_f64)
-                    .ok_or_else(|| anyhow!("Complex filter value is missing '{name}'"))
-            };
-            (
-                Arc::new(Float64Array::from(vec![Some(read_component("real")?)])) as ArrayRef,
-                Arc::new(Float64Array::from(vec![Some(read_component("imag")?)])) as ArrayRef,
-                None,
-            )
-        }
-        other => bail!("Expected complex filter value object, got {other}"),
-    };
-
-    Ok(Arc::new(StructArray::new(
-        fields.clone(),
-        vec![real, imag],
-        nulls,
-    )))
-}
-
-fn build_filter_array(data_type: &DataType, value: &serde_json::Value) -> Result<ArrayRef> {
-    match data_type {
-        DataType::Float64 => build_float64_array(value),
-        DataType::Struct(fields) if is_complex_fields(fields) => build_complex_array(fields, value),
-        other => bail!("Unsupported filter data type: {other}"),
-    }
-}
-
 pub(crate) async fn load_filter_data(
     session: &WorkspaceSession,
     id: i32,
     exclude_columns: Option<Vec<String>>,
 ) -> Result<DataInternal> {
-    let dataset = session.dataset(id).await?;
-    let schema = dataset.schema()?;
-    let index_columns = dataset.try_index_columns()?;
-
-    let Some(index_col_indices) = index_columns else {
-        return Ok(DataInternal::empty());
-    };
-
-    let filtered_indices: Vec<usize> = index_col_indices
-        .iter()
-        .filter(|&&i| {
-            let col_name = schema.columns().keys().nth(i).map(String::as_str);
-            if let Some(exclude) = &exclude_columns {
-                col_name.is_none_or(|name| !exclude.iter().any(|e| e == name))
-            } else {
-                true
-            }
-        })
-        .copied()
-        .collect();
-
-    if filtered_indices.is_empty() {
+    let exclude_columns = exclude_columns.unwrap_or_default();
+    let (axis_fields, rows) =
+        semantic_source::load_axis_rows(session, id, &exclude_columns).await?;
+    if axis_fields.is_empty() {
         return Ok(DataInternal::empty());
     }
 
-    let fields: Vec<String> = filtered_indices
+    let fields = axis_fields
         .iter()
-        .filter_map(|&i| schema.columns().keys().nth(i).cloned())
-        .collect();
-    let field_types: Vec<DatasetDataType> = filtered_indices
-        .iter()
-        .filter_map(|&i| schema.columns().values().nth(i).copied())
-        .collect();
-
-    let (_, batches) = dataset
-        .select_data(&SelectOptions {
-            start: Bound::Unbounded,
-            end: Bound::Unbounded,
-            index_filters: None,
-            selected_columns: Some(filtered_indices),
-        })
-        .context("Failed to select index data")?;
-
-    let rows = collect_filter_rows(&batches, &field_types)?;
+        .map(|field| field.id.clone())
+        .collect::<Vec<_>>();
+    let field_labels = axis_fields
+        .into_iter()
+        .map(|field| (field.id, field.label))
+        .collect::<HashMap<_, _>>();
     let processed = process_filter_rows(&fields, rows);
     Ok(DataInternal {
         fields,
+        field_labels,
         unique_rows: processed.unique_rows,
         column_unique_values: processed.column_unique_values,
         column_raw_values: processed.column_raw_values,
@@ -224,20 +82,19 @@ pub(crate) async fn get_filter_table_data(
     let data = load_filter_data(session, id, exclude_columns).await?;
     Ok(TableData {
         fields: data.fields,
+        field_labels: data.field_labels,
         rows: data.unique_rows,
         column_unique_values: data.column_unique_values,
     })
 }
 
-pub(crate) async fn build_filter_batch(
+pub(crate) async fn build_semantic_filters(
     session: &WorkspaceSession,
     id: i32,
     exclude_columns: Option<Vec<String>>,
     indices: &[usize],
-    arrow_schema: SchemaRef,
-) -> Result<Option<RecordBatch>> {
+) -> Result<Vec<(String, serde_json::Value)>> {
     let filter_data = load_filter_data(session, id, exclude_columns).await?;
-
     let mut selected_filters = Vec::new();
     for (field_index, &value_index) in indices.iter().enumerate() {
         if let Some(field_name) = filter_data.fields.get(field_index)
@@ -246,37 +103,10 @@ pub(crate) async fn build_filter_batch(
                 .get(field_name)
                 .and_then(|values| values.get(value_index))
         {
-            selected_filters.push((field_name.as_str(), value));
+            selected_filters.push((field_name.clone(), value.clone()));
         }
     }
-
-    if selected_filters.is_empty() {
-        return Ok(None);
-    }
-
-    let projection_indices: Vec<usize> = selected_filters
-        .iter()
-        .map(|(field_name, _)| {
-            arrow_schema
-                .index_of(field_name)
-                .with_context(|| format!("Field '{field_name}' not found in schema"))
-        })
-        .collect::<Result<_>>()?;
-    let filter_schema = Arc::new(
-        arrow_schema
-            .project(&projection_indices)
-            .context("Failed to project filter schema")?,
-    );
-    let arrays = filter_schema
-        .fields()
-        .iter()
-        .zip(selected_filters)
-        .map(|(field, (_, value))| build_filter_array(field.data_type(), value))
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(Some(
-        RecordBatch::try_new(filter_schema, arrays).context("Failed to build filter batch")?,
-    ))
+    Ok(selected_filters)
 }
 
 pub(crate) fn process_filter_rows(

--- a/crates/fricon-ui/src/features/charts/filter_table.rs
+++ b/crates/fricon-ui/src/features/charts/filter_table.rs
@@ -170,7 +170,13 @@ pub(crate) fn process_filter_rows(
 
 #[cfg(test)]
 mod tests {
+    use fricon::{
+        AppManager, Client, DatasetRow, DatasetScalar, ScanAxis, ScanAxisValue, ScanPlan,
+        WorkspaceRoot,
+    };
+    use indexmap::IndexMap;
     use serde_json::json;
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -209,5 +215,69 @@ mod tests {
         );
         assert_eq!(processed.unique_rows[0].value_indices, vec![0]);
         assert_eq!(processed.unique_rows[1].value_indices, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn filter_data_includes_nonnumeric_logical_scan_axes() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        WorkspaceRoot::create_new(temp_dir.path())?;
+        let app_manager =
+            AppManager::new_with_path(temp_dir.path())?.start(&tokio::runtime::Handle::current())?;
+        let client = Client::connect(temp_dir.path()).await?;
+
+        let rows = [10.0, 20.0, 30.0, 40.0]
+            .into_iter()
+            .map(|signal| {
+                DatasetRow(IndexMap::from([(
+                    "signal".to_string(),
+                    DatasetScalar::Numeric(signal),
+                )]))
+            })
+            .collect::<Vec<_>>();
+        let scan_plan = ScanPlan::new(vec![
+            ScanAxis::static_values(
+                "gate",
+                vec![
+                    ScanAxisValue::String("low".to_string()),
+                    ScanAxisValue::String("high".to_string()),
+                ],
+            ),
+            ScanAxis::static_values("bias", vec![ScanAxisValue::Int(0), ScanAxisValue::Int(1)]),
+        ]);
+        let mut writer = client
+            .create_dataset(
+                "scan-filter-test".to_string(),
+                String::new(),
+                vec![],
+                rows[0].to_schema(),
+                Vec::new(),
+                Some(scan_plan),
+                false,
+            )
+            .await?;
+        for row in rows {
+            writer.write(row).await?;
+        }
+        let dataset = writer.finish().await?;
+        let session = WorkspaceSession::new(app_manager.handle().clone());
+
+        let data = load_filter_data(&session, dataset.id(), None).await?;
+
+        assert_eq!(data.fields, vec!["logicalIndex:gate", "logicalIndex:bias"]);
+        assert_eq!(
+            data.unique_rows
+                .iter()
+                .map(|row| row.display_values.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                vec!["low".to_string(), "0.0".to_string()],
+                vec!["low".to_string(), "1.0".to_string()],
+                vec!["high".to_string(), "0.0".to_string()],
+                vec!["high".to_string(), "1.0".to_string()],
+            ]
+        );
+
+        app_manager.shutdown().await;
+        Ok(())
     }
 }

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -1,0 +1,391 @@
+use std::{collections::HashMap, ops::Bound, sync::Arc};
+
+use anyhow::{Context, Result, bail};
+use arrow_array::{Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_select::{concat::concat_batches, filter::FilterBuilder};
+use fricon::{
+    DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, ResolvedDuplicatePolicy,
+    ResolvedLogicalIndexPoint, ResolvedScanAxisMode, ScalarKind, SelectOptions,
+    dataset::semantics::ScanAxisValue,
+};
+
+use super::types::ChartCommonOptions;
+use crate::desktop_runtime::session::WorkspaceSession;
+
+pub(crate) const COLUMN_PREFIX: &str = "column:";
+pub(crate) const LOGICAL_INDEX_PREFIX: &str = "logicalIndex:";
+
+#[derive(Debug, Clone)]
+pub(crate) struct AxisField {
+    pub(crate) id: String,
+    pub(crate) column_name: String,
+    pub(crate) label: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedChartData {
+    pub(crate) batch: RecordBatch,
+    pub(crate) schema: DatasetSchema,
+    pub(crate) index_columns: Option<Vec<usize>>,
+}
+
+pub(crate) fn column_id(name: &str) -> String {
+    format!("{COLUMN_PREFIX}{name}")
+}
+
+pub(crate) fn logical_index_id(name: &str) -> String {
+    format!("{LOGICAL_INDEX_PREFIX}{name}")
+}
+
+pub(crate) fn resolve_column_name(value: &str) -> String {
+    value
+        .strip_prefix(COLUMN_PREFIX)
+        .unwrap_or(value)
+        .to_string()
+}
+
+pub(crate) fn resolve_axis_column_name(value: &str) -> String {
+    if value.starts_with(LOGICAL_INDEX_PREFIX) {
+        value.to_string()
+    } else {
+        resolve_column_name(value)
+    }
+}
+
+pub(crate) async fn prepare_chart_data(
+    session: &WorkspaceSession,
+    id: i32,
+    common: &ChartCommonOptions,
+    filters: &[(String, serde_json::Value)],
+) -> Result<PreparedChartData> {
+    let dataset = session.dataset(id).await?;
+    let interpretation = dataset.interpret()?;
+    let source_schema = dataset.schema()?.clone();
+    let (start, end) = resolve_row_range(&dataset, common.start, common.end);
+    let (output_schema, batches) = dataset.select_data(&SelectOptions {
+        start: Bound::Included(start),
+        end: Bound::Excluded(end),
+        index_filters: None,
+        selected_columns: None,
+    })?;
+    let batch = concat_or_empty(output_schema, batches)?;
+    prepare_batch_from_reader(
+        &dataset,
+        &source_schema,
+        &interpretation,
+        batch,
+        start,
+        end,
+        filters,
+    )
+}
+
+pub(crate) async fn load_axis_rows(
+    session: &WorkspaceSession,
+    id: i32,
+    exclude_fields: &[String],
+) -> Result<(Vec<AxisField>, Vec<Vec<serde_json::Value>>)> {
+    let dataset = session.dataset(id).await?;
+    let interpretation = dataset.interpret()?;
+    let source_schema = dataset.schema()?.clone();
+    let end = dataset.num_rows();
+    let (output_schema, batches) = dataset.select_data(&SelectOptions {
+        start: Bound::Included(0),
+        end: Bound::Excluded(end),
+        index_filters: None,
+        selected_columns: None,
+    })?;
+    let batch = concat_or_empty(output_schema, batches)?;
+    let prepared = prepare_batch_from_reader(
+        &dataset,
+        &source_schema,
+        &interpretation,
+        batch,
+        0,
+        end,
+        &[],
+    )?;
+    let fields = axis_fields(&interpretation, &prepared.schema)
+        .into_iter()
+        .filter(|field| !exclude_fields.iter().any(|excluded| excluded == &field.id))
+        .collect::<Vec<_>>();
+
+    let rows = (0..prepared.batch.num_rows())
+        .map(|row| {
+            fields
+                .iter()
+                .map(|field| {
+                    let column = prepared
+                        .batch
+                        .column_by_name(&field.column_name)
+                        .with_context(|| format!("Axis '{}' not found", field.column_name))?;
+                    json_value_at(column.as_ref(), row)
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok((fields, rows))
+}
+
+pub(crate) fn apply_semantic_filters(
+    batch: RecordBatch,
+    filters: &[(String, serde_json::Value)],
+) -> Result<RecordBatch> {
+    if filters.is_empty() || batch.num_rows() == 0 {
+        return Ok(batch);
+    }
+
+    let mut mask = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let mut keep = true;
+        for (field, expected) in filters {
+            let column_name = resolve_axis_column_name(field);
+            let column = batch
+                .column_by_name(&column_name)
+                .with_context(|| format!("Filter field '{field}' not found"))?;
+            if json_value_at(column.as_ref(), row)? != *expected {
+                keep = false;
+                break;
+            }
+        }
+        mask.push(keep);
+    }
+    filter_batch(&batch, &mask)
+}
+
+fn prepare_batch_from_reader(
+    dataset: &DatasetReader,
+    source_schema: &DatasetSchema,
+    interpretation: &DatasetInterpretation,
+    batch: RecordBatch,
+    start: usize,
+    end: usize,
+    filters: &[(String, serde_json::Value)],
+) -> Result<PreparedChartData> {
+    let mut schema = source_schema.clone();
+    let mut batch = append_logical_axes(dataset, interpretation, &mut schema, batch, start, end)?;
+    batch = apply_semantic_filters(batch, filters)?;
+    let index_columns = resolve_index_columns(interpretation, &schema)
+        .or_else(|| dataset.try_index_columns().ok().flatten());
+    Ok(PreparedChartData {
+        batch,
+        schema,
+        index_columns,
+    })
+}
+
+fn append_logical_axes(
+    dataset: &DatasetReader,
+    interpretation: &DatasetInterpretation,
+    schema: &mut DatasetSchema,
+    batch: RecordBatch,
+    start: usize,
+    end: usize,
+) -> Result<RecordBatch> {
+    if interpretation.scan_axes.is_empty() {
+        return Ok(batch);
+    }
+
+    let logical_axes = interpretation
+        .scan_axes
+        .iter()
+        .enumerate()
+        .filter(|(_, axis)| scan_axis_is_numeric(&axis.mode))
+        .collect::<Vec<_>>();
+    if logical_axes.is_empty() {
+        return Ok(batch);
+    }
+
+    let point_by_record_id = dataset
+        .logical_index_points()?
+        .into_iter()
+        .map(|point| (point.record_id, point))
+        .collect::<HashMap<_, _>>();
+    let record_ids = dataset.record_ids_range((Bound::Included(start), Bound::Excluded(end)))?;
+    if record_ids.len() != batch.num_rows() {
+        bail!("Logical index rows do not match selected chart rows");
+    }
+
+    let keep_mask = if interpretation.duplicate_policy == ResolvedDuplicatePolicy::LatestByRecordId
+    {
+        record_ids
+            .iter()
+            .map(|record_id| point_by_record_id.contains_key(record_id))
+            .collect::<Vec<_>>()
+    } else {
+        vec![true; record_ids.len()]
+    };
+    let kept_record_ids = record_ids
+        .into_iter()
+        .zip(&keep_mask)
+        .filter_map(|(record_id, keep)| (*keep).then_some(record_id))
+        .collect::<Vec<_>>();
+    let mut batch = filter_batch(&batch, &keep_mask)?;
+
+    let mut fields = batch.schema().fields().iter().cloned().collect::<Vec<_>>();
+    let mut arrays = batch.columns().to_vec();
+    let mut columns = schema.columns().clone();
+    for (axis_index, axis) in logical_axes {
+        let id = logical_index_id(&axis.name);
+        let values = kept_record_ids
+            .iter()
+            .map(|record_id| {
+                point_by_record_id
+                    .get(record_id)
+                    .and_then(|point| numeric_coordinate(point, axis_index))
+            })
+            .collect::<Vec<_>>();
+        fields.push(Arc::new(Field::new(&id, DataType::Float64, true)));
+        arrays.push(Arc::new(Float64Array::from(values)) as ArrayRef);
+        columns.insert(id, DatasetDataType::Scalar(ScalarKind::Numeric));
+    }
+
+    *schema = DatasetSchema::new(columns);
+    batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)?;
+    Ok(batch)
+}
+
+fn axis_fields(interpretation: &DatasetInterpretation, schema: &DatasetSchema) -> Vec<AxisField> {
+    let mut fields = Vec::new();
+    if interpretation.scan_axes.is_empty() {
+        fields.extend(
+            interpretation
+                .logical_index_columns
+                .iter()
+                .filter_map(|ordinal| {
+                    let column = interpretation
+                        .columns
+                        .iter()
+                        .find(|column| column.visible_ordinal == Some(*ordinal))?;
+                    Some(AxisField {
+                        id: column_id(&column.name),
+                        column_name: column.name.clone(),
+                        label: column.label.clone().unwrap_or_else(|| column.name.clone()),
+                    })
+                }),
+        );
+    } else {
+        fields.extend(interpretation.scan_axes.iter().filter_map(|axis| {
+            let id = logical_index_id(&axis.name);
+            schema.columns().contains_key(&id).then(|| AxisField {
+                id: id.clone(),
+                column_name: id,
+                label: axis.label.clone().unwrap_or_else(|| axis.name.clone()),
+            })
+        }));
+    }
+    fields
+}
+
+fn resolve_index_columns(
+    interpretation: &DatasetInterpretation,
+    schema: &DatasetSchema,
+) -> Option<Vec<usize>> {
+    let mut indices = Vec::new();
+    for ordinal in &interpretation.chart_axis_candidate_columns {
+        if let Some(column) = interpretation
+            .columns
+            .iter()
+            .find(|column| column.visible_ordinal == Some(*ordinal))
+            && let Some((index, _, _)) = schema.columns().get_full(&column.name)
+        {
+            indices.push(index);
+        }
+    }
+    for axis in &interpretation.scan_axes {
+        let id = logical_index_id(&axis.name);
+        if let Some((index, _, _)) = schema.columns().get_full(&id) {
+            indices.push(index);
+        }
+    }
+    if indices.is_empty() {
+        None
+    } else {
+        Some(indices)
+    }
+}
+
+fn scan_axis_is_numeric(mode: &ResolvedScanAxisMode) -> bool {
+    match mode {
+        ResolvedScanAxisMode::ImplicitIndex => true,
+        ResolvedScanAxisMode::Static { values } => values
+            .iter()
+            .all(|value| matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_))),
+    }
+}
+
+fn numeric_coordinate(point: &ResolvedLogicalIndexPoint, axis_index: usize) -> Option<f64> {
+    match point.coordinates.get(axis_index)? {
+        ScanAxisValue::Int(value) => Some(*value as f64),
+        ScanAxisValue::Float(value) => Some(*value),
+        ScanAxisValue::Bool(_) | ScanAxisValue::String(_) => None,
+    }
+}
+
+fn json_value_at(array: &dyn Array, row: usize) -> Result<serde_json::Value> {
+    if array.is_null(row) {
+        return Ok(serde_json::Value::Null);
+    }
+    match array.data_type() {
+        DataType::Float64 => {
+            let array = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .context("Expected Float64Array")?;
+            Ok(serde_json::Value::from(array.value(row)))
+        }
+        DataType::Boolean => {
+            let array = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .context("Expected BooleanArray")?;
+            Ok(serde_json::Value::from(array.value(row)))
+        }
+        DataType::Utf8 => {
+            let array = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .context("Expected StringArray")?;
+            Ok(serde_json::Value::from(array.value(row)))
+        }
+        other => bail!("Unsupported semantic axis data type: {other}"),
+    }
+}
+
+fn filter_batch(batch: &RecordBatch, mask: &[bool]) -> Result<RecordBatch> {
+    if mask.iter().all(|keep| *keep) {
+        return Ok(batch.clone());
+    }
+    let mask = BooleanArray::from(mask.to_vec());
+    let predicate = FilterBuilder::new(&mask).build();
+    let arrays = batch
+        .columns()
+        .iter()
+        .map(|array| {
+            predicate
+                .filter(array)
+                .context("Failed to filter chart data")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(RecordBatch::try_new(batch.schema(), arrays)?)
+}
+
+fn concat_or_empty(schema: SchemaRef, batches: Vec<RecordBatch>) -> Result<RecordBatch> {
+    if batches.is_empty() {
+        Ok(RecordBatch::new_empty(schema))
+    } else {
+        concat_batches(&schema, &batches).context("Failed to concat chart batches")
+    }
+}
+
+fn resolve_row_range(
+    dataset: &DatasetReader,
+    start: Option<usize>,
+    end: Option<usize>,
+) -> (usize, usize) {
+    let total_rows = dataset.num_rows();
+    let start = start.unwrap_or(0).min(total_rows);
+    let end = end.unwrap_or(total_rows).min(total_rows).max(start);
+    (start, end)
+}

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -86,19 +86,19 @@ pub(crate) async fn prepare_chart_data(
     let alias_physical_columns = true;
     let (start, end) = resolve_row_range(&dataset, common.start, common.end);
     let selected_physical_columns =
-        selected_physical_columns(&source_schema, selected_columns, filters)?;
+        selected_physical_columns(&source_schema, selected_columns, filters);
     let (output_schema, batches) = dataset.select_data(&SelectOptions {
         start: Bound::Included(start),
         end: Bound::Excluded(end),
         index_filters: None,
         selected_columns: selected_physical_columns.clone(),
     })?;
-    let batch = concat_or_empty(output_schema, batches)?;
+    let batch = concat_or_empty(output_schema, &batches)?;
     let selected_schema = selected_physical_columns.as_deref().map_or_else(
         || project_all_schema(&source_schema, alias_physical_columns),
         |columns| project_schema(&source_schema, columns, alias_physical_columns),
     )?;
-    let batch = rename_batch(batch, &selected_schema)?;
+    let batch = rename_batch(&batch, &selected_schema)?;
     prepare_batch_from_reader(
         &dataset,
         &selected_schema,
@@ -132,7 +132,7 @@ pub(crate) async fn load_axis_rows(
             index_filters: None,
             selected_columns: Some(selected_columns.clone()),
         })?;
-        concat_or_empty(output_schema, batches)?
+        concat_or_empty(output_schema, &batches)?
     };
     let selected_schema = project_schema(&source_schema, &selected_columns, false)?;
     let prepared = prepare_batch_from_reader(
@@ -255,10 +255,8 @@ fn selected_physical_columns(
     source_schema: &DatasetSchema,
     selected_columns: Option<&[usize]>,
     filters: &[(String, serde_json::Value)],
-) -> Result<Option<Vec<usize>>> {
-    let Some(selected_columns) = selected_columns else {
-        return Ok(None);
-    };
+) -> Option<Vec<usize>> {
+    let selected_columns = selected_columns?;
 
     let mut physical_columns = Vec::new();
     for &index in selected_columns {
@@ -272,7 +270,7 @@ fn selected_physical_columns(
             push_unique(&mut physical_columns, index);
         }
     }
-    Ok(Some(physical_columns))
+    Some(physical_columns)
 }
 
 fn empty_row_count_batch(row_count: usize) -> Result<RecordBatch> {
@@ -322,7 +320,7 @@ fn alias_physical_column_name(name: &str, alias_physical: bool) -> String {
     }
 }
 
-fn rename_batch(batch: RecordBatch, schema: &DatasetSchema) -> Result<RecordBatch> {
+fn rename_batch(batch: &RecordBatch, schema: &DatasetSchema) -> Result<RecordBatch> {
     Ok(RecordBatch::try_new(
         Arc::new(schema.to_arrow_schema()),
         batch.columns().to_vec(),
@@ -578,6 +576,10 @@ fn logical_axis_array(mode: &ResolvedScanAxisMode, values: &[Option<ScanAxisValu
     }
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Logical integer scan coordinates are plotted on Float64 chart axes"
+)]
 fn numeric_axis_array(values: &[Option<ScanAxisValue>]) -> ArrayRef {
     Arc::new(Float64Array::from(
         values
@@ -679,11 +681,11 @@ fn filter_batch(batch: &RecordBatch, mask: &[bool]) -> Result<RecordBatch> {
     Ok(RecordBatch::try_new(batch.schema(), arrays)?)
 }
 
-fn concat_or_empty(schema: SchemaRef, batches: Vec<RecordBatch>) -> Result<RecordBatch> {
+fn concat_or_empty(schema: SchemaRef, batches: &[RecordBatch]) -> Result<RecordBatch> {
     if batches.is_empty() {
         Ok(RecordBatch::new_empty(schema))
     } else {
-        concat_batches(&schema, &batches).context("Failed to concat chart batches")
+        concat_batches(&schema, batches).context("Failed to concat chart batches")
     }
 }
 
@@ -759,7 +761,7 @@ mod tests {
         )
         .expect("selected columns");
 
-        assert_eq!(selected, Some(vec![0, 1]));
+        assert_eq!(selected, vec![0, 1]);
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -36,6 +36,7 @@ pub(crate) struct PreparedChartData {
     pub(crate) batch: RecordBatch,
     pub(crate) schema: DatasetSchema,
     pub(crate) index_columns: Option<Vec<usize>>,
+    pub(crate) row_indices: Vec<usize>,
 }
 
 pub(crate) fn column_id(name: &str) -> String {
@@ -152,14 +153,13 @@ pub(crate) async fn load_axis_rows(
     Ok((fields, rows))
 }
 
-pub(crate) fn apply_semantic_filters(
-    batch: RecordBatch,
+fn semantic_filter_mask(
+    batch: &RecordBatch,
     filters: &[(String, serde_json::Value)],
-) -> Result<RecordBatch> {
+) -> Result<Option<Vec<bool>>> {
     if filters.is_empty() || batch.num_rows() == 0 {
-        return Ok(batch);
+        return Ok(None);
     }
-
     let mut mask = Vec::with_capacity(batch.num_rows());
     for row in 0..batch.num_rows() {
         let mut keep = true;
@@ -175,7 +175,7 @@ pub(crate) fn apply_semantic_filters(
         }
         mask.push(keep);
     }
-    filter_batch(&batch, &mask)
+    Ok(Some(mask))
 }
 
 fn prepare_batch_from_reader(
@@ -188,8 +188,20 @@ fn prepare_batch_from_reader(
     filters: &[(String, serde_json::Value)],
 ) -> Result<PreparedChartData> {
     let mut schema = source_schema.clone();
-    let mut batch = append_logical_axes(dataset, interpretation, &mut schema, batch, start, end)?;
-    batch = apply_semantic_filters(batch, filters)?;
+    let mut row_indices = (start..end).collect::<Vec<_>>();
+    let mut batch = append_logical_axes(
+        dataset,
+        interpretation,
+        &mut schema,
+        batch,
+        &mut row_indices,
+        start,
+        end,
+    )?;
+    if let Some(mask) = semantic_filter_mask(&batch, filters)? {
+        batch = filter_batch(&batch, &mask)?;
+        row_indices = filter_row_indices(&row_indices, &mask);
+    }
     let index_columns = resolve_index_columns(interpretation, &schema).or_else(|| {
         fallback_to_inferred_index_columns(interpretation)
             .then(|| {
@@ -203,6 +215,7 @@ fn prepare_batch_from_reader(
         batch,
         schema,
         index_columns,
+        row_indices,
     })
 }
 
@@ -297,6 +310,7 @@ fn append_logical_axes(
     interpretation: &DatasetInterpretation,
     schema: &mut DatasetSchema,
     batch: RecordBatch,
+    row_indices: &mut Vec<usize>,
     start: usize,
     end: usize,
 ) -> Result<RecordBatch> {
@@ -307,6 +321,9 @@ fn append_logical_axes(
     let record_ids = dataset.record_ids_range((Bound::Included(start), Bound::Excluded(end)))?;
     if record_ids.len() != batch.num_rows() {
         bail!("Logical index rows do not match selected chart rows");
+    }
+    if row_indices.len() != batch.num_rows() {
+        bail!("Logical row indices do not match selected chart rows");
     }
     let point_by_record_id = logical_points_by_record_id(
         dataset.logical_index_points_for_record_ids(&record_ids)?,
@@ -327,42 +344,41 @@ fn append_logical_axes(
         .zip(&keep_mask)
         .filter_map(|(record_id, keep)| (*keep).then_some(record_id))
         .collect::<Vec<_>>();
+    *row_indices = filter_row_indices(row_indices, &keep_mask);
     let mut batch = filter_batch(&batch, &keep_mask)?;
 
     let mut fields = batch.schema().fields().iter().cloned().collect::<Vec<_>>();
     let mut arrays = batch.columns().to_vec();
     let mut columns = schema.columns().clone();
-    for (axis_index, axis) in interpretation
-        .scan_axes
-        .iter()
-        .enumerate()
-        .filter(|(_, axis)| scan_axis_is_numeric(&axis.mode))
-    {
+    for (axis_index, axis) in interpretation.scan_axes.iter().enumerate() {
         let id = logical_index_id(&axis.name);
         let values = logical_axis_values(&kept_record_ids, &point_by_record_id, axis_index);
-        fields.push(Arc::new(Field::new(&id, DataType::Float64, true)));
-        arrays.push(numeric_axis_array(&values));
-        columns.insert(id, DatasetDataType::Scalar(ScalarKind::Numeric));
+        if scan_axis_is_numeric(&axis.mode) {
+            fields.push(Arc::new(Field::new(&id, DataType::Float64, true)));
+            arrays.push(numeric_axis_array(&values));
+            columns.insert(id, DatasetDataType::Scalar(ScalarKind::Numeric));
+        } else {
+            fields.push(Arc::new(Field::new(
+                &id,
+                logical_axis_data_type(&axis.mode),
+                true,
+            )));
+            arrays.push(logical_axis_array(&axis.mode, &values));
+            columns.insert(id, DatasetDataType::Scalar(ScalarKind::Complex));
+        }
     }
-
     *schema = DatasetSchema::new(columns);
-    for (axis_index, axis) in interpretation
-        .scan_axes
-        .iter()
-        .enumerate()
-        .filter(|(_, axis)| !scan_axis_is_numeric(&axis.mode))
-    {
-        let id = logical_index_id(&axis.name);
-        let values = logical_axis_values(&kept_record_ids, &point_by_record_id, axis_index);
-        fields.push(Arc::new(Field::new(
-            &id,
-            logical_axis_data_type(&axis.mode),
-            true,
-        )));
-        arrays.push(logical_axis_array(&axis.mode, &values));
-    }
     batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)?;
     Ok(batch)
+}
+
+fn filter_row_indices(row_indices: &[usize], mask: &[bool]) -> Vec<usize> {
+    row_indices
+        .iter()
+        .copied()
+        .zip(mask)
+        .filter_map(|(row, keep)| (*keep).then_some(row))
+        .collect()
 }
 
 fn axis_fields(interpretation: &DatasetInterpretation, batch: &RecordBatch) -> Vec<AxisField> {

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -5,14 +5,17 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use arrow_array::{Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, StringArray};
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_array::{
+    Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, StringArray, StructArray,
+};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
 use fricon::{
     DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, InterpretationSource,
     ResolvedDuplicatePolicy, ResolvedLogicalIndexPoint, ResolvedScanAxisMode, ScalarKind,
     SelectOptions, dataset::semantics::ScanAxisValue,
 };
+use indexmap::IndexMap;
 
 use super::types::ChartCommonOptions;
 use crate::desktop_runtime::session::WorkspaceSession;
@@ -62,21 +65,28 @@ pub(crate) async fn prepare_chart_data(
     id: i32,
     common: &ChartCommonOptions,
     filters: &[(String, serde_json::Value)],
+    selected_columns: Option<&[usize]>,
 ) -> Result<PreparedChartData> {
     let dataset = session.dataset(id).await?;
     let interpretation = dataset.interpret()?;
     let source_schema = dataset.schema()?.clone();
     let (start, end) = resolve_row_range(&dataset, common.start, common.end);
+    let selected_physical_columns =
+        selected_physical_columns(&source_schema, selected_columns, filters)?;
     let (output_schema, batches) = dataset.select_data(&SelectOptions {
         start: Bound::Included(start),
         end: Bound::Excluded(end),
         index_filters: None,
-        selected_columns: None,
+        selected_columns: selected_physical_columns.clone(),
     })?;
     let batch = concat_or_empty(output_schema, batches)?;
+    let selected_schema = selected_physical_columns.as_deref().map_or_else(
+        || Ok(source_schema.clone()),
+        |columns| project_schema(&source_schema, columns),
+    )?;
     prepare_batch_from_reader(
         &dataset,
-        &source_schema,
+        &selected_schema,
         &interpretation,
         batch,
         start,
@@ -172,7 +182,11 @@ fn prepare_batch_from_reader(
     batch = apply_semantic_filters(batch, filters)?;
     let index_columns = resolve_index_columns(interpretation, &schema).or_else(|| {
         fallback_to_inferred_index_columns(interpretation)
-            .then(|| dataset.try_index_columns().ok().flatten())
+            .then(|| {
+                let full_schema = dataset.schema().ok()?;
+                let indices = dataset.try_index_columns().ok().flatten()?;
+                Some(map_full_index_columns(full_schema, &schema, &indices))
+            })
             .flatten()
     });
     Ok(PreparedChartData {
@@ -186,6 +200,65 @@ fn fallback_to_inferred_index_columns(interpretation: &DatasetInterpretation) ->
     interpretation.source == InterpretationSource::CompatibilityInference
         || (interpretation.scan_axes.is_empty()
             && interpretation.chart_axis_candidate_columns.is_empty())
+}
+
+fn selected_physical_columns(
+    source_schema: &DatasetSchema,
+    selected_columns: Option<&[usize]>,
+    filters: &[(String, serde_json::Value)],
+) -> Result<Option<Vec<usize>>> {
+    let Some(selected_columns) = selected_columns else {
+        return Ok(None);
+    };
+
+    let mut physical_columns = Vec::new();
+    for &index in selected_columns {
+        if index < source_schema.columns().len() {
+            push_unique(&mut physical_columns, index);
+        }
+    }
+    for (field, _) in filters {
+        let column_name = resolve_axis_column_name(field);
+        if let Some((index, _, _)) = source_schema.columns().get_full(&column_name) {
+            push_unique(&mut physical_columns, index);
+        }
+    }
+    Ok(Some(physical_columns))
+}
+
+fn push_unique(columns: &mut Vec<usize>, index: usize) {
+    if !columns.contains(&index) {
+        columns.push(index);
+    }
+}
+
+fn project_schema(source_schema: &DatasetSchema, columns: &[usize]) -> Result<DatasetSchema> {
+    let mut projected = IndexMap::new();
+    for &index in columns {
+        let (name, dtype) = source_schema
+            .columns()
+            .get_index(index)
+            .with_context(|| format!("Selected dataset column index out of bounds: {index}"))?;
+        projected.insert(name.clone(), *dtype);
+    }
+    Ok(DatasetSchema::new(projected))
+}
+
+fn map_full_index_columns(
+    full_schema: &DatasetSchema,
+    selected_schema: &DatasetSchema,
+    indices: &[usize],
+) -> Vec<usize> {
+    indices
+        .iter()
+        .filter_map(|&index| {
+            let name = full_schema.columns().get_index(index)?.0;
+            selected_schema
+                .columns()
+                .get_full(name)
+                .map(|(selected_index, _, _)| selected_index)
+        })
+        .collect()
 }
 
 fn append_logical_axes(
@@ -460,8 +533,39 @@ fn json_value_at(array: &dyn Array, row: usize) -> Result<serde_json::Value> {
                 .context("Expected StringArray")?;
             Ok(serde_json::Value::from(array.value(row)))
         }
+        DataType::Struct(fields) if is_complex_fields(fields) => {
+            let array = array
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .context("Expected complex StructArray")?;
+            let real = array
+                .column(0)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .context("Expected complex real Float64Array")?
+                .value(row);
+            let imag = array
+                .column(1)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .context("Expected complex imag Float64Array")?
+                .value(row);
+            Ok(serde_json::json!({
+                "real": real,
+                "imag": imag,
+            }))
+        }
         other => bail!("Unsupported semantic axis data type: {other}"),
     }
+}
+
+fn is_complex_fields(fields: &Fields) -> bool {
+    fields.as_ref().as_array::<2>().is_some_and(|[real, imag]| {
+        real.name() == "real"
+            && imag.name() == "imag"
+            && matches!(real.data_type(), DataType::Float64)
+            && matches!(imag.data_type(), DataType::Float64)
+    })
 }
 
 fn filter_batch(batch: &RecordBatch, mask: &[bool]) -> Result<RecordBatch> {
@@ -503,6 +607,8 @@ fn resolve_row_range(
 
 #[cfg(test)]
 mod tests {
+    use arrow_array::StructArray;
+
     use super::*;
 
     fn point(record_id: u64, indices: Vec<u64>) -> ResolvedLogicalIndexPoint {
@@ -538,5 +644,49 @@ mod tests {
 
         assert!(projected.contains_key(&0));
         assert!(projected.contains_key(&1));
+    }
+
+    #[test]
+    fn selected_physical_columns_keep_requested_payloads_and_filter_axes() {
+        let source_schema = DatasetSchema::new(IndexMap::from([
+            (
+                "quantity".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Numeric),
+            ),
+            (
+                "axis".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Numeric),
+            ),
+        ]));
+
+        let selected = selected_physical_columns(
+            &source_schema,
+            Some(&[0, 2]),
+            &[("column:axis".to_string(), serde_json::json!(1.0))],
+        )
+        .expect("selected columns");
+
+        assert_eq!(selected, Some(vec![0, 1]));
+    }
+
+    #[test]
+    fn json_value_at_serializes_complex_struct_axes() {
+        let array = StructArray::new(
+            vec![
+                Field::new("real", DataType::Float64, false),
+                Field::new("imag", DataType::Float64, false),
+            ]
+            .into(),
+            vec![
+                Arc::new(Float64Array::from(vec![1.0])) as ArrayRef,
+                Arc::new(Float64Array::from(vec![2.0])) as ArrayRef,
+            ],
+            None,
+        );
+
+        assert_eq!(
+            json_value_at(&array, 0).expect("complex value"),
+            serde_json::json!({"real": 1.0, "imag": 2.0})
+        );
     }
 }

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -48,10 +48,14 @@ pub(crate) fn logical_index_id(name: &str) -> String {
 }
 
 pub(crate) fn resolve_column_name(value: &str) -> String {
-    value
-        .strip_prefix(COLUMN_PREFIX)
-        .unwrap_or(value)
-        .to_string()
+    let Some(column_name) = value.strip_prefix(COLUMN_PREFIX) else {
+        return value.to_string();
+    };
+    if column_name.starts_with(LOGICAL_INDEX_PREFIX) || column_name.starts_with(COLUMN_PREFIX) {
+        value.to_string()
+    } else {
+        column_name.to_string()
+    }
 }
 
 pub(crate) fn resolve_axis_column_name(value: &str) -> String {
@@ -60,6 +64,13 @@ pub(crate) fn resolve_axis_column_name(value: &str) -> String {
     } else {
         resolve_column_name(value)
     }
+}
+
+fn resolve_source_column_name(value: &str) -> String {
+    value
+        .strip_prefix(COLUMN_PREFIX)
+        .unwrap_or(value)
+        .to_string()
 }
 
 pub(crate) async fn prepare_chart_data(
@@ -72,6 +83,7 @@ pub(crate) async fn prepare_chart_data(
     let dataset = session.dataset(id).await?;
     let interpretation = dataset.interpret()?;
     let source_schema = dataset.schema()?.clone();
+    let alias_physical_columns = !interpretation.scan_axes.is_empty();
     let (start, end) = resolve_row_range(&dataset, common.start, common.end);
     let selected_physical_columns =
         selected_physical_columns(&source_schema, selected_columns, filters)?;
@@ -83,9 +95,10 @@ pub(crate) async fn prepare_chart_data(
     })?;
     let batch = concat_or_empty(output_schema, batches)?;
     let selected_schema = selected_physical_columns.as_deref().map_or_else(
-        || Ok(source_schema.clone()),
-        |columns| project_schema(&source_schema, columns),
+        || project_all_schema(&source_schema, alias_physical_columns),
+        |columns| project_schema(&source_schema, columns, alias_physical_columns),
     )?;
+    let batch = rename_batch(batch, &selected_schema)?;
     prepare_batch_from_reader(
         &dataset,
         &selected_schema,
@@ -121,7 +134,7 @@ pub(crate) async fn load_axis_rows(
         })?;
         concat_or_empty(output_schema, batches)?
     };
-    let selected_schema = project_schema(&source_schema, &selected_columns)?;
+    let selected_schema = project_schema(&source_schema, &selected_columns, false)?;
     let prepared = prepare_batch_from_reader(
         &dataset,
         &selected_schema,
@@ -254,7 +267,7 @@ fn selected_physical_columns(
         }
     }
     for (field, _) in filters {
-        let column_name = resolve_axis_column_name(field);
+        let column_name = resolve_source_column_name(field);
         if let Some((index, _, _)) = source_schema.columns().get_full(&column_name) {
             push_unique(&mut physical_columns, index);
         }
@@ -276,16 +289,44 @@ fn push_unique(columns: &mut Vec<usize>, index: usize) {
     }
 }
 
-fn project_schema(source_schema: &DatasetSchema, columns: &[usize]) -> Result<DatasetSchema> {
+fn project_all_schema(
+    source_schema: &DatasetSchema,
+    alias_physical: bool,
+) -> Result<DatasetSchema> {
+    let columns = (0..source_schema.columns().len()).collect::<Vec<_>>();
+    project_schema(source_schema, &columns, alias_physical)
+}
+
+fn project_schema(
+    source_schema: &DatasetSchema,
+    columns: &[usize],
+    alias_physical: bool,
+) -> Result<DatasetSchema> {
     let mut projected = IndexMap::new();
     for &index in columns {
         let (name, dtype) = source_schema
             .columns()
             .get_index(index)
             .with_context(|| format!("Selected dataset column index out of bounds: {index}"))?;
-        projected.insert(name.clone(), *dtype);
+        projected.insert(alias_physical_column_name(name, alias_physical), *dtype);
     }
     Ok(DatasetSchema::new(projected))
+}
+
+fn alias_physical_column_name(name: &str, alias_physical: bool) -> String {
+    if alias_physical && (name.starts_with(LOGICAL_INDEX_PREFIX) || name.starts_with(COLUMN_PREFIX))
+    {
+        column_id(name)
+    } else {
+        name.to_string()
+    }
+}
+
+fn rename_batch(batch: RecordBatch, schema: &DatasetSchema) -> Result<RecordBatch> {
+    Ok(RecordBatch::try_new(
+        Arc::new(schema.to_arrow_schema()),
+        batch.columns().to_vec(),
+    )?)
 }
 
 fn map_full_index_columns(
@@ -714,6 +755,30 @@ mod tests {
         .expect("selected columns");
 
         assert_eq!(selected, Some(vec![0, 1]));
+    }
+
+    #[test]
+    fn prefixed_physical_columns_keep_column_namespace() {
+        assert_eq!(
+            resolve_column_name("column:logicalIndex:gate"),
+            "column:logicalIndex:gate"
+        );
+        assert_eq!(
+            resolve_axis_column_name("column:logicalIndex:gate"),
+            "column:logicalIndex:gate"
+        );
+        assert_eq!(
+            resolve_source_column_name("column:logicalIndex:gate"),
+            "logicalIndex:gate"
+        );
+
+        let source_schema = DatasetSchema::new(IndexMap::from([(
+            "logicalIndex:gate".to_string(),
+            DatasetDataType::Scalar(ScalarKind::Numeric),
+        )]));
+        let projected = project_schema(&source_schema, &[0], true).expect("project schema");
+
+        assert!(projected.columns().contains_key("column:logicalIndex:gate"));
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -83,7 +83,7 @@ pub(crate) async fn prepare_chart_data(
     let dataset = session.dataset(id).await?;
     let interpretation = dataset.interpret()?;
     let source_schema = dataset.schema()?.clone();
-    let alias_physical_columns = !interpretation.scan_axes.is_empty();
+    let alias_physical_columns = true;
     let (start, end) = resolve_row_range(&dataset, common.start, common.end);
     let selected_physical_columns =
         selected_physical_columns(&source_schema, selected_columns, filters)?;
@@ -341,6 +341,11 @@ fn map_full_index_columns(
             selected_schema
                 .columns()
                 .get_full(name)
+                .or_else(|| {
+                    selected_schema
+                        .columns()
+                        .get_full(&alias_physical_column_name(name, true))
+                })
                 .map(|(selected_index, _, _)| selected_index)
         })
         .collect()
@@ -779,6 +784,10 @@ mod tests {
         let projected = project_schema(&source_schema, &[0], true).expect("project schema");
 
         assert!(projected.columns().contains_key("column:logicalIndex:gate"));
+        assert_eq!(
+            map_full_index_columns(&source_schema, &projected, &[0]),
+            vec![0]
+        );
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -6,7 +6,8 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use arrow_array::{
-    Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, StringArray, StructArray,
+    Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, RecordBatchOptions, StringArray,
+    StructArray,
 };
 use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
@@ -104,16 +105,25 @@ pub(crate) async fn load_axis_rows(
     let interpretation = dataset.interpret()?;
     let source_schema = dataset.schema()?.clone();
     let end = dataset.num_rows();
-    let (output_schema, batches) = dataset.select_data(&SelectOptions {
-        start: Bound::Included(0),
-        end: Bound::Excluded(end),
-        index_filters: None,
-        selected_columns: None,
-    })?;
-    let batch = concat_or_empty(output_schema, batches)?;
+    let selected_columns = axis_row_selected_columns(&dataset, &interpretation)?;
+    if interpretation.scan_axes.is_empty() && selected_columns.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let batch = if selected_columns.is_empty() {
+        empty_row_count_batch(end)?
+    } else {
+        let (output_schema, batches) = dataset.select_data(&SelectOptions {
+            start: Bound::Included(0),
+            end: Bound::Excluded(end),
+            index_filters: None,
+            selected_columns: Some(selected_columns.clone()),
+        })?;
+        concat_or_empty(output_schema, batches)?
+    };
+    let selected_schema = project_schema(&source_schema, &selected_columns)?;
     let prepared = prepare_batch_from_reader(
         &dataset,
-        &source_schema,
+        &selected_schema,
         &interpretation,
         batch,
         0,
@@ -202,6 +212,19 @@ fn fallback_to_inferred_index_columns(interpretation: &DatasetInterpretation) ->
             && interpretation.chart_axis_candidate_columns.is_empty())
 }
 
+fn axis_row_selected_columns(
+    dataset: &DatasetReader,
+    interpretation: &DatasetInterpretation,
+) -> Result<Vec<usize>> {
+    if !interpretation.scan_axes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(index_columns) = dataset.try_index_columns()? else {
+        return Ok(Vec::new());
+    };
+    Ok(index_columns)
+}
+
 fn selected_physical_columns(
     source_schema: &DatasetSchema,
     selected_columns: Option<&[usize]>,
@@ -224,6 +247,14 @@ fn selected_physical_columns(
         }
     }
     Ok(Some(physical_columns))
+}
+
+fn empty_row_count_batch(row_count: usize) -> Result<RecordBatch> {
+    Ok(RecordBatch::try_new_with_options(
+        Arc::new(Schema::new(Vec::<Field>::new())),
+        Vec::new(),
+        &RecordBatchOptions::new().with_row_count(Some(row_count)),
+    )?)
 }
 
 fn push_unique(columns: &mut Vec<usize>, index: usize) {

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -6,8 +6,8 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use arrow_array::{
-    Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, RecordBatchOptions, StringArray,
-    StructArray,
+    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int64Array, RecordBatch,
+    RecordBatchOptions, StringArray, StructArray, UInt64Array,
 };
 use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
@@ -321,10 +321,73 @@ fn alias_physical_column_name(name: &str, alias_physical: bool) -> String {
 }
 
 fn rename_batch(batch: &RecordBatch, schema: &DatasetSchema) -> Result<RecordBatch> {
-    Ok(RecordBatch::try_new(
-        Arc::new(schema.to_arrow_schema()),
-        batch.columns().to_vec(),
-    )?)
+    let arrow_schema = Arc::new(schema.to_arrow_schema());
+    let columns = batch
+        .columns()
+        .iter()
+        .zip(arrow_schema.fields())
+        .map(|(column, field)| coerce_column_for_field(column, field))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(RecordBatch::try_new(arrow_schema, columns)?)
+}
+
+fn coerce_column_for_field(column: &ArrayRef, field: &Field) -> Result<ArrayRef> {
+    if column.data_type() == field.data_type() {
+        return Ok(column.clone());
+    }
+    if matches!(field.data_type(), DataType::Float64) {
+        return coerce_numeric_to_float64(column.as_ref());
+    }
+    Ok(column.clone())
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "Chart transforms normalize supported numeric axis candidates to Float64"
+)]
+fn coerce_numeric_to_float64(column: &dyn Array) -> Result<ArrayRef> {
+    match column.data_type() {
+        DataType::Float32 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .context("Expected Float32Array")?;
+            Ok(Arc::new(
+                array
+                    .iter()
+                    .map(|value| value.map(f64::from))
+                    .collect::<Float64Array>(),
+            ))
+        }
+        DataType::Int64 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .context("Expected Int64Array")?;
+            Ok(Arc::new(
+                array
+                    .iter()
+                    .map(|value| value.map(|value| value as f64))
+                    .collect::<Float64Array>(),
+            ))
+        }
+        DataType::UInt64 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .context("Expected UInt64Array")?;
+            Ok(Arc::new(
+                array
+                    .iter()
+                    .map(|value| value.map(|value| value as f64))
+                    .collect::<Float64Array>(),
+            ))
+        }
+        _ => bail!(
+            "Cannot use {} column as a Float64 chart coordinate",
+            column.data_type()
+        ),
+    }
 }
 
 fn map_full_index_columns(
@@ -762,6 +825,33 @@ mod tests {
         .expect("selected columns");
 
         assert_eq!(selected, vec![0, 1]);
+    }
+
+    #[test]
+    fn rename_batch_normalizes_supported_numeric_columns_to_float64() {
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "axis",
+            DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            source_schema,
+            vec![Arc::new(Int64Array::from(vec![1_i64, 2_i64])) as ArrayRef],
+        )
+        .expect("source batch");
+        let target_schema = DatasetSchema::new(IndexMap::from([(
+            "axis".to_string(),
+            DatasetDataType::Scalar(ScalarKind::Numeric),
+        )]));
+
+        let renamed = rename_batch(&batch, &target_schema).expect("renamed batch");
+        let axis = renamed
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("Float64 chart axis");
+
+        assert_eq!(axis.values(), &[1.0, 2.0]);
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -106,7 +106,7 @@ pub(crate) async fn load_axis_rows(
         end,
         &[],
     )?;
-    let fields = axis_fields(&interpretation, &prepared.schema)
+    let fields = axis_fields(&interpretation, &prepared.batch)
         .into_iter()
         .filter(|field| !exclude_fields.iter().any(|excluded| excluded == &field.id))
         .collect::<Vec<_>>();
@@ -187,16 +187,6 @@ fn append_logical_axes(
         return Ok(batch);
     }
 
-    let logical_axes = interpretation
-        .scan_axes
-        .iter()
-        .enumerate()
-        .filter(|(_, axis)| scan_axis_is_numeric(&axis.mode))
-        .collect::<Vec<_>>();
-    if logical_axes.is_empty() {
-        return Ok(batch);
-    }
-
     let point_by_record_id = dataset
         .logical_index_points()?
         .into_iter()
@@ -226,27 +216,40 @@ fn append_logical_axes(
     let mut fields = batch.schema().fields().iter().cloned().collect::<Vec<_>>();
     let mut arrays = batch.columns().to_vec();
     let mut columns = schema.columns().clone();
-    for (axis_index, axis) in logical_axes {
+    for (axis_index, axis) in interpretation
+        .scan_axes
+        .iter()
+        .enumerate()
+        .filter(|(_, axis)| scan_axis_is_numeric(&axis.mode))
+    {
         let id = logical_index_id(&axis.name);
-        let values = kept_record_ids
-            .iter()
-            .map(|record_id| {
-                point_by_record_id
-                    .get(record_id)
-                    .and_then(|point| numeric_coordinate(point, axis_index))
-            })
-            .collect::<Vec<_>>();
+        let values = logical_axis_values(&kept_record_ids, &point_by_record_id, axis_index);
         fields.push(Arc::new(Field::new(&id, DataType::Float64, true)));
-        arrays.push(Arc::new(Float64Array::from(values)) as ArrayRef);
+        arrays.push(numeric_axis_array(&values));
         columns.insert(id, DatasetDataType::Scalar(ScalarKind::Numeric));
     }
 
     *schema = DatasetSchema::new(columns);
+    for (axis_index, axis) in interpretation
+        .scan_axes
+        .iter()
+        .enumerate()
+        .filter(|(_, axis)| !scan_axis_is_numeric(&axis.mode))
+    {
+        let id = logical_index_id(&axis.name);
+        let values = logical_axis_values(&kept_record_ids, &point_by_record_id, axis_index);
+        fields.push(Arc::new(Field::new(
+            &id,
+            logical_axis_data_type(&axis.mode),
+            true,
+        )));
+        arrays.push(logical_axis_array(&axis.mode, &values));
+    }
     batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)?;
     Ok(batch)
 }
 
-fn axis_fields(interpretation: &DatasetInterpretation, schema: &DatasetSchema) -> Vec<AxisField> {
+fn axis_fields(interpretation: &DatasetInterpretation, batch: &RecordBatch) -> Vec<AxisField> {
     let mut fields = Vec::new();
     if interpretation.scan_axes.is_empty() {
         fields.extend(
@@ -268,7 +271,7 @@ fn axis_fields(interpretation: &DatasetInterpretation, schema: &DatasetSchema) -
     } else {
         fields.extend(interpretation.scan_axes.iter().filter_map(|axis| {
             let id = logical_index_id(&axis.name);
-            schema.columns().contains_key(&id).then(|| AxisField {
+            batch.schema().field_with_name(&id).ok().map(|_| AxisField {
                 id: id.clone(),
                 column_name: id,
                 label: axis.label.clone().unwrap_or_else(|| axis.name.clone()),
@@ -293,7 +296,11 @@ fn resolve_index_columns(
             indices.push(index);
         }
     }
-    for axis in &interpretation.scan_axes {
+    for axis in interpretation
+        .scan_axes
+        .iter()
+        .filter(|axis| scan_axis_is_numeric(&axis.mode))
+    {
         let id = logical_index_id(&axis.name);
         if let Some((index, _, _)) = schema.columns().get_full(&id) {
             indices.push(index);
@@ -315,11 +322,84 @@ fn scan_axis_is_numeric(mode: &ResolvedScanAxisMode) -> bool {
     }
 }
 
-fn numeric_coordinate(point: &ResolvedLogicalIndexPoint, axis_index: usize) -> Option<f64> {
-    match point.coordinates.get(axis_index)? {
-        ScanAxisValue::Int(value) => Some(*value as f64),
-        ScanAxisValue::Float(value) => Some(*value),
-        ScanAxisValue::Bool(_) | ScanAxisValue::String(_) => None,
+fn logical_axis_values(
+    record_ids: &[u64],
+    point_by_record_id: &HashMap<u64, ResolvedLogicalIndexPoint>,
+    axis_index: usize,
+) -> Vec<Option<ScanAxisValue>> {
+    record_ids
+        .iter()
+        .map(|record_id| {
+            point_by_record_id
+                .get(record_id)
+                .and_then(|point| point.coordinates.get(axis_index))
+                .cloned()
+        })
+        .collect()
+}
+
+fn logical_axis_data_type(mode: &ResolvedScanAxisMode) -> DataType {
+    match mode {
+        ResolvedScanAxisMode::ImplicitIndex => DataType::Float64,
+        ResolvedScanAxisMode::Static { values } => {
+            if values
+                .iter()
+                .all(|value| matches!(value, ScanAxisValue::Bool(_)))
+            {
+                DataType::Boolean
+            } else if values
+                .iter()
+                .all(|value| matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_)))
+            {
+                DataType::Float64
+            } else {
+                DataType::Utf8
+            }
+        }
+    }
+}
+
+fn logical_axis_array(mode: &ResolvedScanAxisMode, values: &[Option<ScanAxisValue>]) -> ArrayRef {
+    match logical_axis_data_type(mode) {
+        DataType::Boolean => Arc::new(BooleanArray::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ScanAxisValue::Bool(value)) => Some(*value),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        )),
+        DataType::Float64 => numeric_axis_array(values),
+        DataType::Utf8 => Arc::new(StringArray::from(
+            values
+                .iter()
+                .map(|value| value.as_ref().map(scan_axis_value_to_string))
+                .collect::<Vec<_>>(),
+        )),
+        _ => unreachable!("logical scan axes only use bool, numeric, or string arrays"),
+    }
+}
+
+fn numeric_axis_array(values: &[Option<ScanAxisValue>]) -> ArrayRef {
+    Arc::new(Float64Array::from(
+        values
+            .iter()
+            .map(|value| match value.as_ref()? {
+                ScanAxisValue::Int(value) => Some(*value as f64),
+                ScanAxisValue::Float(value) => Some(*value),
+                ScanAxisValue::Bool(_) | ScanAxisValue::String(_) => None,
+            })
+            .collect::<Vec<_>>(),
+    ))
+}
+
+fn scan_axis_value_to_string(value: &ScanAxisValue) -> String {
+    match value {
+        ScanAxisValue::String(value) => value.clone(),
+        ScanAxisValue::Int(value) => value.to_string(),
+        ScanAxisValue::Float(value) => value.to_string(),
+        ScanAxisValue::Bool(value) => value.to_string(),
     }
 }
 

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, ops::Bound, sync::Arc};
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    ops::Bound,
+    sync::Arc,
+};
 
 use anyhow::{Context, Result, bail};
 use arrow_array::{Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, StringArray};
@@ -196,15 +200,14 @@ fn append_logical_axes(
         return Ok(batch);
     }
 
-    let point_by_record_id = dataset
-        .logical_index_points()?
-        .into_iter()
-        .map(|point| (point.record_id, point))
-        .collect::<HashMap<_, _>>();
     let record_ids = dataset.record_ids_range((Bound::Included(start), Bound::Excluded(end)))?;
     if record_ids.len() != batch.num_rows() {
         bail!("Logical index rows do not match selected chart rows");
     }
+    let point_by_record_id = logical_points_by_record_id(
+        dataset.logical_index_points_for_record_ids(&record_ids)?,
+        interpretation.duplicate_policy,
+    );
 
     let keep_mask = if interpretation.duplicate_policy == ResolvedDuplicatePolicy::LatestByRecordId
     {
@@ -319,6 +322,35 @@ fn scan_axis_is_numeric(mode: &ResolvedScanAxisMode) -> bool {
             .iter()
             .all(|value| matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_))),
     }
+}
+
+fn logical_points_by_record_id(
+    points: Vec<ResolvedLogicalIndexPoint>,
+    duplicate_policy: ResolvedDuplicatePolicy,
+) -> HashMap<u64, ResolvedLogicalIndexPoint> {
+    if duplicate_policy != ResolvedDuplicatePolicy::LatestByRecordId {
+        return points
+            .into_iter()
+            .map(|point| (point.record_id, point))
+            .collect();
+    }
+
+    let mut latest_by_indices: HashMap<Vec<u64>, ResolvedLogicalIndexPoint> = HashMap::new();
+    for point in points {
+        match latest_by_indices.entry(point.indices.clone()) {
+            Entry::Occupied(mut entry) if point.record_id > entry.get().record_id => {
+                entry.insert(point);
+            }
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                entry.insert(point);
+            }
+        }
+    }
+    latest_by_indices
+        .into_values()
+        .map(|point| (point.record_id, point))
+        .collect()
 }
 
 fn logical_axis_values(
@@ -467,4 +499,44 @@ fn resolve_row_range(
     let start = start.unwrap_or(0).min(total_rows);
     let end = end.unwrap_or(total_rows).min(total_rows).max(start);
     (start, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point(record_id: u64, indices: Vec<u64>) -> ResolvedLogicalIndexPoint {
+        ResolvedLogicalIndexPoint {
+            record_id,
+            indices,
+            coordinates: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn latest_logical_points_are_projected_within_selected_points() {
+        let projected = logical_points_by_record_id(
+            vec![
+                point(0, vec![0, 0]),
+                point(1, vec![0, 1]),
+                point(2, vec![0, 0]),
+            ],
+            ResolvedDuplicatePolicy::LatestByRecordId,
+        );
+
+        assert!(!projected.contains_key(&0));
+        assert!(projected.contains_key(&1));
+        assert!(projected.contains_key(&2));
+    }
+
+    #[test]
+    fn bounded_logical_points_do_not_consider_later_replacements() {
+        let projected = logical_points_by_record_id(
+            vec![point(0, vec![0, 0]), point(1, vec![0, 1])],
+            ResolvedDuplicatePolicy::LatestByRecordId,
+        );
+
+        assert!(projected.contains_key(&0));
+        assert!(projected.contains_key(&1));
+    }
 }

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -234,8 +234,7 @@ fn prepare_batch_from_reader(
 
 fn fallback_to_inferred_index_columns(interpretation: &DatasetInterpretation) -> bool {
     interpretation.source == InterpretationSource::CompatibilityInference
-        || (interpretation.scan_axes.is_empty()
-            && interpretation.chart_axis_candidate_columns.is_empty())
+        || interpretation.scan_axes.is_empty()
 }
 
 fn axis_row_selected_columns(
@@ -802,6 +801,22 @@ mod tests {
 
         assert!(projected.contains_key(&0));
         assert!(projected.contains_key(&1));
+    }
+
+    #[test]
+    fn manifest_without_scan_axes_still_uses_inferred_index_fallback() {
+        let interpretation = DatasetInterpretation {
+            columns: Vec::new(),
+            value_columns: Vec::new(),
+            logical_index_columns: Vec::new(),
+            chart_axis_candidate_columns: vec![fricon::VisibleColumnOrdinal(0)],
+            duplicate_policy: ResolvedDuplicatePolicy::LatestByRecordId,
+            index_realization: fricon::ResolvedIndexRealization::None,
+            scan_axes: Vec::new(),
+            source: InterpretationSource::Manifest,
+        };
+
+        assert!(fallback_to_inferred_index_columns(&interpretation));
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -5,9 +5,9 @@ use arrow_array::{Array, ArrayRef, BooleanArray, Float64Array, RecordBatch, Stri
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
 use fricon::{
-    DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, ResolvedDuplicatePolicy,
-    ResolvedLogicalIndexPoint, ResolvedScanAxisMode, ScalarKind, SelectOptions,
-    dataset::semantics::ScanAxisValue,
+    DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, InterpretationSource,
+    ResolvedDuplicatePolicy, ResolvedLogicalIndexPoint, ResolvedScanAxisMode, ScalarKind,
+    SelectOptions, dataset::semantics::ScanAxisValue,
 };
 
 use super::types::ChartCommonOptions;
@@ -166,13 +166,22 @@ fn prepare_batch_from_reader(
     let mut schema = source_schema.clone();
     let mut batch = append_logical_axes(dataset, interpretation, &mut schema, batch, start, end)?;
     batch = apply_semantic_filters(batch, filters)?;
-    let index_columns = resolve_index_columns(interpretation, &schema)
-        .or_else(|| dataset.try_index_columns().ok().flatten());
+    let index_columns = resolve_index_columns(interpretation, &schema).or_else(|| {
+        fallback_to_inferred_index_columns(interpretation)
+            .then(|| dataset.try_index_columns().ok().flatten())
+            .flatten()
+    });
     Ok(PreparedChartData {
         batch,
         schema,
         index_columns,
     })
+}
+
+fn fallback_to_inferred_index_columns(interpretation: &DatasetInterpretation) -> bool {
+    interpretation.source == InterpretationSource::CompatibilityInference
+        || (interpretation.scan_axes.is_empty()
+            && interpretation.chart_axis_candidate_columns.is_empty())
 }
 
 fn append_logical_axes(
@@ -286,16 +295,6 @@ fn resolve_index_columns(
     schema: &DatasetSchema,
 ) -> Option<Vec<usize>> {
     let mut indices = Vec::new();
-    for ordinal in &interpretation.chart_axis_candidate_columns {
-        if let Some(column) = interpretation
-            .columns
-            .iter()
-            .find(|column| column.visible_ordinal == Some(*ordinal))
-            && let Some((index, _, _)) = schema.columns().get_full(&column.name)
-        {
-            indices.push(index);
-        }
-    }
     for axis in interpretation
         .scan_axes
         .iter()

--- a/crates/fricon-ui/src/features/charts/transform.rs
+++ b/crates/fricon-ui/src/features/charts/transform.rs
@@ -5,7 +5,8 @@ pub(crate) mod mapping;
 pub(crate) mod xy;
 
 use anyhow::{Context, Result, bail};
-use arrow_array::RecordBatch;
+use arrow_array::{Array, BooleanArray, Float64Array, RecordBatch, StringArray};
+use arrow_schema::DataType;
 use fricon::{DatasetArray, DatasetSchema};
 
 pub(crate) use self::{
@@ -94,26 +95,20 @@ pub(super) fn compute_group_starts(
     }
 
     let column_names: Vec<&str> = schema.columns().keys().map(String::as_str).collect();
-    let group_values: Vec<Vec<f64>> = group_columns
+    let group_values: Vec<Vec<String>> = group_columns
         .iter()
         .map(|&idx| {
             let arr = batch
                 .column_by_name(column_names[idx])
                 .expect("group column present");
-            let ds: DatasetArray = arr.clone().try_into().expect("valid group column");
-            ds.as_numeric()
-                .expect("numeric group column")
-                .values()
-                .to_vec()
+            (0..num_rows)
+                .map(|row| group_value_at(arr.as_ref(), row))
+                .collect()
         })
         .collect();
 
     let mut group_starts = vec![0];
     for row in 1..num_rows {
-        #[expect(
-            clippy::float_cmp,
-            reason = "Index values are stored, not computed; exact comparison is correct"
-        )]
         if group_values.iter().any(|col| col[row] != col[row - 1]) {
             group_starts.push(row);
         }
@@ -194,9 +189,7 @@ pub(super) fn make_group_label(
         .map(|&idx| {
             let name = column_names[idx];
             let arr = batch.column_by_name(name).expect("group column present");
-            let ds: DatasetArray = arr.clone().try_into().expect("valid group column");
-            let value = ds.as_numeric().expect("numeric group column").values()[row];
-            format!("{name}={}", format_numeric_value(value))
+            format!("{name}={}", group_value_at(arr.as_ref(), row))
         })
         .collect::<Vec<_>>();
 
@@ -231,18 +224,28 @@ fn resolve_named_index_columns(
 ) -> Result<Vec<usize>> {
     let mut resolved = Vec::new();
     for name in names {
-        let index = resolve_named_index_column(schema, index_columns, name)?;
+        let index = resolve_named_group_column(schema, index_columns, name)?;
         if !resolved.contains(&index) {
             resolved.push(index);
         }
     }
-    resolved.sort_by_key(|index| {
-        index_columns
-            .iter()
-            .position(|candidate| candidate == index)
-            .expect("resolved index is present in index_columns")
-    });
+    resolved.sort_unstable();
     Ok(resolved)
+}
+
+fn resolve_named_group_column(
+    schema: &DatasetSchema,
+    index_columns: &[usize],
+    name: &str,
+) -> Result<usize> {
+    let (idx, _, _) = schema
+        .columns()
+        .get_full(name)
+        .with_context(|| format!("Column '{name}' not found"))?;
+    if index_columns.contains(&idx) || name.starts_with("logicalIndex:") {
+        return Ok(idx);
+    }
+    bail!("Column '{name}' is not an index column");
 }
 
 fn resolve_named_index_column(
@@ -258,6 +261,36 @@ fn resolve_named_index_column(
         bail!("Column '{name}' is not an index column");
     }
     Ok(idx)
+}
+
+fn group_value_at(array: &dyn Array, row: usize) -> String {
+    if array.is_null(row) {
+        return "null".to_string();
+    }
+    match array.data_type() {
+        DataType::Float64 => {
+            let array = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("Float64 group column");
+            format_numeric_value(array.value(row))
+        }
+        DataType::Boolean => {
+            let array = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("Boolean group column");
+            array.value(row).to_string()
+        }
+        DataType::Utf8 => {
+            let array = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Utf8 group column");
+            array.value(row).to_string()
+        }
+        other => panic!("unsupported group column data type: {other}"),
+    }
 }
 
 #[cfg(test)]
@@ -294,6 +327,13 @@ pub(super) mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Float64Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use fricon::{DatasetDataType, DatasetSchema, ScalarKind};
+    use indexmap::IndexMap;
+
     use super::{
         compute_group_starts, group_ranges, last_outer_group_start, resolve_xy_trace_roles,
         test_utils::{numeric_batch, numeric_schema},
@@ -320,6 +360,33 @@ mod tests {
         let batch = numeric_batch(&[("idx", &[1.0, 2.0, 3.0])]);
         let schema = numeric_schema(&["idx"]);
         assert_eq!(compute_group_starts(&batch, &schema, &[]), vec![0]);
+    }
+
+    #[test]
+    fn compute_group_starts_supports_string_logical_axes() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("logicalIndex:gate", DataType::Utf8, false),
+                Field::new("sweep", DataType::Float64, false),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["low", "low", "high", "high"])),
+                Arc::new(Float64Array::from(vec![0.0, 1.0, 0.0, 1.0])),
+            ],
+        )
+        .unwrap();
+        let schema = DatasetSchema::new(IndexMap::from([
+            (
+                "logicalIndex:gate".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Complex),
+            ),
+            (
+                "sweep".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Numeric),
+            ),
+        ]));
+
+        assert_eq!(compute_group_starts(&batch, &schema, &[0]), vec![0, 2]);
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/transform.rs
+++ b/crates/fricon-ui/src/features/charts/transform.rs
@@ -1,7 +1,6 @@
 pub(crate) mod heatmap;
 pub(crate) mod live_heatmap;
 pub(crate) mod live_xy;
-#[cfg(test)]
 pub(crate) mod mapping;
 pub(crate) mod xy;
 

--- a/crates/fricon-ui/src/features/charts/transform.rs
+++ b/crates/fricon-ui/src/features/charts/transform.rs
@@ -34,20 +34,7 @@ pub(super) fn resolve_xy_trace_roles(
     options: &XYTraceRoleOptions,
     draw_style: XYDrawStyle,
 ) -> Result<XYTraceRoles> {
-    let Some(index_columns) = index_columns else {
-        if options.sweep_index_column.is_some()
-            || options
-                .trace_group_index_columns
-                .as_ref()
-                .is_some_and(|columns| !columns.is_empty())
-        {
-            bail!("Trace roles require dataset index columns");
-        }
-        return Ok(XYTraceRoles {
-            trace_group: vec![],
-            sweep: None,
-        });
-    };
+    let index_columns = index_columns.unwrap_or(&[]);
 
     let trace_group = resolve_named_index_columns(
         schema,
@@ -415,6 +402,27 @@ mod tests {
 
         assert_eq!(roles.trace_group, vec![0]);
         assert_eq!(roles.sweep, Some(2));
+    }
+
+    #[test]
+    fn resolve_xy_trace_roles_allows_categorical_logical_group_without_numeric_indices() {
+        let schema = DatasetSchema::new(IndexMap::from([(
+            "logicalIndex:gate".to_string(),
+            DatasetDataType::Scalar(ScalarKind::Complex),
+        )]));
+        let roles = resolve_xy_trace_roles(
+            &schema,
+            None,
+            &XYTraceRoleOptions {
+                trace_group_index_columns: Some(vec!["logicalIndex:gate".to_string()]),
+                sweep_index_column: None,
+            },
+            XYDrawStyle::Line,
+        )
+        .unwrap();
+
+        assert_eq!(roles.trace_group, vec![0]);
+        assert_eq!(roles.sweep, None);
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/transform.rs
+++ b/crates/fricon-ui/src/features/charts/transform.rs
@@ -15,6 +15,14 @@ pub(crate) use self::{
 };
 use crate::features::charts::types::{XYDrawStyle, XYTraceRoleOptions};
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum GroupKey {
+    Null,
+    Float64(u64),
+    Boolean(bool),
+    Utf8(String),
+}
+
 pub(super) struct XYTraceRoles {
     pub(super) trace_group: Vec<usize>,
     pub(super) sweep: Option<usize>,
@@ -82,14 +90,14 @@ pub(super) fn compute_group_starts(
     }
 
     let column_names: Vec<&str> = schema.columns().keys().map(String::as_str).collect();
-    let group_values: Vec<Vec<String>> = group_columns
+    let group_values: Vec<Vec<GroupKey>> = group_columns
         .iter()
         .map(|&idx| {
             let arr = batch
                 .column_by_name(column_names[idx])
                 .expect("group column present");
             (0..num_rows)
-                .map(|row| group_value_at(arr.as_ref(), row))
+                .map(|row| group_key_at(arr.as_ref(), row))
                 .collect()
         })
         .collect();
@@ -189,8 +197,21 @@ pub(super) fn make_group_id_suffix(
     group_columns: &[usize],
     row: usize,
 ) -> Option<String> {
-    make_group_label(batch, schema, group_columns, row)
-        .map(|label| label.replace(", ", "|").replace('=', ":"))
+    if group_columns.is_empty() {
+        return None;
+    }
+
+    let column_names: Vec<&str> = schema.columns().keys().map(String::as_str).collect();
+    let parts = group_columns
+        .iter()
+        .map(|&idx| {
+            let name = column_names[idx];
+            let arr = batch.column_by_name(name).expect("group column present");
+            format!("{name}:{}", group_key_id_at(arr.as_ref(), row))
+        })
+        .collect::<Vec<_>>();
+
+    Some(parts.join("|"))
 }
 
 pub(super) fn format_numeric_value(value: f64) -> String {
@@ -280,6 +301,45 @@ fn group_value_at(array: &dyn Array, row: usize) -> String {
     }
 }
 
+fn group_key_at(array: &dyn Array, row: usize) -> GroupKey {
+    if array.is_null(row) {
+        return GroupKey::Null;
+    }
+    match array.data_type() {
+        DataType::Float64 => {
+            let array = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("Float64 group column");
+            GroupKey::Float64(array.value(row).to_bits())
+        }
+        DataType::Boolean => {
+            let array = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("Boolean group column");
+            GroupKey::Boolean(array.value(row))
+        }
+        DataType::Utf8 => {
+            let array = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Utf8 group column");
+            GroupKey::Utf8(array.value(row).to_string())
+        }
+        other => panic!("unsupported group column data type: {other}"),
+    }
+}
+
+fn group_key_id_at(array: &dyn Array, row: usize) -> String {
+    match group_key_at(array, row) {
+        GroupKey::Null => "null".to_string(),
+        GroupKey::Float64(bits) => format!("f64:{bits:016x}"),
+        GroupKey::Boolean(value) => format!("bool:{value}"),
+        GroupKey::Utf8(value) => format!("utf8:{}:{value}", value.len()),
+    }
+}
+
 #[cfg(test)]
 pub(super) mod test_utils {
     use std::sync::Arc;
@@ -322,7 +382,8 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::{
-        compute_group_starts, group_ranges, last_outer_group_start, resolve_xy_trace_roles,
+        compute_group_starts, group_ranges, last_outer_group_start, make_group_id_suffix,
+        resolve_xy_trace_roles,
         test_utils::{numeric_batch, numeric_schema},
     };
     use crate::features::charts::types::{XYDrawStyle, XYTraceRoleOptions};
@@ -347,6 +408,18 @@ mod tests {
         let batch = numeric_batch(&[("idx", &[1.0, 2.0, 3.0])]);
         let schema = numeric_schema(&["idx"]);
         assert_eq!(compute_group_starts(&batch, &schema, &[]), vec![0]);
+    }
+
+    #[test]
+    fn compute_group_starts_compares_numeric_keys_without_display_rounding() {
+        let batch = numeric_batch(&[("idx", &[0.123_456_4, 0.123_456_5])]);
+        let schema = numeric_schema(&["idx"]);
+
+        assert_eq!(compute_group_starts(&batch, &schema, &[0]), vec![0, 1]);
+        assert_ne!(
+            make_group_id_suffix(&batch, &schema, &[0], 0),
+            make_group_id_suffix(&batch, &schema, &[0], 1)
+        );
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/transform.rs
+++ b/crates/fricon-ui/src/features/charts/transform.rs
@@ -1,6 +1,7 @@
 pub(crate) mod heatmap;
 pub(crate) mod live_heatmap;
 pub(crate) mod live_xy;
+#[cfg(test)]
 pub(crate) mod mapping;
 pub(crate) mod xy;
 

--- a/crates/fricon-ui/src/features/charts/types.rs
+++ b/crates/fricon-ui/src/features/charts/types.rs
@@ -220,6 +220,7 @@ pub(crate) struct ColumnUniqueValue {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TableData {
     pub(crate) fields: Vec<String>,
+    pub(crate) field_labels: HashMap<String, String>,
     pub(crate) rows: Vec<Row>,
     pub(crate) column_unique_values: HashMap<String, Vec<ColumnUniqueValue>>,
 }

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -1,14 +1,19 @@
 use fricon::{
-    DatasetListQuery, InterpretationSource, ReadAppError, ResolvedColumn,
+    DatasetInterpretation, DatasetListQuery, InterpretationSource, ReadAppError, ResolvedColumn,
+    ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedScanAxisMode, VisibleColumnOrdinal,
     dataset::{
         model::DatasetId,
-        semantics::{DatasetDType, TraceValueDType},
+        semantics::{DatasetDType, ScanAxisValue, TraceValueDType},
     },
 };
 
 use super::{
     error::UiDatasetError,
-    types::{ColumnInfo, DatasetDetail, DatasetInfo, DatasetWriteStatus},
+    types::{
+        ChartDuplicatePolicy, ChartIndexRealization, ChartInterpretationSource, ChartSemanticAxis,
+        ChartSemanticAxisKind, ChartSemanticColumn, ChartSemantics, ColumnInfo, DatasetDetail,
+        DatasetInfo, DatasetWriteStatus,
+    },
 };
 use crate::desktop_runtime::session::WorkspaceSession;
 
@@ -52,17 +57,19 @@ pub(crate) async fn get_dataset_detail(
         .get_dataset_including_deleted(DatasetId::Id(id))
         .await?;
     let payload_available = record.metadata.deleted_at.is_none();
-    let columns = if payload_available {
+    let (columns, chart_semantics) = if payload_available {
         let reader = session.dataset(id).await?;
         let interpretation = reader.interpret().map_err(ReadAppError::from)?;
         let expose_manifest_hints = interpretation.source == InterpretationSource::Manifest;
-        interpretation
+        let columns = interpretation
             .columns
             .iter()
             .filter_map(|column| column_info_from_resolved_column(column, expose_manifest_hints))
-            .collect()
+            .collect();
+        let chart_semantics = chart_semantics_from_interpretation(&interpretation);
+        (columns, Some(chart_semantics))
     } else {
-        Vec::new()
+        (Vec::new(), None)
     };
 
     Ok(DatasetDetail {
@@ -77,7 +84,125 @@ pub(crate) async fn get_dataset_detail(
         deleted_at: record.metadata.deleted_at,
         payload_available,
         columns,
+        chart_semantics,
     })
+}
+
+fn chart_semantics_from_interpretation(interpretation: &DatasetInterpretation) -> ChartSemantics {
+    let source = match interpretation.source {
+        InterpretationSource::Manifest => ChartInterpretationSource::Manifest,
+        InterpretationSource::CompatibilityInference => {
+            ChartInterpretationSource::CompatibilityInference
+        }
+    };
+    let duplicate_policy = match interpretation.duplicate_policy {
+        ResolvedDuplicatePolicy::LatestByRecordId => ChartDuplicatePolicy::LatestByRecordId,
+        ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder => {
+            ChartDuplicatePolicy::CompatibilityRowOrderPlaceholder
+        }
+    };
+    let index_realization = match interpretation.index_realization {
+        ResolvedIndexRealization::None => ChartIndexRealization::None,
+        ResolvedIndexRealization::Implicit => ChartIndexRealization::Implicit,
+        ResolvedIndexRealization::Sidecar => ChartIndexRealization::Sidecar,
+    };
+
+    let value_columns = interpretation
+        .value_columns
+        .iter()
+        .filter_map(|ordinal| visible_column(interpretation, *ordinal))
+        .map(chart_semantic_column)
+        .collect();
+
+    let mut axes = Vec::new();
+    if interpretation.source == InterpretationSource::Manifest {
+        axes.extend(interpretation.scan_axes.iter().map(|axis| {
+            let numeric = match &axis.mode {
+                ResolvedScanAxisMode::ImplicitIndex => true,
+                ResolvedScanAxisMode::Static { values } => {
+                    values.iter().all(scan_axis_value_is_numeric)
+                }
+            };
+            ChartSemanticAxis {
+                id: logical_index_id(&axis.name),
+                name: axis.name.clone(),
+                label: axis.label.clone(),
+                kind: ChartSemanticAxisKind::LogicalIndex,
+                numeric,
+                is_compatibility: false,
+                physical_column: None,
+            }
+        }));
+    } else {
+        axes.extend(
+            interpretation
+                .logical_index_columns
+                .iter()
+                .filter_map(|ordinal| visible_column(interpretation, *ordinal))
+                .map(|column| column_axis(column, true)),
+        );
+    }
+
+    let chart_axis_candidates = interpretation
+        .chart_axis_candidate_columns
+        .iter()
+        .filter_map(|ordinal| visible_column(interpretation, *ordinal))
+        .map(|column| column_axis(column, false))
+        .collect();
+
+    ChartSemantics {
+        source,
+        duplicate_policy,
+        index_realization,
+        axes,
+        value_columns,
+        chart_axis_candidates,
+    }
+}
+
+fn visible_column(
+    interpretation: &DatasetInterpretation,
+    ordinal: VisibleColumnOrdinal,
+) -> Option<&ResolvedColumn> {
+    interpretation
+        .columns
+        .iter()
+        .find(|column| column.visible_ordinal == Some(ordinal))
+}
+
+fn chart_semantic_column(column: &ResolvedColumn) -> ChartSemanticColumn {
+    ChartSemanticColumn {
+        id: column_id(&column.name),
+        name: column.name.clone(),
+        label: column.label.clone(),
+        is_complex: dtype_is_complex(&column.dtype),
+        is_trace: matches!(column.dtype, DatasetDType::Trace { .. }),
+        hidden_by_default: column.hidden_by_default,
+    }
+}
+
+fn column_axis(column: &ResolvedColumn, is_compatibility: bool) -> ChartSemanticAxis {
+    ChartSemanticAxis {
+        id: column_id(&column.name),
+        name: column.name.clone(),
+        label: column.label.clone(),
+        kind: ChartSemanticAxisKind::Column,
+        numeric: true,
+        is_compatibility,
+        physical_column: Some(column.name.clone()),
+    }
+}
+
+fn scan_axis_value_is_numeric(value: &ScanAxisValue) -> bool {
+    matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_))
+}
+
+fn column_id(name: &str) -> String {
+    format!("column:{name}")
+}
+
+fn logical_index_id(name: &str) -> String {
+    format!("logicalIndex:{name}")
 }
 
 fn column_info_from_resolved_column(
@@ -158,6 +283,18 @@ mod tests {
         assert!(!detail.columns[0].is_complex);
         assert!(detail.columns[0].hidden_by_default);
         assert!(detail.columns[0].is_chart_axis_candidate);
+        let semantics = detail
+            .chart_semantics
+            .as_ref()
+            .expect("chart semantics should be exposed");
+        assert!(matches!(
+            semantics.source,
+            super::ChartInterpretationSource::Manifest
+        ));
+        assert_eq!(semantics.value_columns.len(), 3);
+        assert_eq!(semantics.value_columns[0].id, "column:signal");
+        assert_eq!(semantics.chart_axis_candidates.len(), 1);
+        assert_eq!(semantics.chart_axis_candidates[0].id, "column:signal");
         assert_eq!(detail.columns[1].name, "trace");
         assert_eq!(detail.columns[1].label, None);
         assert_eq!(detail.columns[1].unit, None);
@@ -208,6 +345,22 @@ mod tests {
         assert!(!detail.columns[1].is_complex);
         assert!(!detail.columns[1].hidden_by_default);
         assert!(!detail.columns[1].is_chart_axis_candidate);
+        let semantics = detail
+            .chart_semantics
+            .as_ref()
+            .expect("compatibility chart semantics should be exposed");
+        assert!(matches!(
+            semantics.source,
+            super::ChartInterpretationSource::CompatibilityInference
+        ));
+        assert_eq!(
+            semantics
+                .axes
+                .iter()
+                .map(|axis| axis.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["column:run", "column:step"]
+        );
         assert_eq!(detail.columns[2].name, "value");
         assert_eq!(detail.columns[2].label, None);
         assert_eq!(detail.columns[2].unit, None);

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -194,7 +194,10 @@ fn column_axis(column: &ResolvedColumn, is_compatibility: bool) -> ChartSemantic
 }
 
 fn dtype_is_chart_axis_numeric(dtype: &DatasetDType) -> bool {
-    matches!(dtype, DatasetDType::Float64)
+    matches!(
+        dtype,
+        DatasetDType::Float64 | DatasetDType::Float32 | DatasetDType::Int64 | DatasetDType::UInt64
+    )
 }
 
 fn scan_axis_value_is_numeric(value: &ScanAxisValue) -> bool {
@@ -255,19 +258,31 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use fricon::{
         AppManager, Client, DatasetRow, DatasetScalar, ScalarArray, WorkspaceRoot,
-        dataset::semantics::ColumnMetadata, workspace::WorkspacePaths,
+        dataset::semantics::{ColumnMetadata, DatasetDType},
+        workspace::WorkspacePaths,
     };
     use indexmap::IndexMap;
     use num::complex::Complex64;
     use tempfile::TempDir;
 
-    use super::{get_dataset_detail, validate_non_negative};
+    use super::{dtype_is_chart_axis_numeric, get_dataset_detail, validate_non_negative};
     use crate::desktop_runtime::session::WorkspaceSession;
 
     #[test]
     fn validate_non_negative_rejects_negative_values() {
         let error = validate_non_negative(Some(-1), "limit").expect_err("expected error");
         assert_eq!(error.to_string(), "limit must be non-negative");
+    }
+
+    #[test]
+    fn chart_axis_numeric_includes_supported_scalar_numeric_dtypes() {
+        assert!(dtype_is_chart_axis_numeric(&DatasetDType::Float64));
+        assert!(dtype_is_chart_axis_numeric(&DatasetDType::Float32));
+        assert!(dtype_is_chart_axis_numeric(&DatasetDType::Int64));
+        assert!(dtype_is_chart_axis_numeric(&DatasetDType::UInt64));
+        assert!(!dtype_is_chart_axis_numeric(&DatasetDType::Bool));
+        assert!(!dtype_is_chart_axis_numeric(&DatasetDType::Utf8));
+        assert!(!dtype_is_chart_axis_numeric(&DatasetDType::Complex128));
     }
 
     #[tokio::test]

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -194,10 +194,7 @@ fn column_axis(column: &ResolvedColumn, is_compatibility: bool) -> ChartSemantic
 }
 
 fn dtype_is_chart_axis_numeric(dtype: &DatasetDType) -> bool {
-    matches!(
-        dtype,
-        DatasetDType::Float64 | DatasetDType::Float32 | DatasetDType::Int64 | DatasetDType::UInt64
-    )
+    matches!(dtype, DatasetDType::Float64)
 }
 
 fn scan_axis_value_is_numeric(value: &ScanAxisValue) -> bool {

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -187,10 +187,17 @@ fn column_axis(column: &ResolvedColumn, is_compatibility: bool) -> ChartSemantic
         name: column.name.clone(),
         label: column.label.clone(),
         kind: ChartSemanticAxisKind::Column,
-        numeric: true,
+        numeric: dtype_is_chart_axis_numeric(&column.dtype),
         is_compatibility,
         physical_column: Some(column.name.clone()),
     }
+}
+
+fn dtype_is_chart_axis_numeric(dtype: &DatasetDType) -> bool {
+    matches!(
+        dtype,
+        DatasetDType::Float64 | DatasetDType::Float32 | DatasetDType::Int64 | DatasetDType::UInt64
+    )
 }
 
 fn scan_axis_value_is_numeric(value: &ScanAxisValue) -> bool {
@@ -293,8 +300,9 @@ mod tests {
         ));
         assert_eq!(semantics.value_columns.len(), 3);
         assert_eq!(semantics.value_columns[0].id, "column:signal");
-        assert_eq!(semantics.chart_axis_candidates.len(), 1);
+        assert_eq!(semantics.chart_axis_candidates.len(), 2);
         assert_eq!(semantics.chart_axis_candidates[0].id, "column:signal");
+        assert!(semantics.chart_axis_candidates[0].numeric);
         assert_eq!(detail.columns[1].name, "trace");
         assert_eq!(detail.columns[1].label, None);
         assert_eq!(detail.columns[1].unit, None);
@@ -302,7 +310,9 @@ mod tests {
         assert!(detail.columns[1].is_trace);
         assert!(!detail.columns[1].is_complex);
         assert!(!detail.columns[1].hidden_by_default);
-        assert!(!detail.columns[1].is_chart_axis_candidate);
+        assert!(detail.columns[1].is_chart_axis_candidate);
+        assert_eq!(semantics.chart_axis_candidates[1].id, "column:trace");
+        assert!(!semantics.chart_axis_candidates[1].numeric);
         assert_eq!(detail.columns[2].name, "complex");
         assert_eq!(detail.columns[2].label, None);
         assert_eq!(detail.columns[2].unit, None);
@@ -390,13 +400,22 @@ mod tests {
                 String::new(),
                 vec!["test".to_string()],
                 schema,
-                vec![ColumnMetadata {
-                    name: "signal".to_string(),
-                    label: Some("Signal".to_string()),
-                    unit: Some("V".to_string()),
-                    hidden_by_default: true,
-                    chart_axis: true,
-                }],
+                vec![
+                    ColumnMetadata {
+                        name: "signal".to_string(),
+                        label: Some("Signal".to_string()),
+                        unit: Some("V".to_string()),
+                        hidden_by_default: true,
+                        chart_axis: true,
+                    },
+                    ColumnMetadata {
+                        name: "trace".to_string(),
+                        label: None,
+                        unit: None,
+                        hidden_by_default: false,
+                        chart_axis: true,
+                    },
+                ],
                 None,
                 false,
             )

--- a/crates/fricon-ui/src/features/datasets/types.rs
+++ b/crates/fricon-ui/src/features/datasets/types.rs
@@ -99,6 +99,69 @@ pub(crate) struct ColumnInfo {
     pub(crate) is_chart_axis_candidate: bool,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ChartInterpretationSource {
+    Manifest,
+    CompatibilityInference,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ChartDuplicatePolicy {
+    LatestByRecordId,
+    CompatibilityRowOrderPlaceholder,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ChartIndexRealization {
+    None,
+    Implicit,
+    Sidecar,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ChartSemanticAxisKind {
+    LogicalIndex,
+    Column,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChartSemanticColumn {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) label: Option<String>,
+    pub(crate) is_complex: bool,
+    pub(crate) is_trace: bool,
+    pub(crate) hidden_by_default: bool,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChartSemanticAxis {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) label: Option<String>,
+    pub(crate) kind: ChartSemanticAxisKind,
+    pub(crate) numeric: bool,
+    pub(crate) is_compatibility: bool,
+    pub(crate) physical_column: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChartSemantics {
+    pub(crate) source: ChartInterpretationSource,
+    pub(crate) duplicate_policy: ChartDuplicatePolicy,
+    pub(crate) index_realization: ChartIndexRealization,
+    pub(crate) axes: Vec<ChartSemanticAxis>,
+    pub(crate) value_columns: Vec<ChartSemanticColumn>,
+    pub(crate) chart_axis_candidates: Vec<ChartSemanticAxis>,
+}
+
 #[derive(Debug, Clone, Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DatasetDetail {
@@ -113,6 +176,7 @@ pub(crate) struct DatasetDetail {
     pub(crate) deleted_at: Option<DateTime<Utc>>,
     pub(crate) payload_available: bool,
     pub(crate) columns: Vec<ColumnInfo>,
+    pub(crate) chart_semantics: Option<ChartSemantics>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, specta::Type)]

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -392,6 +392,14 @@ impl DatasetReader {
     }
 
     pub fn logical_index_points(&self) -> Result<Vec<ResolvedLogicalIndexPoint>, ReadError> {
+        let record_ids = self.record_ids()?;
+        self.logical_index_points_for_record_ids(&record_ids)
+    }
+
+    pub fn logical_index_points_for_record_ids(
+        &self,
+        record_ids: &[u64],
+    ) -> Result<Vec<ResolvedLogicalIndexPoint>, ReadError> {
         let Some(manifest) = &self.manifest else {
             return Ok(Vec::new());
         };
@@ -401,7 +409,6 @@ impl DatasetReader {
         if manifest.scan_plan.is_none() {
             return Ok(Vec::new());
         }
-        let record_ids = self.record_ids()?;
         if manifest.realization.index_realization == IndexRealization::Sidecar {
             if record_ids.is_empty() {
                 return Ok(Vec::new());
@@ -409,9 +416,9 @@ impl DatasetReader {
             let Some(path) = &self.dataset_path else {
                 return Err(ReadError::DatasetFs(DatasetFsError::ChunkNotFound));
             };
-            return Self::sidecar_logical_index_points(path, manifest, &record_ids);
+            return Self::sidecar_logical_index_points(path, manifest, record_ids);
         }
-        Ok(resolve_logical_index_points(manifest, &record_ids))
+        Ok(resolve_logical_index_points(manifest, record_ids))
     }
 
     fn sidecar_logical_index_points(

--- a/crates/fricon/src/dataset/read/reader.rs
+++ b/crates/fricon/src/dataset/read/reader.rs
@@ -485,7 +485,14 @@ impl DatasetReader {
         Ok(points)
     }
 
-    fn record_ids(&self) -> Result<Vec<u64>, ReadError> {
+    pub fn record_ids(&self) -> Result<Vec<u64>, ReadError> {
+        self.record_ids_range(..)
+    }
+
+    pub fn record_ids_range<R>(&self, range: R) -> Result<Vec<u64>, ReadError>
+    where
+        R: RangeBounds<usize> + Copy,
+    {
         let record_id_index = self
             .physical_arrow_schema
             .column_with_name(RECORD_ID_COLUMN)
@@ -496,7 +503,7 @@ impl DatasetReader {
             })?
             .0;
         let mut record_ids = Vec::new();
-        for batch in self.source.range(..) {
+        for batch in self.source.range(range) {
             let column = batch
                 .column(record_id_index)
                 .as_any()


### PR DESCRIPTION
## Summary
- migrate desktop chart defaults, filter table data, heatmaps, and live views to consume resolved dataset semantics instead of inferring behavior from `isIndex`
- add stable semantic IDs for physical columns and logical scan axes, with compatibility handling for legacy inferred datasets
- update frontend bindings, chart selection logic, and dataset detail types to use the new semantics contract

## Testing
- Added and updated Rust, frontend unit, and browser coverage for semantic chart defaults, duplicate handling, legacy compatibility, and filter-table behavior
- Local quality checks passed, including bindings generation, Rust checks/tests, and frontend lint/test/format validation

closes #485