### PR TITLE
docs: split current semantics from historical proposal

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -32,7 +32,7 @@ every canonical document.
 | Workspace format or metadata compatibility  | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Architecture background unless boundary design is unclear              |
 | Dataset archive import/export compatibility | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`              | Public docs unless behavior is user-visible                            |
 | Rust IPC/gRPC contract compatibility        | `maintenance-checklist.md`               | `pr-preflight-checklist.md`, `release-and-versioning.md`                                          | Public docs unless behavior is user-visible                            |
-| Public dataset docs update                  | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, dataset semantic proposal status only                                 | Implementation plan details unless landed behavior is being documented |
+| Public dataset docs update                  | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, `current-dataset-semantics.md`                                        | Implementation plan details unless landed behavior is being documented |
 | Parameter management product planning       | `parameter-management-design.md`         | `project-intent.md`, `roadmap.md`, `adr/README.md`                                                | Treating proposal content as current behavior                          |
 | Future concept capture                      | `future-concepts.md`                     | `project-intent.md`, `roadmap.md`                                                                 | Creating implementation issues before the concept is narrowed          |
 | Product route or issue planning             | `roadmap.md`                             | `project-intent.md`, proposal or implementation-plan files for affected areas                     | Treating roadmap future concepts as current implementation facts       |
@@ -67,6 +67,8 @@ These files describe the current implementation. Update them when the
 implementation changes.
 
 - `current-storage-notes.md` - current workspace and dataset storage details
+- `current-dataset-semantics.md` - current dataset semantic model, writer
+  metadata, reader interpretation, and chart projection behavior
 
 ## Architecture Notes
 
@@ -80,10 +82,12 @@ checklist, policy, or guideline.
 
 ## Proposals
 
-This file describes proposed future direction. Do not treat it as current
-implementation fact unless the implementation has already landed.
+These files describe proposed or historical direction. Do not treat them as
+current implementation fact unless a current implementation note confirms that
+the behavior has landed.
 
-- `dataset-semantic-architecture-proposal.md`
+- `dataset-semantic-architecture-proposal.md` - historical dataset semantics
+  proposal, implementation snapshot, and remaining roadmap pressure
 - `experiment-run-and-runner-design.md` - proposed experiment run, generic
   runner, retry/resume, resource lease, and dataset write provenance model
 - `future-concepts.md` - lightweight ledger for useful but not-yet-designed

--- a/dev-docs/current-dataset-semantics.md
+++ b/dev-docs/current-dataset-semantics.md
@@ -1,0 +1,152 @@
+# Current Dataset Semantics
+
+## Status
+
+Current implementation note. Update this when dataset semantic behavior,
+writer metadata, reader interpretation, or chart projection semantics change.
+
+## Purpose
+
+This note describes the implemented dataset semantic model. Storage layout
+details live in `dev-docs/current-storage-notes.md`. Historical rationale and
+deferred design pressure live in
+`dev-docs/dataset-semantic-architecture-proposal.md`.
+
+## Implemented Model
+
+New datasets created through ingest have a dataset-local semantic sidecar named
+`dataset_manifest.json`. Semantic reads require this manifest and validate it
+against the physical Arrow schema before exposing resolved interpretation.
+
+The manifest v1 model includes:
+
+- `manifest_version`
+- `columns`
+- optional `scan_plan`
+- `realization`
+- `inference`
+
+Each manifest column records a Fricon dataset dtype and required semantic
+facets:
+
+- `value_kind`: numeric, categorical, boolean, timestamp, complex, or display
+- `shape_kind`: scalar or trace
+- `role`: value, logical_index, system, or display
+
+Column metadata may also record `unit`, `label`, `hidden_by_default`, and
+`chart_axis`. These are display and chart hints; renderer capabilities are
+derived by interpretation rather than stored as durable manifest fields.
+
+Fricon reserves the `__ds_` prefix for system fields. User payload columns and
+scan-axis names using this prefix are rejected. New semantic datasets
+physically materialize `__ds_record_id: uint64` as the first Arrow column. It
+is monotonically increasing within the dataset, defines append order, and is
+hidden from ordinary dataset reads, Python convenience reads, desktop details,
+and chart defaults.
+
+## Writer Behavior
+
+Bare Python writes remain low-friction:
+
+```python
+with workspace.dataset_manager.create("run") as writer:
+    writer.write(step=0, signal=1.0)
+```
+
+The first row freezes the user payload schema. Later rows must match that
+schema. The writer constructs the storage schema by prepending
+`__ds_record_id`, writes a minimal manifest, and appends Arrow chunk files.
+
+Dataset creation also supports progressive semantic metadata:
+
+- `columns=` for optional stored-column declarations and display/chart metadata
+- `scan=` for optional logical scan axes
+- `IndexAxis` or `None` for unknown-length integer scan axes
+- `write_dict(..., logical_indices=...)` for explicit durable logical index
+  positions
+
+If `scan=` is present and no explicit logical indices are supplied on the first
+write, the manifest usually uses implicit index realization. Mixed static and
+unknown-length scan axes require sidecar realization, so callers must supply
+`logical_indices` from the start. If `logical_indices` are supplied on the first
+write, the dataset uses logical-index sidecar realization and writes
+append-only sidecar chunks keyed by `__ds_record_id`.
+
+The public `write(**kwargs)` path intentionally remains a clean payload-row
+API. Advanced callers use `write_dict` when they need durable logical index
+context.
+
+## Reader And Interpretation Behavior
+
+The semantic Rust reader requires `dataset_manifest.json`. It validates the
+manifest against Arrow chunks, projects away hidden system columns for ordinary
+reads, and exposes resolved interpretation through `DatasetReader::interpret`.
+
+Resolved interpretation includes:
+
+- physical and visible column ordinals
+- semantic descriptors and renderer capability flags
+- value columns
+- inferred physical axes for minimal bare-write datasets
+- manifest scan axes
+- chart-axis candidate columns
+- duplicate policy
+- index realization
+
+Minimal axis inference still exists for simple datasets, but only when the
+manifest allows inference, no scan plan is present, and no explicit column
+metadata is present. In that case the reader samples the first two visible rows
+and marks leading numeric columns as inferred logical-index roles using the
+temporary `row_order_placeholder` duplicate policy.
+
+For datasets with scan plans, logical index points are resolved from either:
+
+- implicit append order and scan shape, or
+- `logical_index_chunk_<n>.arrow` sidecar chunks.
+
+Chart projection appends resolved logical axes to projected batches and applies
+the default duplicate policy `latest_by_record_id` for explicit scan semantics.
+
+## UI And Chart Behavior
+
+Desktop dataset detail uses resolved interpretation rather than raw Arrow field
+order. It exposes visible columns with semantic descriptors, capability flags,
+labels, units, hidden-by-default state, and chart-axis candidate state.
+
+Chart semantics expose:
+
+- duplicate policy
+- index realization
+- resolved axes
+- value columns
+- chart-axis candidates
+
+Chart data loading uses semantic projection so logical scan axes and inferred
+axes can participate in grouping, filtering, heatmap, and XY transforms without
+being stored as ordinary user payload columns.
+
+## Compatibility Notes
+
+Manifest-free dataset payloads and earlier transition manifests without
+required semantic facets are not supported by the semantic Rust read path.
+
+Python `Dataset.to_arrow()` and `Dataset.to_polars()` are convenience helpers
+that read Arrow chunk files directly and hide `__ds_` columns. They do not
+perform full semantic manifest interpretation.
+
+Dataset archives include catalog metadata, `dataset_manifest.json`, Arrow data
+chunks, and logical-index sidecar chunks when present.
+
+## Deferred
+
+The current implementation does not make these concepts first-class:
+
+- user-authored raw manifests
+- manifest-owned saved views
+- run or measurement manifests
+- execution segment tables
+- status-aware duplicate policies
+- invalidation or quality-state semantics
+- a public raw facts API that exposes system columns by default
+- full semantic grid/select reader APIs beyond the current projection path
+- null-heavy or late-appearing column workflows

--- a/dev-docs/current-storage-notes.md
+++ b/dev-docs/current-storage-notes.md
@@ -12,9 +12,10 @@ as stable user-facing documentation. Public docs should describe workspaces and
 datasets through the CLI, Python API, and desktop UI rather than through the
 on-disk layout.
 
-Dataset semantics proposal documents describe long-term direction. Use this
-file as the current source of truth for implemented storage facts, including
-the current v1 dataset semantic manifest sidecar.
+Dataset semantics documents describe implemented meaning and long-term
+direction. Use this file as the current source of truth for implemented storage
+facts, including the current v1 dataset semantic manifest sidecar. Use
+`dev-docs/current-dataset-semantics.md` for current semantic behavior.
 
 ## Workspace Layout
 
@@ -23,6 +24,7 @@ At the time of writing, a workspace contains:
 ```tree
 workspace/
   .fricon_workspace.json
