### PR TITLE
refactor: consolidate chart semantic handling

### DIFF
--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -15,6 +15,7 @@ use fricon::{
     DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, InterpretationSource,
     ResolvedDuplicatePolicy, ResolvedLogicalIndexPoint, ResolvedScanAxisMode, ScalarKind,
     SelectOptions, dataset::semantics::ScanAxisValue,
+    physical_column_id as core_physical_column_id,
 };
 use indexmap::IndexMap;
 
@@ -40,11 +41,7 @@ pub(crate) struct PreparedChartData {
 }
 
 pub(crate) fn column_id(name: &str) -> String {
-    format!("{COLUMN_PREFIX}{name}")
-}
-
-pub(crate) fn logical_index_id(name: &str) -> String {
-    format!("{LOGICAL_INDEX_PREFIX}{name}")
+    core_physical_column_id(name)
 }
 
 pub(crate) fn resolve_column_name(value: &str) -> String {
@@ -73,6 +70,32 @@ fn resolve_source_column_name(value: &str) -> String {
         .to_string()
 }
 
+fn resolve_axis_column_name_for_interpretation(
+    interpretation: &DatasetInterpretation,
+    value: &str,
+) -> String {
+    if let Some(axis) = interpretation.logical_axis_for_id(value) {
+        return axis.id.clone();
+    }
+    if let Some(column) = interpretation.physical_column_for_id(value) {
+        return alias_physical_column_name(&column.name, true);
+    }
+    resolve_axis_column_name(value)
+}
+
+fn resolve_source_column_name_for_interpretation(
+    interpretation: &DatasetInterpretation,
+    value: &str,
+) -> Option<String> {
+    if interpretation.logical_axis_for_id(value).is_some() {
+        return None;
+    }
+    Some(interpretation.physical_column_for_id(value).map_or_else(
+        || resolve_source_column_name(value),
+        |column| column.name.clone(),
+    ))
+}
+
 pub(crate) async fn prepare_chart_data(
     session: &WorkspaceSession,
     id: i32,
@@ -85,8 +108,12 @@ pub(crate) async fn prepare_chart_data(
     let source_schema = dataset.schema()?.clone();
     let alias_physical_columns = true;
     let (start, end) = resolve_row_range(&dataset, common.start, common.end);
-    let selected_physical_columns =
-        selected_physical_columns(&source_schema, selected_columns, filters);
+    let selected_physical_columns = selected_physical_columns(
+        &source_schema,
+        Some(&interpretation),
+        selected_columns,
+        filters,
+    );
     let (output_schema, batches) = dataset.select_data(&SelectOptions {
         start: Bound::Included(start),
         end: Bound::Excluded(end),
@@ -167,6 +194,7 @@ pub(crate) async fn load_axis_rows(
 }
 
 fn semantic_filter_mask(
+    interpretation: &DatasetInterpretation,
     batch: &RecordBatch,
     filters: &[(String, serde_json::Value)],
 ) -> Result<Option<Vec<bool>>> {
@@ -177,7 +205,7 @@ fn semantic_filter_mask(
     for row in 0..batch.num_rows() {
         let mut keep = true;
         for (field, expected) in filters {
-            let column_name = resolve_axis_column_name(field);
+            let column_name = resolve_axis_column_name_for_interpretation(interpretation, field);
             let column = batch
                 .column_by_name(&column_name)
                 .with_context(|| format!("Filter field '{field}' not found"))?;
@@ -211,7 +239,7 @@ fn prepare_batch_from_reader(
         start,
         end,
     )?;
-    if let Some(mask) = semantic_filter_mask(&batch, filters)? {
+    if let Some(mask) = semantic_filter_mask(interpretation, &batch, filters)? {
         batch = filter_batch(&batch, &mask)?;
         row_indices = filter_row_indices(&row_indices, &mask);
     }
@@ -252,6 +280,7 @@ fn axis_row_selected_columns(
 
 fn selected_physical_columns(
     source_schema: &DatasetSchema,
+    interpretation: Option<&DatasetInterpretation>,
     selected_columns: Option<&[usize]>,
     filters: &[(String, serde_json::Value)],
 ) -> Option<Vec<usize>> {
@@ -264,7 +293,13 @@ fn selected_physical_columns(
         }
     }
     for (field, _) in filters {
-        let column_name = resolve_source_column_name(field);
+        let column_name = interpretation.map_or_else(
+            || Some(resolve_source_column_name(field)),
+            |interpretation| resolve_source_column_name_for_interpretation(interpretation, field),
+        );
+        let Some(column_name) = column_name else {
+            continue;
+        };
         if let Some((index, _, _)) = source_schema.columns().get_full(&column_name) {
             push_unique(&mut physical_columns, index);
         }
@@ -457,9 +492,9 @@ fn append_logical_axes(
     let mut arrays = batch.columns().to_vec();
     let mut columns = schema.columns().clone();
     for (axis_index, axis) in interpretation.scan_axes.iter().enumerate() {
-        let id = logical_index_id(&axis.name);
+        let id = axis.id.clone();
         let values = logical_axis_values(&kept_record_ids, &point_by_record_id, axis_index);
-        if scan_axis_is_numeric(&axis.mode) {
+        if axis.numeric_axis {
             fields.push(Arc::new(Field::new(&id, DataType::Float64, true)));
             arrays.push(numeric_axis_array(&values));
             columns.insert(id, DatasetDataType::Scalar(ScalarKind::Numeric));
@@ -488,35 +523,33 @@ fn filter_row_indices(row_indices: &[usize], mask: &[bool]) -> Vec<usize> {
 }
 
 fn axis_fields(interpretation: &DatasetInterpretation, batch: &RecordBatch) -> Vec<AxisField> {
-    let mut fields = Vec::new();
-    if interpretation.scan_axes.is_empty() {
-        fields.extend(
-            interpretation
-                .logical_index_columns
-                .iter()
-                .filter_map(|ordinal| {
-                    let column = interpretation
-                        .columns
-                        .iter()
-                        .find(|column| column.visible_ordinal == Some(*ordinal))?;
-                    Some(AxisField {
-                        id: column_id(&column.name),
-                        column_name: column.name.clone(),
+    interpretation
+        .group_axes
+        .iter()
+        .filter_map(|reference| match reference {
+            fricon::ResolvedSemanticReference::PhysicalColumn(column) => {
+                let column_name = alias_physical_column_name(&column.name, true);
+                batch
+                    .schema()
+                    .field_with_name(&column_name)
+                    .ok()
+                    .map(|_| AxisField {
+                        id: column.id.clone(),
+                        column_name,
                         label: column.label.clone().unwrap_or_else(|| column.name.clone()),
                     })
+            }
+            fricon::ResolvedSemanticReference::LogicalIndex(axis) => batch
+                .schema()
+                .field_with_name(&axis.id)
+                .ok()
+                .map(|_| AxisField {
+                    id: axis.id.clone(),
+                    column_name: axis.id.clone(),
+                    label: axis.label.clone().unwrap_or_else(|| axis.name.clone()),
                 }),
-        );
-    } else {
-        fields.extend(interpretation.scan_axes.iter().filter_map(|axis| {
-            let id = logical_index_id(&axis.name);
-            batch.schema().field_with_name(&id).ok().map(|_| AxisField {
-                id: id.clone(),
-                column_name: id,
-                label: axis.label.clone().unwrap_or_else(|| axis.name.clone()),
-            })
-        }));
-    }
-    fields
+        })
+        .collect()
 }
 
 fn resolve_index_columns(
@@ -524,29 +557,29 @@ fn resolve_index_columns(
     schema: &DatasetSchema,
 ) -> Option<Vec<usize>> {
     let mut indices = Vec::new();
-    for axis in interpretation
-        .scan_axes
+    for reference in interpretation
+        .plotted_coordinates
         .iter()
-        .filter(|axis| scan_axis_is_numeric(&axis.mode))
+        .filter(|reference| reference.numeric_axis())
     {
-        let id = logical_index_id(&axis.name);
-        if let Some((index, _, _)) = schema.columns().get_full(&id) {
-            indices.push(index);
+        match reference {
+            fricon::ResolvedSemanticReference::PhysicalColumn(column) => {
+                let column_name = alias_physical_column_name(&column.name, true);
+                if let Some((index, _, _)) = schema.columns().get_full(&column_name) {
+                    indices.push(index);
+                }
+            }
+            fricon::ResolvedSemanticReference::LogicalIndex(axis) => {
+                if let Some((index, _, _)) = schema.columns().get_full(&axis.id) {
+                    indices.push(index);
+                }
+            }
         }
     }
     if indices.is_empty() {
         None
     } else {
         Some(indices)
-    }
-}
-
-fn scan_axis_is_numeric(mode: &ResolvedScanAxisMode) -> bool {
-    match mode {
-        ResolvedScanAxisMode::ImplicitIndex => true,
-        ResolvedScanAxisMode::Static { values } => values
-            .iter()
-            .all(|value| matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_))),
     }
 }
 
@@ -807,6 +840,13 @@ mod tests {
     fn manifest_without_scan_axes_still_uses_inferred_index_fallback() {
         let interpretation = DatasetInterpretation {
             columns: Vec::new(),
+            semantic_references: Vec::new(),
+            value_references: Vec::new(),
+            plotted_coordinates: Vec::new(),
+            sweep_axes: Vec::new(),
+            group_axes: Vec::new(),
+            filter_axes: Vec::new(),
+            chart_axis_candidates: Vec::new(),
             value_columns: Vec::new(),
             logical_index_columns: Vec::new(),
             chart_axis_candidate_columns: vec![fricon::VisibleColumnOrdinal(0)],
@@ -834,6 +874,7 @@ mod tests {
 
         let selected = selected_physical_columns(
             &source_schema,
+            None,
             Some(&[0, 2]),
             &[("column:axis".to_string(), serde_json::json!(1.0))],
         )

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -14,8 +14,8 @@ use arrow_select::{concat::concat_batches, filter::FilterBuilder};
 #[cfg(test)]
 use fricon::{
     ColumnMeaning, PhysicalColumnOrdinal, ResolvedColumn, ResolvedIndexRealization,
-    ResolvedPhysicalColumnReference, ResolvedSemanticReference, VisibleColumnOrdinal,
-    dataset::semantics::DatasetDType,
+    ResolvedLogicalIndexReference, ResolvedPhysicalColumnReference, ResolvedSemanticReference,
+    VisibleColumnOrdinal, dataset::semantics::DatasetDType,
 };
 use fricon::{
     DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, InterpretationSource,
@@ -571,7 +571,7 @@ fn resolve_index_columns(
 ) -> Option<Vec<usize>> {
     let mut indices = Vec::new();
     for reference in interpretation
-        .plotted_coordinates
+        .sweep_axes
         .iter()
         .filter(|reference| reference.numeric_axis())
     {
@@ -1005,6 +1005,73 @@ mod tests {
         assert_eq!(fields.len(), 1);
         assert_eq!(fields[0].id, "column:logicalIndex:gate");
         assert_eq!(fields[0].column_name, "logicalIndex:gate");
+    }
+
+    #[test]
+    fn index_columns_use_sweep_axes_not_chart_axis_candidates() {
+        let schema = DatasetSchema::new(IndexMap::from([
+            (
+                "signal".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Numeric),
+            ),
+            (
+                "physicalAxis".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Numeric),
+            ),
+            (
+                "logicalIndex:gate".to_string(),
+                DatasetDataType::Scalar(ScalarKind::Numeric),
+            ),
+        ]));
+        let logical_gate = ResolvedSemanticReference::LogicalIndex(ResolvedLogicalIndexReference {
+            id: "logicalIndex:gate".to_string(),
+            name: "gate".to_string(),
+            axis_ordinal: 0,
+            label: None,
+            hidden_by_default: false,
+            numeric_axis: true,
+            is_compatibility: false,
+        });
+        let chart_axis =
+            ResolvedSemanticReference::PhysicalColumn(ResolvedPhysicalColumnReference {
+                id: "column:physicalAxis".to_string(),
+                name: "physicalAxis".to_string(),
+                physical_ordinal: PhysicalColumnOrdinal(1),
+                visible_ordinal: Some(VisibleColumnOrdinal(1)),
+                dtype: DatasetDType::Float64,
+                meaning: ColumnMeaning::UserValue,
+                is_index: false,
+                is_system: false,
+                is_compatibility: false,
+                hidden_by_default: false,
+                is_chart_axis_candidate: true,
+                unit: None,
+                label: None,
+                is_complex: false,
+                is_trace: false,
+                numeric_axis: true,
+            });
+        let interpretation = DatasetInterpretation {
+            columns: Vec::<ResolvedColumn>::new(),
+            semantic_references: vec![logical_gate.clone(), chart_axis.clone()],
+            value_references: Vec::new(),
+            plotted_coordinates: vec![logical_gate.clone(), chart_axis.clone()],
+            sweep_axes: vec![logical_gate],
+            group_axes: Vec::new(),
+            filter_axes: Vec::new(),
+            chart_axis_candidates: vec![chart_axis],
+            value_columns: Vec::new(),
+            logical_index_columns: Vec::new(),
+            chart_axis_candidate_columns: Vec::new(),
+            duplicate_policy: ResolvedDuplicatePolicy::LatestByRecordId,
+            index_realization: ResolvedIndexRealization::Implicit,
+            scan_axes: Vec::new(),
+            source: InterpretationSource::Manifest,
+        };
+
+        let index_columns = resolve_index_columns(&interpretation, &schema);
+
+        assert_eq!(index_columns, Some(vec![2]));
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -13,9 +13,9 @@ use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
 #[cfg(test)]
 use fricon::{
-    ColumnMeaning, PhysicalColumnOrdinal, ResolvedColumn, ResolvedIndexRealization,
-    ResolvedLogicalIndexReference, ResolvedPhysicalColumnReference, ResolvedSemanticReference,
-    VisibleColumnOrdinal, dataset::semantics::DatasetDType,
+    ColumnMeaning, PhysicalColumnOrdinal, ResolvedIndexRealization, ResolvedLogicalIndexReference,
+    ResolvedPhysicalColumnReference, ResolvedSemanticReference, VisibleColumnOrdinal,
+    dataset::semantics::DatasetDType,
 };
 use fricon::{
     DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, InterpretationSource,
@@ -822,6 +822,64 @@ mod tests {
         }
     }
 
+    fn empty_interpretation(source: InterpretationSource) -> DatasetInterpretation {
+        DatasetInterpretation {
+            columns: Vec::new(),
+            semantic_references: Vec::new(),
+            value_references: Vec::new(),
+            plotted_coordinates: Vec::new(),
+            sweep_axes: Vec::new(),
+            group_axes: Vec::new(),
+            filter_axes: Vec::new(),
+            chart_axis_candidates: Vec::new(),
+            value_columns: Vec::new(),
+            logical_index_columns: Vec::new(),
+            chart_axis_candidate_columns: Vec::new(),
+            duplicate_policy: ResolvedDuplicatePolicy::LatestByRecordId,
+            index_realization: ResolvedIndexRealization::None,
+            scan_axes: Vec::new(),
+            source,
+        }
+    }
+
+    fn physical_reference(
+        id: &str,
+        name: &str,
+        meaning: ColumnMeaning,
+        is_compatibility: bool,
+    ) -> ResolvedSemanticReference {
+        ResolvedSemanticReference::PhysicalColumn(ResolvedPhysicalColumnReference {
+            id: id.to_string(),
+            name: name.to_string(),
+            physical_ordinal: PhysicalColumnOrdinal(0),
+            visible_ordinal: Some(VisibleColumnOrdinal(0)),
+            dtype: DatasetDType::Float64,
+            meaning,
+            is_index: matches!(meaning, ColumnMeaning::CompatibilityIndex),
+            is_system: false,
+            is_compatibility,
+            hidden_by_default: false,
+            is_chart_axis_candidate: true,
+            unit: None,
+            label: None,
+            is_complex: false,
+            is_trace: false,
+            numeric_axis: true,
+        })
+    }
+
+    fn logical_reference(id: &str, name: &str) -> ResolvedSemanticReference {
+        ResolvedSemanticReference::LogicalIndex(ResolvedLogicalIndexReference {
+            id: id.to_string(),
+            name: name.to_string(),
+            axis_ordinal: 0,
+            label: None,
+            hidden_by_default: false,
+            numeric_axis: true,
+            is_compatibility: false,
+        })
+    }
+
     #[test]
     fn latest_logical_points_are_projected_within_selected_points() {
         let projected = logical_points_by_record_id(
@@ -851,23 +909,8 @@ mod tests {
 
     #[test]
     fn manifest_without_scan_axes_still_uses_inferred_index_fallback() {
-        let interpretation = DatasetInterpretation {
-            columns: Vec::new(),
-            semantic_references: Vec::new(),
-            value_references: Vec::new(),
-            plotted_coordinates: Vec::new(),
-            sweep_axes: Vec::new(),
-            group_axes: Vec::new(),
-            filter_axes: Vec::new(),
-            chart_axis_candidates: Vec::new(),
-            value_columns: Vec::new(),
-            logical_index_columns: Vec::new(),
-            chart_axis_candidate_columns: vec![fricon::VisibleColumnOrdinal(0)],
-            duplicate_policy: ResolvedDuplicatePolicy::LatestByRecordId,
-            index_realization: fricon::ResolvedIndexRealization::None,
-            scan_axes: Vec::new(),
-            source: InterpretationSource::Manifest,
-        };
+        let mut interpretation = empty_interpretation(InterpretationSource::Manifest);
+        interpretation.chart_axis_candidate_columns = vec![VisibleColumnOrdinal(0)];
 
         assert!(fallback_to_inferred_index_columns(&interpretation));
     }
@@ -963,42 +1006,22 @@ mod tests {
             vec![Arc::new(Float64Array::from(vec![1.0])) as ArrayRef],
         )
         .expect("source batch");
-        let reference =
-            ResolvedSemanticReference::PhysicalColumn(ResolvedPhysicalColumnReference {
-                id: "column:logicalIndex:gate".to_string(),
-                name: "logicalIndex:gate".to_string(),
-                physical_ordinal: PhysicalColumnOrdinal(0),
-                visible_ordinal: Some(VisibleColumnOrdinal(0)),
-                dtype: DatasetDType::Float64,
-                meaning: ColumnMeaning::CompatibilityIndex,
-                is_index: true,
-                is_system: false,
-                is_compatibility: true,
-                hidden_by_default: false,
-                is_chart_axis_candidate: true,
-                unit: None,
-                label: None,
-                is_complex: false,
-                is_trace: false,
-                numeric_axis: true,
-            });
-        let interpretation = DatasetInterpretation {
-            columns: Vec::<ResolvedColumn>::new(),
-            semantic_references: vec![reference.clone()],
-            value_references: Vec::new(),
-            plotted_coordinates: vec![reference.clone()],
-            sweep_axes: vec![reference.clone()],
-            group_axes: vec![reference.clone()],
-            filter_axes: vec![reference.clone()],
-            chart_axis_candidates: vec![reference],
-            value_columns: Vec::new(),
-            logical_index_columns: vec![VisibleColumnOrdinal(0)],
-            chart_axis_candidate_columns: vec![VisibleColumnOrdinal(0)],
-            duplicate_policy: ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder,
-            index_realization: ResolvedIndexRealization::None,
-            scan_axes: Vec::new(),
-            source: InterpretationSource::CompatibilityInference,
-        };
+        let reference = physical_reference(
+            "column:logicalIndex:gate",
+            "logicalIndex:gate",
+            ColumnMeaning::CompatibilityIndex,
+            true,
+        );
+        let mut interpretation = empty_interpretation(InterpretationSource::CompatibilityInference);
+        interpretation.semantic_references = vec![reference.clone()];
+        interpretation.plotted_coordinates = vec![reference.clone()];
+        interpretation.sweep_axes = vec![reference.clone()];
+        interpretation.group_axes = vec![reference.clone()];
+        interpretation.filter_axes = vec![reference.clone()];
+        interpretation.chart_axis_candidates = vec![reference];
+        interpretation.logical_index_columns = vec![VisibleColumnOrdinal(0)];
+        interpretation.chart_axis_candidate_columns = vec![VisibleColumnOrdinal(0)];
+        interpretation.duplicate_policy = ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder;
 
         let fields = axis_fields(&interpretation, &batch);
 
@@ -1023,51 +1046,19 @@ mod tests {
                 DatasetDataType::Scalar(ScalarKind::Numeric),
             ),
         ]));
-        let logical_gate = ResolvedSemanticReference::LogicalIndex(ResolvedLogicalIndexReference {
-            id: "logicalIndex:gate".to_string(),
-            name: "gate".to_string(),
-            axis_ordinal: 0,
-            label: None,
-            hidden_by_default: false,
-            numeric_axis: true,
-            is_compatibility: false,
-        });
-        let chart_axis =
-            ResolvedSemanticReference::PhysicalColumn(ResolvedPhysicalColumnReference {
-                id: "column:physicalAxis".to_string(),
-                name: "physicalAxis".to_string(),
-                physical_ordinal: PhysicalColumnOrdinal(1),
-                visible_ordinal: Some(VisibleColumnOrdinal(1)),
-                dtype: DatasetDType::Float64,
-                meaning: ColumnMeaning::UserValue,
-                is_index: false,
-                is_system: false,
-                is_compatibility: false,
-                hidden_by_default: false,
-                is_chart_axis_candidate: true,
-                unit: None,
-                label: None,
-                is_complex: false,
-                is_trace: false,
-                numeric_axis: true,
-            });
-        let interpretation = DatasetInterpretation {
-            columns: Vec::<ResolvedColumn>::new(),
-            semantic_references: vec![logical_gate.clone(), chart_axis.clone()],
-            value_references: Vec::new(),
-            plotted_coordinates: vec![logical_gate.clone(), chart_axis.clone()],
-            sweep_axes: vec![logical_gate],
-            group_axes: Vec::new(),
-            filter_axes: Vec::new(),
-            chart_axis_candidates: vec![chart_axis],
-            value_columns: Vec::new(),
-            logical_index_columns: Vec::new(),
-            chart_axis_candidate_columns: Vec::new(),
-            duplicate_policy: ResolvedDuplicatePolicy::LatestByRecordId,
-            index_realization: ResolvedIndexRealization::Implicit,
-            scan_axes: Vec::new(),
-            source: InterpretationSource::Manifest,
-        };
+        let logical_gate = logical_reference("logicalIndex:gate", "gate");
+        let chart_axis = physical_reference(
+            "column:physicalAxis",
+            "physicalAxis",
+            ColumnMeaning::UserValue,
+            false,
+        );
+        let mut interpretation = empty_interpretation(InterpretationSource::Manifest);
+        interpretation.semantic_references = vec![logical_gate.clone(), chart_axis.clone()];
+        interpretation.plotted_coordinates = vec![logical_gate.clone(), chart_axis.clone()];
+        interpretation.sweep_axes = vec![logical_gate];
+        interpretation.chart_axis_candidates = vec![chart_axis];
+        interpretation.index_realization = ResolvedIndexRealization::Implicit;
 
         let index_columns = resolve_index_columns(&interpretation, &schema);
 

--- a/crates/fricon-ui/src/features/charts/semantic_source.rs
+++ b/crates/fricon-ui/src/features/charts/semantic_source.rs
@@ -11,6 +11,12 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use arrow_select::{concat::concat_batches, filter::FilterBuilder};
+#[cfg(test)]
+use fricon::{
+    ColumnMeaning, PhysicalColumnOrdinal, ResolvedColumn, ResolvedIndexRealization,
+    ResolvedPhysicalColumnReference, ResolvedSemanticReference, VisibleColumnOrdinal,
+    dataset::semantics::DatasetDType,
+};
 use fricon::{
     DatasetDataType, DatasetInterpretation, DatasetReader, DatasetSchema, InterpretationSource,
     ResolvedDuplicatePolicy, ResolvedLogicalIndexPoint, ResolvedScanAxisMode, ScalarKind,
@@ -528,16 +534,11 @@ fn axis_fields(interpretation: &DatasetInterpretation, batch: &RecordBatch) -> V
         .iter()
         .filter_map(|reference| match reference {
             fricon::ResolvedSemanticReference::PhysicalColumn(column) => {
-                let column_name = alias_physical_column_name(&column.name, true);
-                batch
-                    .schema()
-                    .field_with_name(&column_name)
-                    .ok()
-                    .map(|_| AxisField {
-                        id: column.id.clone(),
-                        column_name,
-                        label: column.label.clone().unwrap_or_else(|| column.name.clone()),
-                    })
+                axis_field_column_name(batch, &column.name).map(|column_name| AxisField {
+                    id: column.id.clone(),
+                    column_name,
+                    label: column.label.clone().unwrap_or_else(|| column.name.clone()),
+                })
             }
             fricon::ResolvedSemanticReference::LogicalIndex(axis) => batch
                 .schema()
@@ -550,6 +551,18 @@ fn axis_fields(interpretation: &DatasetInterpretation, batch: &RecordBatch) -> V
                 }),
         })
         .collect()
+}
+
+fn axis_field_column_name(batch: &RecordBatch, physical_name: &str) -> Option<String> {
+    if batch.schema().field_with_name(physical_name).is_ok() {
+        return Some(physical_name.to_string());
+    }
+    let aliased_name = alias_physical_column_name(physical_name, true);
+    batch
+        .schema()
+        .field_with_name(&aliased_name)
+        .ok()
+        .map(|_| aliased_name)
 }
 
 fn resolve_index_columns(
@@ -936,6 +949,62 @@ mod tests {
             map_full_index_columns(&source_schema, &projected, &[0]),
             vec![0]
         );
+    }
+
+    #[test]
+    fn axis_fields_find_unaliased_prefixed_compatibility_columns() {
+        let source_schema = Arc::new(Schema::new(vec![Field::new(
+            "logicalIndex:gate",
+            DataType::Float64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            source_schema,
+            vec![Arc::new(Float64Array::from(vec![1.0])) as ArrayRef],
+        )
+        .expect("source batch");
+        let reference =
+            ResolvedSemanticReference::PhysicalColumn(ResolvedPhysicalColumnReference {
+                id: "column:logicalIndex:gate".to_string(),
+                name: "logicalIndex:gate".to_string(),
+                physical_ordinal: PhysicalColumnOrdinal(0),
+                visible_ordinal: Some(VisibleColumnOrdinal(0)),
+                dtype: DatasetDType::Float64,
+                meaning: ColumnMeaning::CompatibilityIndex,
+                is_index: true,
+                is_system: false,
+                is_compatibility: true,
+                hidden_by_default: false,
+                is_chart_axis_candidate: true,
+                unit: None,
+                label: None,
+                is_complex: false,
+                is_trace: false,
+                numeric_axis: true,
+            });
+        let interpretation = DatasetInterpretation {
+            columns: Vec::<ResolvedColumn>::new(),
+            semantic_references: vec![reference.clone()],
+            value_references: Vec::new(),
+            plotted_coordinates: vec![reference.clone()],
+            sweep_axes: vec![reference.clone()],
+            group_axes: vec![reference.clone()],
+            filter_axes: vec![reference.clone()],
+            chart_axis_candidates: vec![reference],
+            value_columns: Vec::new(),
+            logical_index_columns: vec![VisibleColumnOrdinal(0)],
+            chart_axis_candidate_columns: vec![VisibleColumnOrdinal(0)],
+            duplicate_policy: ResolvedDuplicatePolicy::CompatibilityRowOrderPlaceholder,
+            index_realization: ResolvedIndexRealization::None,
+            scan_axes: Vec::new(),
+            source: InterpretationSource::CompatibilityInference,
+        };
+
+        let fields = axis_fields(&interpretation, &batch);
+
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].id, "column:logicalIndex:gate");
+        assert_eq!(fields[0].column_name, "logicalIndex:gate");
     }
 
     #[test]

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use fricon::dataset::semantics::DatasetDType;
 use fricon::{
     DatasetInterpretation, DatasetListQuery, InterpretationSource, ReadAppError, ResolvedColumn,
     ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedSemanticReference,
@@ -171,14 +169,6 @@ fn semantic_axis(reference: &ResolvedSemanticReference) -> ChartSemanticAxis {
     }
 }
 
-#[cfg(test)]
-fn dtype_is_chart_axis_numeric(dtype: &DatasetDType) -> bool {
-    matches!(
-        dtype,
-        DatasetDType::Float64 | DatasetDType::Float32 | DatasetDType::Int64 | DatasetDType::UInt64
-    )
-}
-
 fn column_info_from_resolved_column(
     column: &ResolvedColumn,
     expose_manifest_hints: bool,
@@ -214,31 +204,19 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use fricon::{
         AppManager, Client, DatasetRow, DatasetScalar, ScalarArray, WorkspaceRoot,
-        dataset::semantics::{ColumnMetadata, DatasetDType},
-        workspace::WorkspacePaths,
+        dataset::semantics::ColumnMetadata, workspace::WorkspacePaths,
     };
     use indexmap::IndexMap;
     use num::complex::Complex64;
     use tempfile::TempDir;
 
-    use super::{dtype_is_chart_axis_numeric, get_dataset_detail, validate_non_negative};
+    use super::{get_dataset_detail, validate_non_negative};
     use crate::desktop_runtime::session::WorkspaceSession;
 
     #[test]
     fn validate_non_negative_rejects_negative_values() {
         let error = validate_non_negative(Some(-1), "limit").expect_err("expected error");
         assert_eq!(error.to_string(), "limit must be non-negative");
-    }
-
-    #[test]
-    fn chart_axis_numeric_includes_supported_scalar_numeric_dtypes() {
-        assert!(dtype_is_chart_axis_numeric(&DatasetDType::Float64));
-        assert!(dtype_is_chart_axis_numeric(&DatasetDType::Float32));
-        assert!(dtype_is_chart_axis_numeric(&DatasetDType::Int64));
-        assert!(dtype_is_chart_axis_numeric(&DatasetDType::UInt64));
-        assert!(!dtype_is_chart_axis_numeric(&DatasetDType::Bool));
-        assert!(!dtype_is_chart_axis_numeric(&DatasetDType::Utf8));
-        assert!(!dtype_is_chart_axis_numeric(&DatasetDType::Complex128));
     }
 
     #[tokio::test]

--- a/crates/fricon-ui/src/features/datasets/queries.rs
+++ b/crates/fricon-ui/src/features/datasets/queries.rs
@@ -1,10 +1,9 @@
+#[cfg(test)]
+use fricon::dataset::semantics::DatasetDType;
 use fricon::{
     DatasetInterpretation, DatasetListQuery, InterpretationSource, ReadAppError, ResolvedColumn,
-    ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedScanAxisMode, VisibleColumnOrdinal,
-    dataset::{
-        model::DatasetId,
-        semantics::{DatasetDType, ScanAxisValue, TraceValueDType},
-    },
+    ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedSemanticReference,
+    dataset::model::DatasetId,
 };
 
 use super::{
@@ -108,46 +107,21 @@ fn chart_semantics_from_interpretation(interpretation: &DatasetInterpretation) -
     };
 
     let value_columns = interpretation
-        .value_columns
+        .value_references
         .iter()
-        .filter_map(|ordinal| visible_column(interpretation, *ordinal))
-        .map(chart_semantic_column)
+        .filter_map(chart_semantic_column)
         .collect();
 
-    let mut axes = Vec::new();
-    if interpretation.source == InterpretationSource::Manifest {
-        axes.extend(interpretation.scan_axes.iter().map(|axis| {
-            let numeric = match &axis.mode {
-                ResolvedScanAxisMode::ImplicitIndex => true,
-                ResolvedScanAxisMode::Static { values } => {
-                    values.iter().all(scan_axis_value_is_numeric)
-                }
-            };
-            ChartSemanticAxis {
-                id: logical_index_id(&axis.name),
-                name: axis.name.clone(),
-                label: axis.label.clone(),
-                kind: ChartSemanticAxisKind::LogicalIndex,
-                numeric,
-                is_compatibility: false,
-                physical_column: None,
-            }
-        }));
-    } else {
-        axes.extend(
-            interpretation
-                .logical_index_columns
-                .iter()
-                .filter_map(|ordinal| visible_column(interpretation, *ordinal))
-                .map(|column| column_axis(column, true)),
-        );
-    }
+    let axes = interpretation
+        .sweep_axes
+        .iter()
+        .map(semantic_axis)
+        .collect();
 
     let chart_axis_candidates = interpretation
-        .chart_axis_candidate_columns
+        .chart_axis_candidates
         .iter()
-        .filter_map(|ordinal| visible_column(interpretation, *ordinal))
-        .map(|column| column_axis(column, false))
+        .map(semantic_axis)
         .collect();
 
     ChartSemantics {
@@ -160,56 +134,49 @@ fn chart_semantics_from_interpretation(interpretation: &DatasetInterpretation) -
     }
 }
 
-fn visible_column(
-    interpretation: &DatasetInterpretation,
-    ordinal: VisibleColumnOrdinal,
-) -> Option<&ResolvedColumn> {
-    interpretation
-        .columns
-        .iter()
-        .find(|column| column.visible_ordinal == Some(ordinal))
-}
-
-fn chart_semantic_column(column: &ResolvedColumn) -> ChartSemanticColumn {
-    ChartSemanticColumn {
-        id: column_id(&column.name),
+fn chart_semantic_column(reference: &ResolvedSemanticReference) -> Option<ChartSemanticColumn> {
+    let ResolvedSemanticReference::PhysicalColumn(column) = reference else {
+        return None;
+    };
+    Some(ChartSemanticColumn {
+        id: column.id.clone(),
         name: column.name.clone(),
         label: column.label.clone(),
-        is_complex: dtype_is_complex(&column.dtype),
-        is_trace: matches!(column.dtype, DatasetDType::Trace { .. }),
+        is_complex: column.is_complex,
+        is_trace: column.is_trace,
         hidden_by_default: column.hidden_by_default,
+    })
+}
+
+fn semantic_axis(reference: &ResolvedSemanticReference) -> ChartSemanticAxis {
+    match reference {
+        ResolvedSemanticReference::PhysicalColumn(column) => ChartSemanticAxis {
+            id: column.id.clone(),
+            name: column.name.clone(),
+            label: column.label.clone(),
+            kind: ChartSemanticAxisKind::Column,
+            numeric: column.numeric_axis,
+            is_compatibility: column.is_compatibility,
+            physical_column: Some(column.name.clone()),
+        },
+        ResolvedSemanticReference::LogicalIndex(axis) => ChartSemanticAxis {
+            id: axis.id.clone(),
+            name: axis.name.clone(),
+            label: axis.label.clone(),
+            kind: ChartSemanticAxisKind::LogicalIndex,
+            numeric: axis.numeric_axis,
+            is_compatibility: axis.is_compatibility,
+            physical_column: None,
+        },
     }
 }
 
-fn column_axis(column: &ResolvedColumn, is_compatibility: bool) -> ChartSemanticAxis {
-    ChartSemanticAxis {
-        id: column_id(&column.name),
-        name: column.name.clone(),
-        label: column.label.clone(),
-        kind: ChartSemanticAxisKind::Column,
-        numeric: dtype_is_chart_axis_numeric(&column.dtype),
-        is_compatibility,
-        physical_column: Some(column.name.clone()),
-    }
-}
-
+#[cfg(test)]
 fn dtype_is_chart_axis_numeric(dtype: &DatasetDType) -> bool {
     matches!(
         dtype,
         DatasetDType::Float64 | DatasetDType::Float32 | DatasetDType::Int64 | DatasetDType::UInt64
     )
-}
-
-fn scan_axis_value_is_numeric(value: &ScanAxisValue) -> bool {
-    matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_))
-}
-
-fn column_id(name: &str) -> String {
-    format!("column:{name}")
-}
-
-fn logical_index_id(name: &str) -> String {
-    format!("logicalIndex:{name}")
 }
 
 fn column_info_from_resolved_column(
@@ -221,23 +188,12 @@ fn column_info_from_resolved_column(
         name: column.name.clone(),
         label: column.label.clone(),
         unit: column.unit.clone(),
-        is_complex: dtype_is_complex(&column.dtype),
-        is_trace: matches!(column.dtype, DatasetDType::Trace { .. }),
+        is_complex: column.is_complex,
+        is_trace: column.is_trace,
         is_index: column.is_index,
         hidden_by_default: column.hidden_by_default,
         is_chart_axis_candidate: expose_manifest_hints && column.is_chart_axis_candidate,
     })
-}
-
-fn dtype_is_complex(dtype: &DatasetDType) -> bool {
-    matches!(
-        dtype,
-        DatasetDType::Complex128
-            | DatasetDType::Trace {
-                value: TraceValueDType::Complex128,
-                ..
-            }
-    )
 }
 
 pub(crate) async fn get_dataset_write_status(

--- a/crates/fricon/src/dataset.rs
+++ b/crates/fricon/src/dataset.rs
@@ -15,7 +15,9 @@ pub use self::{
     interpret::{
         ColumnMeaning, DatasetInterpretation, InterpretationSource, PhysicalColumnOrdinal,
         ResolvedColumn, ResolvedDuplicatePolicy, ResolvedIndexRealization,
-        ResolvedLogicalIndexPoint, ResolvedScanAxis, ResolvedScanAxisMode, VisibleColumnOrdinal,
+        ResolvedLogicalIndexPoint, ResolvedLogicalIndexReference, ResolvedPhysicalColumnReference,
+        ResolvedScanAxis, ResolvedScanAxisMode, ResolvedSemanticReference, VisibleColumnOrdinal,
+        logical_index_id, physical_column_id,
     },
     model::{
         DatasetId, DatasetListQuery, DatasetMetadata, DatasetRecord, DatasetSortBy, DatasetStatus,

--- a/crates/fricon/src/dataset/interpret.rs
+++ b/crates/fricon/src/dataset/interpret.rs
@@ -7,7 +7,9 @@ use arrow_schema::Schema;
 pub use self::model::{
     ColumnMeaning, DatasetInterpretation, InterpretationSource, PhysicalColumnOrdinal,
     ResolvedColumn, ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedLogicalIndexPoint,
-    ResolvedScanAxis, ResolvedScanAxisMode, VisibleColumnOrdinal,
+    ResolvedLogicalIndexReference, ResolvedPhysicalColumnReference, ResolvedScanAxis,
+    ResolvedScanAxisMode, ResolvedSemanticReference, VisibleColumnOrdinal, logical_index_id,
+    physical_column_id,
 };
 use crate::dataset::{
     schema::{DatasetDataType, DatasetSchema, ScalarKind, TraceKind},
@@ -41,11 +43,13 @@ pub(crate) fn resolve_from_manifest(
                 .get(&name)
                 .expect("manifest should be validated against arrow schema");
             let is_record_id = column.system == Some(SystemColumn::RecordId);
+            let dtype = column.dtype.clone();
             ResolvedColumn {
+                id: physical_column_id(&name),
                 name,
                 physical_ordinal: PhysicalColumnOrdinal(physical_ordinal),
                 visible_ordinal: visible_ordinals.get(&physical_ordinal).copied(),
-                dtype: column.dtype.clone(),
+                dtype: dtype.clone(),
                 meaning: if is_record_id {
                     ColumnMeaning::SystemRecordId
                 } else {
@@ -57,6 +61,9 @@ pub(crate) fn resolve_from_manifest(
                 is_chart_axis_candidate: column.chart_axis,
                 unit: column.unit.clone(),
                 label: column.label.clone(),
+                is_complex: dtype_is_complex(&dtype),
+                is_trace: dtype_is_trace(&dtype),
+                is_numeric_axis_candidate: dtype_is_chart_axis_numeric(&dtype),
             }
         })
         .collect();
@@ -72,9 +79,17 @@ pub(crate) fn resolve_from_manifest(
         .filter_map(|column| column.visible_ordinal)
         .collect();
     let scan_axes = resolve_scan_axes(manifest);
+    let role_projections = manifest_role_projections(&columns, &scan_axes);
 
     DatasetInterpretation {
         columns,
+        semantic_references: role_projections.semantic_references,
+        value_references: role_projections.value_references,
+        plotted_coordinates: role_projections.plotted_coordinates,
+        sweep_axes: role_projections.sweep_axes,
+        group_axes: role_projections.group_axes,
+        filter_axes: role_projections.filter_axes,
+        chart_axis_candidates: role_projections.chart_axis_candidates,
         value_columns,
         logical_index_columns: Vec::new(),
         chart_axis_candidate_columns,
@@ -93,6 +108,60 @@ pub(crate) fn resolve_from_manifest(
     }
 }
 
+struct RoleProjections {
+    semantic_references: Vec<ResolvedSemanticReference>,
+    value_references: Vec<ResolvedSemanticReference>,
+    plotted_coordinates: Vec<ResolvedSemanticReference>,
+    sweep_axes: Vec<ResolvedSemanticReference>,
+    group_axes: Vec<ResolvedSemanticReference>,
+    filter_axes: Vec<ResolvedSemanticReference>,
+    chart_axis_candidates: Vec<ResolvedSemanticReference>,
+}
+
+fn manifest_role_projections(
+    columns: &[ResolvedColumn],
+    scan_axes: &[ResolvedScanAxis],
+) -> RoleProjections {
+    let logical_index_references = scan_axes
+        .iter()
+        .map(ResolvedScanAxis::as_semantic_reference)
+        .collect::<Vec<_>>();
+    let value_references = physical_column_references(columns, false, |column| {
+        column.meaning == ColumnMeaning::UserValue
+    });
+    let chart_axis_candidates = physical_column_references(columns, false, |column| {
+        column.is_chart_axis_candidate && column.visible_ordinal.is_some()
+    });
+    let mut semantic_references = physical_column_references(columns, false, |_| true);
+    semantic_references.extend(logical_index_references.clone());
+    let mut plotted_coordinates = logical_index_references.clone();
+    plotted_coordinates.extend(chart_axis_candidates.clone());
+    let mut filter_axes = logical_index_references.clone();
+    filter_axes.extend(chart_axis_candidates.clone());
+
+    RoleProjections {
+        semantic_references,
+        value_references,
+        plotted_coordinates,
+        sweep_axes: logical_index_references.clone(),
+        group_axes: logical_index_references,
+        filter_axes,
+        chart_axis_candidates,
+    }
+}
+
+fn physical_column_references(
+    columns: &[ResolvedColumn],
+    is_compatibility: bool,
+    predicate: impl Fn(&ResolvedColumn) -> bool,
+) -> Vec<ResolvedSemanticReference> {
+    columns
+        .iter()
+        .filter(|column| predicate(column))
+        .map(|column| column.as_semantic_reference(is_compatibility))
+        .collect()
+}
+
 fn resolve_scan_axes(manifest: &DatasetSemanticManifest) -> Vec<ResolvedScanAxis> {
     manifest
         .scan_plan
@@ -101,15 +170,22 @@ fn resolve_scan_axes(manifest: &DatasetSemanticManifest) -> Vec<ResolvedScanAxis
             scan_plan
                 .axes
                 .iter()
-                .map(|axis| ResolvedScanAxis {
-                    name: axis.name.clone(),
-                    label: axis.label.clone(),
-                    mode: match &axis.mode {
+                .enumerate()
+                .map(|(axis_ordinal, axis)| {
+                    let mode = match &axis.mode {
                         ScanAxisMode::Static { values } => ResolvedScanAxisMode::Static {
                             values: values.clone(),
                         },
                         ScanAxisMode::ImplicitIndex => ResolvedScanAxisMode::ImplicitIndex,
-                    },
+                    };
+                    ResolvedScanAxis {
+                        id: logical_index_id(&axis.name),
+                        axis_ordinal,
+                        name: axis.name.clone(),
+                        label: axis.label.clone(),
+                        numeric_axis: scan_axis_mode_is_numeric(&mode),
+                        mode,
+                    }
                 })
                 .collect()
         })
@@ -208,11 +284,13 @@ pub(crate) fn resolve_from_compatibility_inference(
         .map(|(ordinal, (name, data_type))| {
             let visible_ordinal = VisibleColumnOrdinal(ordinal);
             let is_index = index_column_set.contains(&visible_ordinal);
+            let dtype = dataset_dtype_from_compatibility_type(*data_type);
             ResolvedColumn {
+                id: physical_column_id(name),
                 name: name.to_owned(),
                 physical_ordinal: PhysicalColumnOrdinal(ordinal),
                 visible_ordinal: Some(visible_ordinal),
-                dtype: dataset_dtype_from_compatibility_type(*data_type),
+                dtype: dtype.clone(),
                 meaning: if is_index {
                     ColumnMeaning::CompatibilityIndex
                 } else {
@@ -224,6 +302,9 @@ pub(crate) fn resolve_from_compatibility_inference(
                 is_chart_axis_candidate: is_index,
                 unit: None,
                 label: None,
+                is_complex: dtype_is_complex(&dtype),
+                is_trace: dtype_is_trace(&dtype),
+                is_numeric_axis_candidate: dtype_is_chart_axis_numeric(&dtype),
             }
         })
         .collect();
@@ -233,9 +314,17 @@ pub(crate) fn resolve_from_compatibility_inference(
         .filter(|column| column.meaning == ColumnMeaning::UserValue)
         .filter_map(|column| column.visible_ordinal)
         .collect();
+    let role_projections = compatibility_role_projections(&columns);
 
     DatasetInterpretation {
         columns,
+        semantic_references: role_projections.semantic_references,
+        value_references: role_projections.value_references,
+        plotted_coordinates: role_projections.plotted_coordinates,
+        sweep_axes: role_projections.sweep_axes,
+        group_axes: role_projections.group_axes,
+        filter_axes: role_projections.filter_axes,
+        chart_axis_candidates: role_projections.chart_axis_candidates,
         value_columns,
         logical_index_columns: index_columns.clone(),
         chart_axis_candidate_columns: index_columns,
@@ -243,6 +332,26 @@ pub(crate) fn resolve_from_compatibility_inference(
         index_realization: ResolvedIndexRealization::None,
         scan_axes: Vec::new(),
         source: InterpretationSource::CompatibilityInference,
+    }
+}
+
+fn compatibility_role_projections(columns: &[ResolvedColumn]) -> RoleProjections {
+    let value_references = physical_column_references(columns, true, |column| {
+        column.meaning == ColumnMeaning::UserValue
+    });
+    let compatibility_axes = physical_column_references(columns, true, |column| {
+        column.meaning == ColumnMeaning::CompatibilityIndex
+    });
+    let semantic_references = physical_column_references(columns, true, |_| true);
+
+    RoleProjections {
+        semantic_references,
+        value_references,
+        plotted_coordinates: compatibility_axes.clone(),
+        sweep_axes: compatibility_axes.clone(),
+        group_axes: compatibility_axes.clone(),
+        filter_axes: compatibility_axes.clone(),
+        chart_axis_candidates: compatibility_axes,
     }
 }
 
@@ -273,6 +382,37 @@ fn trace_value_from_compatibility_type(scalar_kind: ScalarKind) -> TraceValueDTy
     }
 }
 
+fn dtype_is_complex(dtype: &DatasetDType) -> bool {
+    matches!(
+        dtype,
+        DatasetDType::Complex128
+            | DatasetDType::Trace {
+                value: TraceValueDType::Complex128,
+                ..
+            }
+    )
+}
+
+fn dtype_is_trace(dtype: &DatasetDType) -> bool {
+    matches!(dtype, DatasetDType::Trace { .. })
+}
+
+fn dtype_is_chart_axis_numeric(dtype: &DatasetDType) -> bool {
+    matches!(
+        dtype,
+        DatasetDType::Float64 | DatasetDType::Float32 | DatasetDType::Int64 | DatasetDType::UInt64
+    )
+}
+
+fn scan_axis_mode_is_numeric(mode: &ResolvedScanAxisMode) -> bool {
+    match mode {
+        ResolvedScanAxisMode::ImplicitIndex => true,
+        ResolvedScanAxisMode::Static { values } => values
+            .iter()
+            .all(|value| matches!(value, ScanAxisValue::Int(_) | ScanAxisValue::Float(_))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{ops::Bound, sync::Arc};
@@ -283,7 +423,8 @@ mod tests {
     use super::{
         ColumnMeaning, InterpretationSource, PhysicalColumnOrdinal, ResolvedDuplicatePolicy,
         ResolvedIndexRealization, ResolvedLogicalIndexPoint, ResolvedScanAxisMode,
-        VisibleColumnOrdinal, resolve_from_manifest, resolve_logical_index_points,
+        ResolvedSemanticReference, VisibleColumnOrdinal, resolve_from_manifest,
+        resolve_logical_index_points,
     };
     use crate::dataset::{
         DatasetReader,
@@ -331,6 +472,7 @@ mod tests {
         );
 
         let record_id = &interpretation.columns[0];
+        assert_eq!(record_id.id, "column:__ds_record_id");
         assert_eq!(record_id.name, RECORD_ID_COLUMN);
         assert_eq!(record_id.physical_ordinal, PhysicalColumnOrdinal(0));
         assert_eq!(record_id.visible_ordinal, None);
@@ -342,12 +484,22 @@ mod tests {
         assert!(!record_id.is_chart_axis_candidate);
 
         let signal = &interpretation.columns[1];
+        assert_eq!(signal.id, "column:signal");
         assert_eq!(signal.physical_ordinal, PhysicalColumnOrdinal(1));
         assert_eq!(signal.visible_ordinal, Some(VisibleColumnOrdinal(0)));
         assert_eq!(signal.meaning, ColumnMeaning::UserValue);
         assert_eq!(signal.dtype, DatasetDType::Float64);
         assert!(!signal.is_system);
         assert!(!signal.hidden_by_default);
+        assert_eq!(interpretation.value_references.len(), 1);
+        assert_eq!(interpretation.value_references[0].id(), "column:signal");
+        assert_eq!(
+            interpretation
+                .physical_column_for_id("column:signal")
+                .expect("physical semantic reference")
+                .name,
+            "signal"
+        );
     }
 
     #[test]
@@ -371,6 +523,12 @@ mod tests {
         assert!(signal.hidden_by_default);
         assert!(signal.is_chart_axis_candidate);
         assert_eq!(interpretation.chart_axis_candidate_columns, visible(&[0]));
+        assert_eq!(interpretation.chart_axis_candidates.len(), 1);
+        assert_eq!(
+            interpretation.chart_axis_candidates[0].id(),
+            "column:signal"
+        );
+        assert!(interpretation.chart_axis_candidates[0].hidden_by_default());
     }
 
     #[test]
@@ -398,6 +556,20 @@ mod tests {
             ResolvedIndexRealization::Implicit
         );
         assert_eq!(interpretation.scan_axes.len(), 2);
+        assert_eq!(interpretation.scan_axes[0].id, "logicalIndex:gate");
+        assert_eq!(interpretation.sweep_axes.len(), 2);
+        assert_eq!(interpretation.group_axes[0].id(), "logicalIndex:gate");
+        assert_eq!(interpretation.filter_axes[1].id(), "logicalIndex:bias");
+        assert_eq!(
+            interpretation.plotted_coordinates[0].id(),
+            "logicalIndex:gate"
+        );
+        assert!(
+            interpretation
+                .logical_axis_for_id("logicalIndex:gate")
+                .expect("logical semantic reference")
+                .numeric_axis
+        );
         assert!(matches!(
             interpretation.scan_axes[0].mode,
             ResolvedScanAxisMode::Static { .. }
@@ -525,6 +697,28 @@ mod tests {
             interpretation.chart_axis_candidate_columns,
             visible(&[0, 1])
         );
+        assert_eq!(
+            interpretation
+                .sweep_axes
+                .iter()
+                .map(ResolvedSemanticReference::id)
+                .collect::<Vec<_>>(),
+            vec!["column:run", "column:step"]
+        );
+        assert_eq!(
+            interpretation
+                .chart_axis_candidates
+                .iter()
+                .map(ResolvedSemanticReference::id)
+                .collect::<Vec<_>>(),
+            vec!["column:run", "column:step"]
+        );
+        assert!(
+            interpretation
+                .sweep_axes
+                .iter()
+                .all(ResolvedSemanticReference::is_compatibility)
+        );
         assert_eq!(interpretation.value_columns, visible(&[2]));
         assert_eq!(
             interpretation.columns[0].meaning,
@@ -534,6 +728,34 @@ mod tests {
         assert!(interpretation.columns[0].is_chart_axis_candidate);
         assert_eq!(interpretation.columns[2].meaning, ColumnMeaning::UserValue);
         assert!(!interpretation.columns[2].is_index);
+    }
+
+    #[test]
+    fn interpretation_ids_preserve_prefixed_physical_column_names() {
+        let schema = DatasetSchema::try_from(&Schema::new(vec![
+            Field::new("logicalIndex:gate", DataType::Float64, false),
+            Field::new("column:value", DataType::Float64, false),
+        ]))
+        .expect("schema");
+
+        let interpretation = resolve_from_compatibility_inference(&schema, Some(vec![0]));
+
+        assert_eq!(interpretation.columns[0].id, "column:logicalIndex:gate");
+        assert_eq!(interpretation.columns[1].id, "column:column:value");
+        assert_eq!(
+            interpretation
+                .physical_column_for_id("column:logicalIndex:gate")
+                .expect("prefixed physical column")
+                .name,
+            "logicalIndex:gate"
+        );
+        assert!(
+            matches!(
+                interpretation.semantic_reference("logicalIndex:gate"),
+                None | Some(ResolvedSemanticReference::LogicalIndex(_))
+            ),
+            "a physical column whose name starts with logicalIndex: must stay in column namespace"
+        );
     }
 
     #[test]

--- a/crates/fricon/src/dataset/interpret/model.rs
+++ b/crates/fricon/src/dataset/interpret/model.rs
@@ -1,8 +1,18 @@
 use crate::dataset::semantics::{DatasetDType, ScanAxisValue};
 
+const COLUMN_ID_PREFIX: &str = "column:";
+const LOGICAL_INDEX_ID_PREFIX: &str = "logicalIndex:";
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct DatasetInterpretation {
     pub columns: Vec<ResolvedColumn>,
+    pub semantic_references: Vec<ResolvedSemanticReference>,
+    pub value_references: Vec<ResolvedSemanticReference>,
+    pub plotted_coordinates: Vec<ResolvedSemanticReference>,
+    pub sweep_axes: Vec<ResolvedSemanticReference>,
+    pub group_axes: Vec<ResolvedSemanticReference>,
+    pub filter_axes: Vec<ResolvedSemanticReference>,
+    pub chart_axis_candidates: Vec<ResolvedSemanticReference>,
     pub value_columns: Vec<VisibleColumnOrdinal>,
     pub logical_index_columns: Vec<VisibleColumnOrdinal>,
     pub chart_axis_candidate_columns: Vec<VisibleColumnOrdinal>,
@@ -10,6 +20,33 @@ pub struct DatasetInterpretation {
     pub index_realization: ResolvedIndexRealization,
     pub scan_axes: Vec<ResolvedScanAxis>,
     pub source: InterpretationSource,
+}
+
+impl DatasetInterpretation {
+    #[must_use]
+    pub fn semantic_reference(&self, id: &str) -> Option<&ResolvedSemanticReference> {
+        self.semantic_references
+            .iter()
+            .find(|reference| reference.id() == id)
+    }
+
+    #[must_use]
+    pub fn physical_column_for_id(&self, id: &str) -> Option<&ResolvedPhysicalColumnReference> {
+        self.semantic_reference(id)
+            .and_then(|reference| match reference {
+                ResolvedSemanticReference::PhysicalColumn(column) => Some(column),
+                ResolvedSemanticReference::LogicalIndex(_) => None,
+            })
+    }
+
+    #[must_use]
+    pub fn logical_axis_for_id(&self, id: &str) -> Option<&ResolvedLogicalIndexReference> {
+        self.semantic_reference(id)
+            .and_then(|reference| match reference {
+                ResolvedSemanticReference::PhysicalColumn(_) => None,
+                ResolvedSemanticReference::LogicalIndex(axis) => Some(axis),
+            })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -24,6 +61,7 @@ pub struct VisibleColumnOrdinal(pub usize);
     reason = "resolved column flags are compatibility and UI-facing projections"
 )]
 pub struct ResolvedColumn {
+    pub id: String,
     pub name: String,
     pub physical_ordinal: PhysicalColumnOrdinal,
     pub visible_ordinal: Option<VisibleColumnOrdinal>,
@@ -35,6 +73,124 @@ pub struct ResolvedColumn {
     pub is_chart_axis_candidate: bool,
     pub unit: Option<String>,
     pub label: Option<String>,
+    pub is_complex: bool,
+    pub is_trace: bool,
+    pub is_numeric_axis_candidate: bool,
+}
+
+impl ResolvedColumn {
+    #[must_use]
+    pub fn as_semantic_reference(&self, is_compatibility: bool) -> ResolvedSemanticReference {
+        ResolvedSemanticReference::PhysicalColumn(ResolvedPhysicalColumnReference {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            physical_ordinal: self.physical_ordinal,
+            visible_ordinal: self.visible_ordinal,
+            dtype: self.dtype.clone(),
+            meaning: self.meaning,
+            is_index: self.is_index,
+            is_system: self.is_system,
+            is_compatibility,
+            hidden_by_default: self.hidden_by_default,
+            is_chart_axis_candidate: self.is_chart_axis_candidate,
+            unit: self.unit.clone(),
+            label: self.label.clone(),
+            is_complex: self.is_complex,
+            is_trace: self.is_trace,
+            numeric_axis: self.is_numeric_axis_candidate,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedSemanticReference {
+    PhysicalColumn(ResolvedPhysicalColumnReference),
+    LogicalIndex(ResolvedLogicalIndexReference),
+}
+
+impl ResolvedSemanticReference {
+    #[must_use]
+    pub fn id(&self) -> &str {
+        match self {
+            Self::PhysicalColumn(column) => &column.id,
+            Self::LogicalIndex(axis) => &axis.id,
+        }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::PhysicalColumn(column) => &column.name,
+            Self::LogicalIndex(axis) => &axis.name,
+        }
+    }
+
+    #[must_use]
+    pub fn label(&self) -> Option<&String> {
+        match self {
+            Self::PhysicalColumn(column) => column.label.as_ref(),
+            Self::LogicalIndex(axis) => axis.label.as_ref(),
+        }
+    }
+
+    #[must_use]
+    pub const fn hidden_by_default(&self) -> bool {
+        match self {
+            Self::PhysicalColumn(column) => column.hidden_by_default,
+            Self::LogicalIndex(axis) => axis.hidden_by_default,
+        }
+    }
+
+    #[must_use]
+    pub const fn numeric_axis(&self) -> bool {
+        match self {
+            Self::PhysicalColumn(column) => column.numeric_axis,
+            Self::LogicalIndex(axis) => axis.numeric_axis,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_compatibility(&self) -> bool {
+        match self {
+            Self::PhysicalColumn(column) => column.is_compatibility,
+            Self::LogicalIndex(axis) => axis.is_compatibility,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "semantic references expose resolved role and UI capabilities"
+)]
+pub struct ResolvedPhysicalColumnReference {
+    pub id: String,
+    pub name: String,
+    pub physical_ordinal: PhysicalColumnOrdinal,
+    pub visible_ordinal: Option<VisibleColumnOrdinal>,
+    pub dtype: DatasetDType,
+    pub meaning: ColumnMeaning,
+    pub is_index: bool,
+    pub is_system: bool,
+    pub is_compatibility: bool,
+    pub hidden_by_default: bool,
+    pub is_chart_axis_candidate: bool,
+    pub unit: Option<String>,
+    pub label: Option<String>,
+    pub is_complex: bool,
+    pub is_trace: bool,
+    pub numeric_axis: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLogicalIndexReference {
+    pub id: String,
+    pub name: String,
+    pub axis_ordinal: usize,
+    pub label: Option<String>,
+    pub hidden_by_default: bool,
+    pub numeric_axis: bool,
+    pub is_compatibility: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,9 +209,27 @@ pub enum ResolvedIndexRealization {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedScanAxis {
+    pub id: String,
+    pub axis_ordinal: usize,
     pub name: String,
     pub label: Option<String>,
     pub mode: ResolvedScanAxisMode,
+    pub numeric_axis: bool,
+}
+
+impl ResolvedScanAxis {
+    #[must_use]
+    pub fn as_semantic_reference(&self) -> ResolvedSemanticReference {
+        ResolvedSemanticReference::LogicalIndex(ResolvedLogicalIndexReference {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            axis_ordinal: self.axis_ordinal,
+            label: self.label.clone(),
+            hidden_by_default: false,
+            numeric_axis: self.numeric_axis,
+            is_compatibility: false,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -81,4 +255,14 @@ pub enum InterpretationSource {
 pub enum ResolvedDuplicatePolicy {
     LatestByRecordId,
     CompatibilityRowOrderPlaceholder,
+}
+
+#[must_use]
+pub fn physical_column_id(name: &str) -> String {
+    format!("{COLUMN_ID_PREFIX}{name}")
+}
+
+#[must_use]
+pub fn logical_index_id(name: &str) -> String {
+    format!("{LOGICAL_INDEX_ID_PREFIX}{name}")
 }

--- a/crates/fricon/src/lib.rs
+++ b/crates/fricon/src/lib.rs
@@ -24,9 +24,10 @@ pub use self::{
         DatasetRow, DatasetScalar, DatasetSchema, DatasetSortBy, DatasetStatus, DatasetUpdate,
         FixedStepTrace, InterpretationSource, PhysicalColumnOrdinal, ResolvedColumn,
         ResolvedDuplicatePolicy, ResolvedIndexRealization, ResolvedLogicalIndexPoint,
-        ResolvedScanAxis, ResolvedScanAxisMode, ScalarArray, ScalarKind, ScanAxis, ScanAxisMode,
-        ScanAxisValue, ScanPlan, SelectOptions, SortDirection, TraceKind, VariableStepTrace,
-        VisibleColumnOrdinal,
+        ResolvedLogicalIndexReference, ResolvedPhysicalColumnReference, ResolvedScanAxis,
+        ResolvedScanAxisMode, ResolvedSemanticReference, ScalarArray, ScalarKind, ScanAxis,
+        ScanAxisMode, ScanAxisValue, ScanPlan, SelectOptions, SortDirection, TraceKind,
+        VariableStepTrace, VisibleColumnOrdinal, logical_index_id, physical_column_id,
     },
     workspace::{WorkspaceError, WorkspaceRoot, get_log_dir},
 };


### PR DESCRIPTION
closes #512 

## Summary
- Consolidates chart semantic resolution into the dataset interpretation layer.
- Reuses the shared semantic model from UI chart sources and dataset queries.
- Updates the public dataset surface to match the new interpretation flow.

## Testing
- Not run (not requested).