### PR TITLE
chore: remove renovate schedule settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,7 @@
     ":approveMajorUpdates",
     ":enablePreCommit",
     "helpers:pinGitHubActionDigestsToSemver",
-    "customManagers:githubActionsVersions",
-    "schedule:weekends",
-    ":timezone(Asia/Shanghai)"
+    "customManagers:githubActionsVersions"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Remove the `schedule:weekends` preset from `renovate.json`
- Remove the now-unused `:timezone(Asia/Shanghai)` preset
- Keep the remaining Renovate presets unchanged

## Testing
- Not run (not requested)