+  .fricon.lock
   fricon.sqlite3
   fricon.socket
   data/
@@ -44,6 +46,7 @@ Notes:
 - Opening an older workspace may trigger a stepwise migration before the
   workspace is usable.
 - `fricon.sqlite3` stores workspace catalog metadata.
+- `.fricon.lock` is runtime workspace exclusivity state, not durable data.
 - `fricon.socket` is runtime IPC state, not durable data.
 - Dataset directories are currently sharded by the first two characters of the
   dataset UID.
@@ -88,9 +91,11 @@ capabilities are derived interpretation/DTO fields, not durable manifest fields.
 Dataset archives store catalog metadata in `metadata.json`, the required
 `dataset_manifest.json` root sidecar, Arrow payload chunks under
 `data/data_chunk_<n>.arrow`, and logical-index chunks under
-`logical_index/logical_index_chunk_<n>.arrow` when present. Dataset readers
-require manifests; manifest-free payloads are not supported by the semantic read
-path.
+`logical_index/logical_index_chunk_<n>.arrow` when present. The semantic Rust
+reader requires manifests; manifest-free payloads are not supported by that
+path. Python `Dataset.to_arrow()` and `Dataset.to_polars()` are convenience
+helpers that read Arrow chunks directly and hide `__ds_` system columns without
+performing full semantic interpretation.
 
 ## Write Buffering
 

--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -16,23 +16,23 @@ remains useful for rationale, tradeoffs, and deferred design ideas.
 
 ## Implementation Snapshot
 
-| Area | Status |
-| --- | --- |
-| Manifest sidecar | Implemented |
-| `__ds_record_id` materialization | Implemented |
-| Reserved `__ds_` prefix | Implemented |
-| Manifest v1 dtype and semantic facets | Implemented |
-| Plain Arrow physical schemas for new semantic datasets | Implemented |
-| Minimal axis inference through resolved interpretation | Implemented |
-| Python `columns=` metadata | Implemented |
-| Python `scan=` metadata | Implemented |
-| `write_dict(..., logical_indices=...)` | Implemented |
-| Logical-index sidecar chunks | Implemented |
-| Dataset detail semantic DTOs | Implemented |
-| Chart projection over resolved semantic sources | Partially implemented |
-| Full reader grid/select API | Deferred |
-| Manifest-owned saved/default views | Deferred |
-| Run, measurement, status, and invalidation semantics | Deferred |
+| Area                                                   | Status                |
+| ------------------------------------------------------ | --------------------- |
+| Manifest sidecar                                       | Implemented           |
+| `__ds_record_id` materialization                       | Implemented           |
+| Reserved `__ds_` prefix                                | Implemented           |
+| Manifest v1 dtype and semantic facets                  | Implemented           |
+| Plain Arrow physical schemas for new semantic datasets | Implemented           |
+| Minimal axis inference through resolved interpretation | Implemented           |
+| Python `columns=` metadata                             | Implemented           |
+| Python `scan=` metadata                                | Implemented           |
+| `write_dict(..., logical_indices=...)`                 | Implemented           |
+| Logical-index sidecar chunks                           | Implemented           |
+| Dataset detail semantic DTOs                           | Implemented           |
+| Chart projection over resolved semantic sources        | Partially implemented |
+| Full reader grid/select API                            | Deferred              |
+| Manifest-owned saved/default views                     | Deferred              |
+| Run, measurement, status, and invalidation semantics   | Deferred              |
 
 This note revises the earlier append-only dataset idea for the actual Fricon
 codebase and assumes the product is still pre-adoption, so breaking internal

--- a/dev-docs/dataset-semantic-architecture-proposal.md
+++ b/dev-docs/dataset-semantic-architecture-proposal.md
@@ -1,19 +1,38 @@
-# Dataset Semantics Architecture Proposal
+# Dataset Semantics Architecture Proposal And Roadmap
 
 ## Status
 
-Proposed.
+Historical proposal and roadmap.
 
 The durable foundation decisions for `dataset_manifest.json`,
 `__ds_record_id`, the reserved `__ds_` prefix, v1 dtypes, plain Arrow storage,
 minimal axis inference, and the interpretation boundary are accepted in
 `dev-docs/adr/0002-decide-dataset-semantic-manifest-v1.md`.
 
-Some foundation pieces are now current behavior, including durable manifests,
-record IDs, and resolved interpretation. Treat the remaining scan authoring,
-chart migration, and workflow sections as proposal material unless current code,
-`dev-docs/current-storage-notes.md`, and the relevant checklist confirm they
-have landed.
+The foundation and much of the progressive metadata and scan work have landed.
+Use `dev-docs/current-dataset-semantics.md` for current semantic behavior and
+`dev-docs/current-storage-notes.md` for storage layout facts. This document
+remains useful for rationale, tradeoffs, and deferred design ideas.
+
+## Implementation Snapshot
+
+| Area | Status |
+| --- | --- |
+| Manifest sidecar | Implemented |
+| `__ds_record_id` materialization | Implemented |
+| Reserved `__ds_` prefix | Implemented |
+| Manifest v1 dtype and semantic facets | Implemented |
+| Plain Arrow physical schemas for new semantic datasets | Implemented |
+| Minimal axis inference through resolved interpretation | Implemented |
+| Python `columns=` metadata | Implemented |
+| Python `scan=` metadata | Implemented |
+| `write_dict(..., logical_indices=...)` | Implemented |
+| Logical-index sidecar chunks | Implemented |
+| Dataset detail semantic DTOs | Implemented |
+| Chart projection over resolved semantic sources | Partially implemented |
+| Full reader grid/select API | Deferred |
+| Manifest-owned saved/default views | Deferred |
+| Run, measurement, status, and invalidation semantics | Deferred |
 
 This note revises the earlier append-only dataset idea for the actual Fricon
 codebase and assumes the product is still pre-adoption, so breaking internal
@@ -116,8 +135,8 @@ workspace/
         dataset_manifest.json
         data_chunk_0.arrow
         data_chunk_1.arrow
-        index_chunk_0.arrow      # optional logical-index sidecar
-        index_chunk_1.arrow      # optional logical-index sidecar
+        logical_index_chunk_0.arrow      # optional logical-index sidecar
+        logical_index_chunk_1.arrow      # optional logical-index sidecar
         ...
 ```
 
@@ -884,26 +903,16 @@ __ds_record_id | restart | step
 Charts should treat this as an observed sparse grid. Missing cells are empty;
 the dataset does not need to claim a rectangular `planned_shape`.
 
-## Feature Shaping
+## Feature Shaping Snapshot
 
-The architecture should land as shaped feature layers, not as one broad v1.
-This keeps the current route dataset-first while leaving clean attachment
-points for later experiment, parameter, provenance, workflow, AI, and device
-models.
+The original architecture was shaped as feature layers instead of one broad v1.
+That split is now mostly historical: Feature 1, Feature 2, and the core of
+Feature 3 have landed. Use `dev-docs/current-dataset-semantics.md` for the
+implemented contract.
 
-### Feature 1: Durable Dataset Semantics Foundation
+### Landed Foundation
 
-Classification: `now`.
-
-User value:
-
-- bare Python writes keep working
-- every new dataset gets durable local meaning
-- simple datasets still get inferred axes through their semantic manifests
-- future run, parameter, provenance, and workflow models get a stable dataset
-  anchor without being hidden inside chart heuristics
-
-Scope:
+The durable foundation is implemented:
 
 - chunked append-only Arrow payloads remain the storage substrate
 - `dataset_manifest.json`
@@ -913,111 +922,47 @@ Scope:
   inference settings
 - manifest IO, serde model, validation, and defaulting
 - plain Arrow physical schemas for new semantic datasets
-- explicit missing-manifest errors for datasets without manifests
+- explicit missing-manifest errors for semantic reads without manifests
 - resolved interpretation API for readers and downstream consumers
-- temporary adapters that preserve existing chart and dataset-detail behavior
 
-Out of scope:
+### Landed Progressive Metadata
 
-- new public `columns=` metadata
-- public `scan=`
-- logical-index sidecar chunks
-- full chart/live-view rewrite
-- status, invalidation, or quality-state semantics
-- run, measurement, parameter, provenance, workflow, AI, or device manifests
-
-First success criterion:
-
-- new datasets produce a valid manifest and record IDs; manifest-free datasets
-  fail with a clear missing-manifest error, while simple newly written datasets
-  preserve equivalent user-facing behavior.
-
-ADR need:
-
-- create an ADR before implementation commits to the durable manifest shape,
-  record-id semantics, compatibility policy, and interpretation-layer boundary.
-
-### Feature 2: Progressive Column Metadata API
-
-Classification: `next`, after the foundation can persist and resolve manifest
-column metadata.
-
-User value:
-
-- users can add units, labels, hidden-by-default state, and chart-axis hints
-  without learning scan-plan or manifest vocabulary
-- future parameter and provenance views get consistent display metadata without
-  treating column names as the only source of meaning
-
-Scope:
+The progressive column metadata API is implemented:
 
 - optional `columns=` creation metadata
-- typed Python helpers such as `Column`
-- declared dtypes where useful, while still allowing first-row inference when
-  omitted
+- typed Python helper `Column`
+- declared dtypes for supported payload kinds, while still allowing first-row
+  inference when omitted
 - `unit`, `label`, `hidden_by_default`, and `chart_axis` metadata
 - reader and UI detail surfaces expose resolved column metadata
 
-Out of scope:
+### Landed Scan Semantics
 
-- `scan=`
-- logical-index sidecar chunks
-- parameter schemas or parameter-set versioning
-- user-authored raw manifests
-
-### Feature 3: Explicit Scan Semantics
-
-Classification: `next`.
-
-User value:
-
-- regular ordered scans can be reopened without row-adjacency guesses
-- non-contiguous, resumed, adaptive, and ragged acquisition can be represented
-  durably
-- framework-owned experiment systems can provide exact logical indices without
-  burdening simple Python scripts
-
-Scope:
+The core explicit scan semantics are implemented:
 
 - optional `scan=` creation metadata
+- typed Python helper `IndexAxis`
 - implicit logical-index realization for regular ordered scans
 - unknown-length integer index axes for minimizer-style workflows
 - optional append-only logical-index sidecar chunks
+- `write_dict(..., logical_indices=...)` for explicit durable logical positions
 - duplicate projection using `latest_by_record_id`
-- sparse/ragged grid projection from observed index pairs
-- active-session live grouping that does not require durable `sweep_id` or
-  `frame_id` payload columns
+- sparse/ragged projection support through observed logical index pairs
 
-Out of scope:
+### Partially Landed Consumer Migration
 
-- execution segment tables
-- status-aware duplicate policies
-- expanded planned-point tables
-- a separate durable derived-coordinate model
+Desktop detail and chart data loading consume resolved semantic interpretation
+for the current chart paths. Remaining migration work is about removing
+temporary adapters and expanding first-class reader/chart APIs, not about
+introducing the semantic foundation.
+
+Still incomplete or intentionally deferred:
+
+- full reader APIs such as semantic `grid(...)` and `select(index=...)`
+- manifest-owned saved/default views
+- active-session live grouping as an explicit semantic API
+- public raw/facts APIs for callers that need system columns
 - null-heavy or late-appearing column workflows
-
-### Feature 4: Consumer Migration
-
-Classification: `next`, after the foundation is stable.
-
-User value:
-
-- desktop detail, chart defaults, heatmaps, and live views consume resolved
-  dataset interpretation instead of rediscovering semantics from raw rows
-
-Scope:
-
-- dataset detail DTOs expose resolved semantic fields such as logical index,
-  chart-axis candidate, label, unit, scan axes, and defaults
-- chart transforms consume resolved logical indices and duplicate policy
-- legacy `isIndex` is removed from the UI contract
-- legacy direct use of index-column inference is removed
-
-Out of scope:
-
-- turning the desktop UI into the primary experiment execution engine
-- saved user-owned chart presets or workspace UI state inside the dataset
-  manifest
 
 ### Deferred Concepts
 


### PR DESCRIPTION
## Summary
- Added `current-dataset-semantics.md` as the current implementation note for dataset semantics.
- Reframed `dataset-semantic-architecture-proposal.md` as a historical proposal and roadmap, with an implementation snapshot.
- Updated `current-storage-notes.md` and `dev-docs/README.md` to point readers at the right current-state doc.

## Testing
- Not run (not requested)
- Verified the doc changes with stale-text checks and `git diff --check` during editing.