### PR TITLE
docs: reset docs-next for v0.2+ planning

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ pnpm-lock.yaml
 .github/instructions
 .pre-commit-config.yaml
 CHANGELOG.md
+docs-next/
 .agents
 routeTree.gen.ts
 crates/fricon-ui/frontend/src/shared/lib/bindings.ts

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,7 @@
+[default.extend-words]
+# QCoDeS-style scan helper family, pronounced "do N-dimensional".
+doNd = "doNd"
+
+[default.extend-identifiers]
+# Keep the exact mixed-case spelling in prose and API sketches.
+doNd = "doNd"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,7 +1,0 @@
-[default.extend-words]
-# QCoDeS-style scan helper family, pronounced "do N-dimensional".
-doNd = "doNd"
-
-[default.extend-identifiers]
-# Keep the exact mixed-case spelling in prose and API sketches.
-doNd = "doNd"

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -16,8 +16,7 @@ Start here when orienting a new human or AI contributor:
 
 1. `project-intent.md`
 2. `roadmap.md`
-3. `v0.2/README.md` and `v0.2/design.md` when working on the proposed v0.2
-   reset
+3. `../docs-next/README.md` when working on new v0.2+ reset design
 4. `maintenance-checklist.md`
 5. `pr-preflight-checklist.md`
 6. The topic-specific note for the area being changed
@@ -35,10 +34,10 @@ every canonical document.
 | Dataset archive import/export compatibility | `maintenance-checklist.md`               | `current-storage-notes.md`, `release-and-versioning.md`, `pr-preflight-checklist.md`                                             | Public docs unless behavior is user-visible                            |
 | Rust IPC/gRPC contract compatibility        | `maintenance-checklist.md`               | `pr-preflight-checklist.md`, `release-and-versioning.md`                                                                         | Public docs unless behavior is user-visible                            |
 | Public dataset docs update                  | `docs/dataset.md` and `docs/concepts.md` | `current-storage-notes.md`, `current-dataset-semantics.md`                                                                       | Implementation plan details unless landed behavior is being documented |
-| v0.2 product or architecture reset          | `v0.2/README.md`                         | `v0.2/design.md`, `v0.2/product-direction.md`, `v0.2/technical-direction.md`, `adr/README.md`                                    | Treating v0.2 proposal content as current behavior                     |
-| Measurement-system foundation redesign      | `v0.2/design.md`                         | `project-intent.md`, `roadmap.md`, `current-dataset-semantics.md`, `v0.2/archive/README.md`, `adr/README.md`                     | Treating archived proposal content as active v0.2 guidance             |
-| Parameter management product planning       | `v0.2/design.md`                         | `v0.2/product-direction.md`, `v0.2/technical-direction.md`, `v0.2/future-concepts.md`, `v0.2/archive/README.md`, `adr/README.md` | Treating archived proposal content as active v0.2 guidance             |
-| Future concept capture                      | `v0.2/future-concepts.md`                | `v0.2/design.md`, `v0.2/product-direction.md`, `v0.2/technical-direction.md`                                                     | Creating implementation issues before the concept is narrowed          |
+| v0.2+ product or architecture reset         | `../docs-next/README.md`                 | `../docs-next/redesign-from-prototype.md`, `../docs-next/product/vision.md`, `../docs-next/domain/conceptual-model.md`, `../docs-next/architecture/system-overview.md`                         | Treating old v0.2 proposal content as current behavior or source of truth |
+| Measurement-system foundation redesign      | `../docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md` | `../docs-next/product/story-map.md`, `../docs-next/domain/lifecycle-model.md`, `../docs-next/architecture/module-boundaries.md` | Treating archived proposal content as active v0.2 guidance             |
+| Parameter management product planning       | `../docs-next/product/future-concepts.md` | `../docs-next/domain/conceptual-model.md`, `../docs-next/product/capability-map.md`, `v0.2/future-concepts.md` as historical input only | Promoting parameter registry work before measurement foundation is accepted |
+| Future concept capture                      | `../docs-next/product/future-concepts.md` | `../docs-next/product/capability-map.md`, `../docs-next/domain/conceptual-model.md`                                               | Creating implementation issues before the concept is narrowed          |
 | Product route or issue planning             | `roadmap.md`                             | `project-intent.md`, proposal or implementation-plan files for affected areas                                                    | Treating roadmap future concepts as current implementation facts       |
 
 ## Canonical Guidance
@@ -74,6 +73,15 @@ implementation changes.
 - `current-dataset-semantics.md` - current dataset semantic model, writer
   metadata, reader interpretation, and chart projection behavior
 
+## v0.2+ Design Baseline
+
+New v0.2+ product, domain, architecture, ADR, traceability, and system-slice
+planning starts in `../docs-next/`.
+
+Use `dev-docs/v0.2/` and `dev-docs/v0.2/archive/` as source inputs and
+historical rationale. They should not override accepted `docs-next/` decisions
+or specs.
+
 ## Architecture Notes
 
 These files are advisory background unless they explicitly point to a canonical
@@ -90,12 +98,10 @@ These files describe proposed or historical direction. Do not treat them as
 current implementation fact unless a current implementation note confirms that
 the behavior has landed.
 
-- `v0.2/` - canonical planning directory for the proposed v0.2 reset. It now
-  owns the active non-implemented proposal set. Start with `v0.2/design.md` for
-  the canonical synthesis, then use the supporting files for product stories,
-  technical details, future concepts, distribution surfaces, remote/auth
-  boundary, and rewrite strategy. Historical proposal inputs live under
-  `v0.2/archive/` and should not override the canonical v0.2 documents.
+- `v0.2/` - historical planning directory for the proposed v0.2 reset. Its
+  contents are source inputs for `../docs-next/`, not the new v0.2+ design
+  baseline. Historical proposal inputs live under `v0.2/archive/` and should
+  not override `docs-next/` decisions or specs.
 
 ## Maintenance Rules
 

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -26,6 +26,7 @@ every canonical document.
 
 ## Agent Starting Points By Change Type
 
+<!-- prettier-ignore -->
 | Change type                                 | Start here                               | Then read                                                                                                                        | Usually avoid                                                          |
 | ------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | SQLite schema visible through Python        | `database-schema-changes.md`             | `maintenance-checklist.md`, `release-and-versioning.md`, Diesel skill                                                            | Dataset semantic proposal files unless semantics are changing          |

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -1,0 +1,86 @@
+# Fricon Docs Next
+
+## Status
+
+Draft v0.2+ documentation baseline.
+
+## Purpose
+
+`docs-next/` is the clean design workspace for the v0.2+ reset. It exists so
+new product, domain, architecture, and implementation planning can move forward
+without mixing:
+
+- current v0.1 implementation facts
+- historical proposal notes
+- AI-agent process discussion
+- new v0.2+ design decisions
+
+For v0.2+ planning, treat this directory as the starting point. Use
+`dev-docs/` only as source material for current implementation facts,
+historical lessons, and reusable maintenance practice.
+
+## Design Stance
+
+Fricon v0.2 is a clean reset from the workspace/dataset-first prototype toward
+a local lab data library for scientific measurement work.
+
+The reset keeps useful infrastructure where it fits, but it does not preserve
+v0.1 workspace, storage, API, IPC, or desktop navigation compatibility when
+that compatibility would keep the wrong user model alive.
+
+## Scale Classification
+
+Fricon is an S2 medium modular system:
+
+- Rust core/service code, Python SDK, CLI, and Tauri/React desktop UI interact.
+- Data library, measurement, dataset artifact, storage, API, lifecycle,
+  provenance, export, and compatibility concepts cross module boundaries.
+- AI-assisted development needs explicit global context, not only local feature
+  specs.
+
+## Reading Order
+
+1. `redesign-from-prototype.md`
+2. `postmortems/v0-lessons.md`
+3. `decisions/ADR-001-v02-clean-reset-boundary.md`
+4. `product/vision.md`
+5. `product/capability-map.md`
+6. `domain/conceptual-model.md`
+7. `architecture/system-overview.md`
+8. `architecture/module-boundaries.md`
+9. `architecture/compatibility-policy.md`
+10. `ai/project-context.md`
+11. `specs/SPEC-001-data-library-measurement-foundation/`
+
+## Directory Map
+
+```text
+docs-next/
+  redesign-from-prototype.md
+  product/              User goals, capabilities, stories, future ledger, glossary
+  domain/               Conceptual model, contexts, lifecycles, invariants
+  architecture/         System shape, boundaries, data flow, storage, API
+  decisions/            ADRs for durable decisions
+  specs/                System-slice specs derived from the baseline
+  implementation-plans/ Milestone plans and quality gates
+  postmortems/          Prototype lessons and reset rationale
+  ai/                   Agent context and documentation update policy
+  user/                 Future public documentation plan, not current docs
+```
+
+## Source Inputs
+
+This baseline was bootstrapped from:
+
+- `README.md`
+- `docs/`
+- `dev-docs/project-intent.md`
+- `dev-docs/roadmap.md`
+- `dev-docs/current-storage-notes.md`
+- `dev-docs/current-dataset-semantics.md`
+- `dev-docs/architecture-guidelines.md`
+- `dev-docs/v0.2/`
+- `dev-docs/v0.2/archive/`
+
+If an old proposal conflicts with this baseline, prefer this baseline for v0.2+
+planning unless a newer ADR says otherwise.

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -15,9 +15,11 @@ without mixing:
 - AI-agent process discussion
 - new v0.2+ design decisions
 
-For v0.2+ planning, treat this directory as the starting point. Use
-`dev-docs/` only as source material for current implementation facts,
-historical lessons, and reusable maintenance practice.
+For v0.2+ planning, treat this directory as the starting point.
+`dev-docs/project-intent.md` remains strategic product canon; `docs-next/`
+derives from it and owns the v0.2+ design baseline. Use older `dev-docs/v0.2/`
+proposal files as source material and historical rationale, not as the current
+source of truth.
 
 ## Design Stance
 
@@ -85,3 +87,12 @@ This baseline was bootstrapped from:
 
 If an old proposal conflicts with this baseline, prefer this baseline for v0.2+
 planning unless a newer ADR says otherwise.
+
+## Token-Efficient Documentation
+
+Future AI sessions should be able to read only the relevant files. Prefer:
+
+- compact bullets over large tables
+- epic-level maps over full cross-product matrices
+- separate user-story files for high-value stories only
+- specs for detailed acceptance criteria and validation

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -48,13 +48,14 @@ Fricon is an S2 medium modular system:
 4. `product/vision.md`
 5. `product/capability-map.md`
 6. `product/story-map.md`
-7. relevant `product/epics/` and `product/user-stories/`
-8. `domain/conceptual-model.md`
-9. `architecture/system-overview.md`
-10. `architecture/module-boundaries.md`
-11. `architecture/compatibility-policy.md`
-12. `ai/project-context.md`
-13. relevant `specs/`
+7. `product/python-sdk-ux.md` for the Python SDK usage guideline
+8. relevant `product/epics/` and `product/user-stories/`
+9. `domain/conceptual-model.md`
+10. `architecture/system-overview.md`
+11. `architecture/module-boundaries.md`
+12. `architecture/compatibility-policy.md`
+13. `ai/project-context.md`
+14. relevant `specs/`
 
 ## Directory Map
 

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -47,12 +47,14 @@ Fricon is an S2 medium modular system:
 3. `decisions/ADR-001-v02-clean-reset-boundary.md`
 4. `product/vision.md`
 5. `product/capability-map.md`
-6. `domain/conceptual-model.md`
-7. `architecture/system-overview.md`
-8. `architecture/module-boundaries.md`
-9. `architecture/compatibility-policy.md`
-10. `ai/project-context.md`
-11. `specs/SPEC-001-data-library-measurement-foundation/`
+6. `product/story-map.md`
+7. relevant `product/epics/` and `product/user-stories/`
+8. `domain/conceptual-model.md`
+9. `architecture/system-overview.md`
+10. `architecture/module-boundaries.md`
+11. `architecture/compatibility-policy.md`
+12. `ai/project-context.md`
+13. relevant `specs/`
 
 ## Directory Map
 

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -30,6 +30,10 @@ The reset keeps useful infrastructure where it fits, but it does not preserve
 v0.1 workspace, storage, API, IPC, or desktop navigation compatibility when
 that compatibility would keep the wrong user model alive.
 
+Product planning in this directory uses MVP, post-MVP priority, and ADR-gated
+labels. Do not treat post-MVP priorities as semantic-version labels; compatible
+features may still ship on the same compatible release line.
+
 ## Scale Classification
 
 Fricon is an S2 medium modular system:

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -64,6 +64,7 @@ docs-next/
   specs/                System-slice specs derived from the baseline
   implementation-plans/ Milestone plans and quality gates
   postmortems/          Prototype lessons and reset rationale
+  research/             Background research process and accepted lessons
   ai/                   Agent context and documentation update policy
   user/                 Future public documentation plan, not current docs
 ```

--- a/docs-next/ai/agent-steering.md
+++ b/docs-next/ai/agent-steering.md
@@ -1,0 +1,37 @@
+# Agent Steering
+
+## Status
+
+Draft.
+
+## Routing Rules
+
+| Task | Start With |
+| --- | --- |
+| Product direction | `product/vision.md`, `product/capability-map.md`, `product/story-map.md` |
+| Domain noun or ownership question | `domain/conceptual-model.md`, `domain/context-map.md` |
+| Storage/API/protocol decision | `architecture/storage-model.md`, `architecture/api-boundaries.md`, ADRs |
+| Compatibility question | `architecture/compatibility-policy.md`, `decisions/ADR-001-v02-clean-reset-boundary.md` |
+| Implementation planning | Relevant `specs/SPEC-###-*` and `implementation-plans/` |
+| Current v0.1 behavior | `dev-docs/current-*.md`, public `docs/`, and code |
+
+## When To Pause And Update Docs
+
+Pause local implementation and update docs when:
+
+- a new domain concept appears
+- a module starts owning a concept outside its boundary
+- storage/API compatibility behavior changes
+- a lifecycle or recovery state is added
+- an AI/calibration/automation feature would mutate data-library state
+- a spec contradicts an accepted ADR
+
+## Review Questions Before Implementation
+
+- Which capability IDs and story IDs does this work support?
+- Which domain concepts does it touch?
+- Which module owns each concept?
+- What data-library, service API, Python SDK, Desktop, CLI, and export effects
+  exist?
+- What compatibility checks or migrations are needed?
+- What validation proves the behavior?

--- a/docs-next/ai/documentation-update-policy.md
+++ b/docs-next/ai/documentation-update-policy.md
@@ -1,0 +1,43 @@
+# Documentation Update Policy
+
+## Status
+
+Accepted.
+
+## Before Implementation
+
+For v0.2+ system work:
+
+- read the relevant product, domain, architecture, and ADR documents
+- confirm the spec status is Accepted or the user explicitly permits Draft work
+- update docs first if implementation would contradict accepted direction
+- record non-goals and compatibility impact in the spec
+
+## During Implementation
+
+Update docs in the same change when:
+
+- a public concept, field, lifecycle state, or capability changes
+- a module boundary changes
+- a compatibility or migration rule changes
+- a validation requirement changes
+
+## After Implementation
+
+Gate D documentation sync requires:
+
+- spec tasks reflect actual status
+- traceability lists affected modules/files at the right granularity
+- public docs are updated if implemented behavior is user-visible
+- architecture docs or ADRs reflect significant deviations
+- stale docs are listed with next actions if immediate update is not possible
+
+## Staleness Policy
+
+Mark stale documents explicitly:
+
+- `Superseded` when replaced by a newer source of truth
+- `Deprecated` when retained for history but not guiding new work
+- `Draft` when exploratory
+
+Do not silently delete old planning material unless the user asks for cleanup.

--- a/docs-next/ai/documentation-update-policy.md
+++ b/docs-next/ai/documentation-update-policy.md
@@ -22,6 +22,10 @@ Update docs in the same change when:
 - a compatibility or migration rule changes
 - a validation requirement changes
 
+Keep docs token-efficient. Avoid large tables and broad duplicated lists. If a
+table starts to grow, split the stable overview from the detailed story, spec,
+or ADR that actually needs the detail.
+
 ## After Implementation
 
 Gate D documentation sync requires:

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -11,9 +11,10 @@ For v0.2+ work, read:
 1. `docs-next/README.md`
 2. `docs-next/decisions/ADR-001-v02-clean-reset-boundary.md`
 3. `docs-next/product/vision.md`
-4. `docs-next/domain/conceptual-model.md`
-5. `docs-next/architecture/module-boundaries.md`
-6. the relevant spec under `docs-next/specs/`
+4. `docs-next/product/python-sdk-ux.md` for the Python SDK usage guideline
+5. `docs-next/domain/conceptual-model.md`
+6. `docs-next/architecture/module-boundaries.md`
+7. the relevant spec under `docs-next/specs/`
 
 Use `dev-docs/` for current implementation details and historical rationale,
 not as the v0.2+ design source of truth.
@@ -21,6 +22,9 @@ not as the v0.2+ design source of truth.
 ## Product Direction
 
 Fricon v0.2+ is a local lab data library for scientific measurement work.
+Its long-term motivation is unified parameter management, measurement-code
+management, SDK runner capture, dataset recording, and provenance in one
+local-first product experience.
 
 Primary user model:
 
@@ -45,6 +49,11 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 ## Good Defaults
 
 - Prefer measurement-scoped dataset writers in public examples.
+- Treat high-impact Python SDK ergonomics as product requirements, not only
+  implementation details.
+- Keep product-level SDK docs focused on usage guidelines and non-binding
+  sketches; exact syntax, capture mechanics, and object models belong in later
+  ADRs/specs.
 - Keep sample/session context optional and correctable.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -1,0 +1,53 @@
+# Project Context For Agents
+
+## Status
+
+Accepted for v0.2+ planning.
+
+## Start Here
+
+For v0.2+ work, read:
+
+1. `docs-next/README.md`
+2. `docs-next/decisions/ADR-001-v02-clean-reset-boundary.md`
+3. `docs-next/product/vision.md`
+4. `docs-next/domain/conceptual-model.md`
+5. `docs-next/architecture/module-boundaries.md`
+6. the relevant spec under `docs-next/specs/`
+
+Use `dev-docs/` for current implementation details and historical rationale,
+not as the v0.2+ design source of truth.
+
+## Product Direction
+
+Fricon v0.2+ is a local lab data library for scientific measurement work.
+
+Primary user model:
+
+```text
+I ran a measurement.
+It produced datasets.
+Fricon helps me inspect, annotate, recover, reopen, and export them.
+```
+
+## Hard Boundaries
+
+- Do not preserve v0.1 compatibility by default.
+- Do not make datasets own measurement, sample, parameter, code, or lifecycle
+  meaning.
+- Do not make Desktop the durable data backend.
+- Do not bypass service compatibility checks for mutating Python APIs.
+- Do not introduce SaaS, accounts, teams, roles, or distributed database
+  behavior for v0.2.
+- Do not implement future runner, device, calibration, or AI mutation systems
+  before their ADRs/specs exist.
+
+## Good Defaults
+
+- Prefer measurement-scoped dataset writers in public examples.
+- Keep sample/session context optional and correctable.
+- Make live views noncritical consumers.
+- Keep code provenance honest: unmanaged means unmanaged.
+- Use events for lifecycle, notes, corrections, and audit history.
+- Use ADRs for storage, service API, export format, and compatibility
+  decisions before durable implementation.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -66,6 +66,8 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 - Keep product-level SDK docs focused on usage guidelines and non-binding
   sketches; exact syntax, capture mechanics, and object models belong in later
   ADRs/specs.
+- For common workflows, provide appropriate simplification, but do not freeze
+  the exact simplification shape before real script/notebook feedback.
 - Keep sample/session context optional and correctable.
 - Do not turn sample target binding into a heavy physical-component ontology
   unless a later product decision requires it. Prefer user-defined parameter

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -21,10 +21,14 @@ not as the v0.2+ design source of truth.
 
 ## Product Direction
 
-Fricon v0.2+ is a local lab data library for scientific measurement work.
+Fricon is a local lab data library for scientific measurement work.
 Its long-term motivation is unified parameter management, measurement-code
 management, SDK runner capture, dataset recording, and provenance in one
 local-first product experience.
+
+Product planning uses MVP, post-MVP priority, and ADR-gated labels. Do not
+interpret post-MVP priorities as semantic-version labels; compatible additions
+may remain on the same compatible release line.
 
 Primary user model:
 
@@ -42,13 +46,15 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 - Do not make Desktop the durable data backend.
 - Do not bypass service compatibility checks for mutating Python APIs.
 - Do not introduce SaaS, accounts, teams, roles, or distributed database
-  behavior for v0.2.
-- Do not implement future runner, device, calibration, or AI mutation systems
+  behavior for the MVP.
+- Do not implement post-MVP runner, device, calibration, or AI mutation systems
   before their ADRs/specs exist.
 
 ## Good Defaults
 
 - Prefer measurement-scoped dataset writers in public examples.
+- Use MVP/post-MVP/ADR-gated for product priority. Do not use `v0.3` or `v0.4`
+  as shorthand for feature horizons.
 - Treat high-impact Python SDK ergonomics as product requirements, not only
   implementation details.
 - Keep product-level SDK docs focused on usage guidelines and non-binding

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -67,6 +67,15 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   sketches; exact syntax, capture mechanics, and object models belong in later
   ADRs/specs.
 - Keep sample/session context optional and correctable.
+- Do not turn sample target binding into a heavy physical-component ontology
+  unless a later product decision requires it. Prefer user-defined parameter
+  row keys plus optional sample-map configs/DSLs.
+- Treat sample visualizers as views over parameter snapshots or snapshot query
+  results. Keep config placement, query syntax, and schema-evolution behavior
+  deferred until a focused spec or ADR.
+- Prioritize post-MVP foundations by user pain: parameter diffs and proposals,
+  run manifests and failure investigation, then reviewed routine replay or
+  automation.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
 - Use events for lifecycle, notes, corrections, and audit history.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -30,6 +30,12 @@ Product planning uses MVP, post-MVP priority, and ADR-gated labels. Do not
 interpret post-MVP priorities as semantic-version labels; compatible additions
 may remain on the same compatible release line.
 
+Post-MVP priority order:
+
+1. Parameter system.
+2. Managed run.
+3. Reviewable automation workflow.
+
 Primary user model:
 
 ```text

--- a/docs-next/architecture/api-boundaries.md
+++ b/docs-next/architecture/api-boundaries.md
@@ -54,8 +54,9 @@ Rules:
 - Sample/session context is a resolved default, not hidden provenance.
 - Low-level datasets may exist, but normal examples are measurement-scoped.
 - Dataset artifacts remain searchable/openable first-class records.
-- Scan schema authoring should have helpers for common 1D/2D/N-D scan and
-  trace shapes, plus raw schema APIs for advanced cases.
+- Scan schema authoring should have Python-native scan plans or helpers for
+  common 1D/2D/N-D scan and trace shapes, plus raw schema APIs for advanced
+  cases.
 - Reads use stable IDs and semantic APIs, not storage paths.
 
 ## Compatibility Negotiation

--- a/docs-next/architecture/api-boundaries.md
+++ b/docs-next/architecture/api-boundaries.md
@@ -25,6 +25,8 @@ Prefer one browser-capable service contract for Desktop, CLI, and Python SDK:
   reads
 - explicit write sessions with create, append, finish, and abort operations
 - server-side summaries, paging, and downsampling for UI reads
+- semantic read shapes for tables, dependent-with-axes views, regular grids,
+  partial grids, irregular/adaptive points, repeated points, and trace data
 
 The current gRPC path is implementation background, not the preferred durable
 v0.2 public Python contract unless an ADR proves otherwise.
@@ -51,6 +53,9 @@ Rules:
 - Measurement creation is explicit but short.
 - Sample/session context is a resolved default, not hidden provenance.
 - Low-level datasets may exist, but normal examples are measurement-scoped.
+- Dataset artifacts remain searchable/openable first-class records.
+- Scan schema authoring should have helpers for common 1D/2D/N-D scan and
+  trace shapes, plus raw schema APIs for advanced cases.
 - Reads use stable IDs and semantic APIs, not storage paths.
 
 ## Compatibility Negotiation

--- a/docs-next/architecture/api-boundaries.md
+++ b/docs-next/architecture/api-boundaries.md
@@ -1,0 +1,68 @@
+# API Boundaries
+
+## Status
+
+Draft.
+
+## Public Surfaces
+
+| Surface | Purpose | v0.2 Stability Posture |
+| --- | --- | --- |
+| Fricon Desktop | Primary GUI for local measurement console, browsing, diagnostics, export. | Product surface, but UI can change during v0.x. |
+| Python SDK | Primary acquisition and analysis API. | Ergonomic but not strict pre-1.0 API stability. Fail before writes on incompatibility. |
+| CLI | Setup, diagnostics, service control, developer workflows. | Narrow public surface. |
+| Export Bundle Reader | Read-only offline analysis. | Format versioned from first implementation. |
+| Local Service API | Shared client/service contract. | Internal Fricon contract first; no third-party long-term stability promise in v0.2. |
+
+## Service Contract Direction
+
+Prefer one browser-capable service contract for Desktop, CLI, and Python SDK:
+
+- JSON HTTP for metadata, control, compatibility negotiation, diagnostics, and
+  ordinary mutations
+- WebSocket or SSE for live measurement, dataset, and service status events
+- binary Arrow IPC or Arrow-compatible chunk endpoints for dataset writes and
+  reads
+- explicit write sessions with create, append, finish, and abort operations
+- server-side summaries, paging, and downsampling for UI reads
+
+The current gRPC path is implementation background, not the preferred durable
+v0.2 public Python contract unless an ADR proves otherwise.
+
+## Python API Direction
+
+Draft shape:
+
+```python
+lib = fricon.library()
+lib.use_context(sample="qpu-017", session="cooldown-2026-05")
+
+with lib.measurement("rabi q3") as meas:
+    rabi = meas.dataset(
+        "rabi",
+        scan={"independent": "amp", "dependent": "signal"},
+    )
+    rabi.write(amp=0.1, signal=0.25)
+```
+
+Rules:
+
+- `fricon.library()` returns a reusable handle.
+- Measurement creation is explicit but short.
+- Sample/session context is a resolved default, not hidden provenance.
+- Low-level datasets may exist, but normal examples are measurement-scoped.
+- Reads use stable IDs and semantic APIs, not storage paths.
+
+## Compatibility Negotiation
+
+Before writes, clients and service negotiate:
+
+- service API/protocol version
+- data-library format version
+- client capabilities
+- write capability
+- measurement creation capability
+- export/migration capability where relevant
+
+Read-only operations may be allowed during limited mismatches if explicitly
+safe.

--- a/docs-next/architecture/compatibility-policy.md
+++ b/docs-next/architecture/compatibility-policy.md
@@ -1,0 +1,77 @@
+# Compatibility Policy
+
+## Status
+
+Accepted reset policy, draft implementation details.
+
+## Policy Summary
+
+v0.2 is a clean reset from pre-v0.2 workspace/dataset-first compatibility.
+
+Do not preserve v0.1 public APIs, workspace layout, IPC contracts, desktop
+navigation, or archive formats when they conflict with the v0.2 data-library
+and measurement-centered model.
+
+## Pre-v0.2 Compatibility
+
+Pre-v0.2 local workspaces are prototype/test data unless a later ADR names a
+specific migration target.
+
+Default policy:
+
+- no requirement to open old workspaces in v0.2
+- no requirement to migrate v0.1 dataset catalogs automatically
+- no requirement to maintain old Python workspace/dataset APIs
+- no requirement to preserve current gRPC/protobuf contracts
+- reusable implementation ideas may be adapted without compatibility promises
+
+If a real legacy migration need appears, create a focused ADR that defines:
+
+- supported source versions
+- migration or import route
+- data loss and unsupported cases
+- validation and recovery checks
+
+## v0.2+ Data Durability Promise
+
+Once v0.2 records real lab data, Fricon must protect recorded data.
+
+The promise is:
+
+- explicit data-library format versioning
+- explicit migrations or recovery paths
+- backup/checkpoint before risky migrations where practical
+- fail-before-write diagnostics for incompatible clients
+- clear user guidance about what to update or migrate
+- readable/exportable data whenever practical, even if mutating APIs change
+
+The promise is not:
+
+- strict v0.x Python API stability
+- strict third-party protocol stability
+- support for direct shared-folder multi-machine database access
+- silent migration during app launch or active measurement
+
+## Compatibility Dimensions
+
+| Dimension | Gate |
+| --- | --- |
+| Data-library format | Storage format version and migration state. |
+| Service API | API/protocol version and capability negotiation. |
+| Python SDK | Required capability checks before writes. |
+| Desktop/CLI | Bundled with compatible service for normal local flow. |
+| Export bundle | Format version and reader compatibility. |
+| Feature support | Capability flags for optional or future features. |
+
+## Update Safety
+
+Updates and migrations must account for:
+
+- active measurements
+- open dataset writers
+- imports/exports
+- data-library migrations or repairs
+- future managed tasks and resource leases
+
+When busy, Fricon should offer "install when idle" or "remind later" rather
+than silently stopping the measurement environment.

--- a/docs-next/architecture/data-flow.md
+++ b/docs-next/architecture/data-flow.md
@@ -19,6 +19,9 @@ Python script
   -> service finalizes datasets and lifecycle events
 ```
 
+Dataset artifacts remain directly searchable and openable after this flow. The
+measurement is the primary navigation context, not the only durable handle.
+
 ## Live Read Flow
 
 ```text
@@ -45,6 +48,10 @@ Python SDK
   -> list produced DatasetArtifacts
   -> request semantic table, dependent-with-axes, or grid-like view
 ```
+
+Semantic reads must distinguish complete regular grids from partial grids,
+irregular/adaptive points, repeated points, and trace data where the scan schema
+declares those modes.
 
 ## Export Flow
 

--- a/docs-next/architecture/data-flow.md
+++ b/docs-next/architecture/data-flow.md
@@ -1,0 +1,69 @@
+# Data Flow
+
+## Status
+
+Draft.
+
+## Measurement Write Flow
+
+```text
+Python script
+  -> Python SDK creates Measurement
+  -> local service checks client/service/data-library compatibility
+  -> service records Measurement and optional context/provenance
+  -> SDK declares DatasetArtifact writer with scan schema
+  -> SDK appends Arrow-compatible payload chunks
+  -> service persists facts and emits live events
+  -> Desktop subscribes and renders nonblocking previews
+  -> SDK finishes Measurement
+  -> service finalizes datasets and lifecycle events
+```
+
+## Live Read Flow
+
+```text
+Desktop live console
+  -> subscribe to service events
+  -> receive measurement and dataset summaries
+  -> request paged/downsampled semantic reads
+  -> render table/chart views
+```
+
+Rules:
+
+- Live readers use explicit append positions or event sequence IDs.
+- Preview updates may be coalesced or dropped under load.
+- Committed data is never dropped.
+- Rendering errors do not fail acquisition writes.
+
+## Python Reopen Flow
+
+```text
+Python SDK
+  -> connect/discover local service
+  -> get Measurement by stable ID/search result
+  -> list produced DatasetArtifacts
+  -> request semantic table, dependent-with-axes, or grid-like view
+```
+
+## Export Flow
+
+```text
+User selects Measurement
+  -> service validates idle/read-safe state
+  -> export writer gathers selected metadata and artifacts
+  -> privacy preview handles sensitive provenance
+  -> bundle manifest/checksums/common files are written
+  -> Python or Desktop opens bundle read-only without importing
+```
+
+## Migration/Update Flow
+
+```text
+update or data-library format change
+  -> client asks service for safe_to_update / safe_to_migrate
+  -> service reports blockers
+  -> if idle: create checkpoint where practical
+  -> run migration
+  -> report success or recovery guidance
+```

--- a/docs-next/architecture/module-boundaries.md
+++ b/docs-next/architecture/module-boundaries.md
@@ -1,0 +1,51 @@
+# Module Boundaries
+
+## Status
+
+Draft.
+
+## Target Feature Slices
+
+| Slice | Owns | Does Not Own |
+| --- | --- | --- |
+| `data_library` | Library identity, opening, compatibility, checkpoints, backup/restore. | Measurement lifecycle or dataset payload semantics. |
+| `measurement` | Measurement records, lifecycle, produced artifact links, notes/events, sample/session links. | Dataset facts, chart projection, global parameter profile mutation. |
+| `dataset_artifact` | Artifact identity, append sessions, Arrow-compatible facts, variable roles, scan schema, semantic reads. | Measurement intent, sample identity, code provenance. |
+| `sample_context` | Samples, sessions, active context, correction history. | Measurement execution or dataset facts. |
+| `provenance` | Parameter snapshots, code provenance summaries, actor/event records. | Managed runner internals until ADR-gated. |
+| `export` | Measurement-centered bundle writing/reading, manifest, checksums, privacy preview. | Source data-library mutation after export. |
+| `service_api` | HTTP/control API, live events, binary payload endpoints, capability negotiation. | Domain decisions hidden in transport DTOs. |
+| `desktop_console` | Measurement console and live/history interaction model. | Durable storage or business orchestration. |
+| `python_sdk` | User-facing Python ergonomics and diagnostics. | Bypassing service compatibility for writes. |
+
+## Dependency Direction
+
+```text
+composition/app
+  -> services + adapters
+services
+  -> domain types + feature-defined ports
+adapters
+  -> domain types + database/filesystem/transport/runtime
+```
+
+## Boundary Rules
+
+- Core/service code must not import Diesel schema modules directly.
+- Transport handlers parse transport shape, call services, and map errors.
+- Feature events are separate from UI shell commands and transport event DTOs.
+- Frontend feature code should remain browser-capable where practical.
+- Tauri-specific file dialogs, launch behavior, updater, diagnostics, and
+  shell integration stay behind shell adapters.
+- Add traits only for real boundaries or multiple plausible implementations.
+
+## Current-to-Target Mapping
+
+| Current Area | v0.2 Treatment |
+| --- | --- |
+| `crates/fricon/src/workspace.rs` | Replace user-facing workspace with data library. Reuse only low-level patterns that fit. |
+| `crates/fricon/src/dataset/**` | Split into dataset artifact facts, semantics, live append, and artifact boundary. |
+| `crates/fricon/src/transport/**` | Treat gRPC/IPC as migration background; design one service API contract by ADR. |
+| `crates/fricon-py/**` | Redesign public API around `fricon.library()` and measurement-scoped writes. |
+| `crates/fricon-ui/frontend/src/features/datasets/**` | Move first-screen UX toward measurement console; keep chart code where model-compatible. |
+| `crates/fricon-ui/src/features/**` | Keep vertical slice discipline; replace dataset-first Tauri command assumptions. |

--- a/docs-next/architecture/risks.md
+++ b/docs-next/architecture/risks.md
@@ -18,3 +18,8 @@ Draft.
 | RISK-008 | Old docs continue to guide agents. | Reintroduced v0.1 assumptions. | Route v0.2+ agents through `docs-next/ai/project-context.md`. |
 | RISK-009 | Export scope becomes an archive/import system too early. | Delays core measurement loop. | Start with measurement-centered read-only analysis bundle. |
 | RISK-010 | AI automation mutates state before audit model exists. | Trust and data integrity risk. | Keep AI read/suggest-only until reviewed mutation ADRs exist. |
+| RISK-011 | Measurement-first UI hides dataset artifacts. | Analysis/import/export workflows become awkward. | Keep datasets searchable and directly openable with stable handles. |
+| RISK-012 | Scan schema is too rectangular. | Adaptive scans, partial grids, repeated points, and traces do not fit. | Accept explicit scan shape modes before implementation. |
+| RISK-013 | Partial recovery is only a status label. | Users cannot analyze interrupted runs reliably. | Expose readable partial/missing-point semantics before resumable execution. |
+| RISK-014 | Raw schema is too verbose. | Python users avoid Fricon for quick scans. | Provide common scan/trace helpers plus raw schema escape hatch. |
+| RISK-015 | Streams leak into the v0.2 concept budget. | Users face Bluesky-like complexity too early. | Allow internal streams only behind dataset artifact APIs. |

--- a/docs-next/architecture/risks.md
+++ b/docs-next/architecture/risks.md
@@ -21,5 +21,5 @@ Draft.
 | RISK-011 | Measurement-first UI hides dataset artifacts. | Analysis/import/export workflows become awkward. | Keep datasets searchable and directly openable with stable handles. |
 | RISK-012 | Scan schema is too rectangular. | Adaptive scans, partial grids, repeated points, and traces do not fit. | Accept explicit scan shape modes before implementation. |
 | RISK-013 | Partial recovery is only a status label. | Users cannot analyze interrupted runs reliably. | Expose readable partial/missing-point semantics before resumable execution. |
-| RISK-014 | Raw schema is too verbose. | Python users avoid Fricon for quick scans. | Provide common scan/trace helpers plus raw schema escape hatch. |
+| RISK-014 | Raw schema is too verbose. | Python users avoid Fricon for quick scans. | Provide Python-native scan plans/helpers plus raw schema escape hatch. |
 | RISK-015 | Streams leak into the v0.2 concept budget. | Users face Bluesky-like complexity too early. | Allow internal streams only behind dataset artifact APIs. |

--- a/docs-next/architecture/risks.md
+++ b/docs-next/architecture/risks.md
@@ -1,0 +1,20 @@
+# Architecture Risks
+
+## Status
+
+Draft.
+
+## Risk Register
+
+| ID | Risk | Impact | Mitigation |
+| --- | --- | --- | --- |
+| RISK-001 | v0.2 grows into too many future concepts before measurement works. | Bloated model and slow delivery. | Keep first slice to data library, measurement, dataset artifacts, optional context, lifecycle, export. |
+| RISK-002 | Dataset metadata absorbs measurement/sample/provenance meaning again. | Confusing ownership and hard migrations. | Enforce context map and module boundaries. |
+| RISK-003 | Python SDK ergonomics suffer from too much schema ceremony. | Users stay with old logger. | Keep measurement creation short; require scan schema only for plotted data. |
+| RISK-004 | Live views slow acquisition writes. | Measurement reliability failure. | Make live views noncritical consumers with bounded queues/coalescing. |
+| RISK-005 | Compatibility checks are delayed until after writes. | Corrupted or partial data. | Build client/service/library negotiation early. |
+| RISK-006 | Desktop remains dataset-first. | Product fails to become measurement-centered. | Make measurement console the first Desktop workflow. |
+| RISK-007 | Reset discards reusable infrastructure unnecessarily. | Slower implementation. | Treat reset as domain reset, not total rewrite. |
+| RISK-008 | Old docs continue to guide agents. | Reintroduced v0.1 assumptions. | Route v0.2+ agents through `docs-next/ai/project-context.md`. |
+| RISK-009 | Export scope becomes an archive/import system too early. | Delays core measurement loop. | Start with measurement-centered read-only analysis bundle. |
+| RISK-010 | AI automation mutates state before audit model exists. | Trust and data integrity risk. | Keep AI read/suggest-only until reviewed mutation ADRs exist. |

--- a/docs-next/architecture/storage-model.md
+++ b/docs-next/architecture/storage-model.md
@@ -1,0 +1,67 @@
+# Storage Model
+
+## Status
+
+Draft. Requires ADRs before implementation.
+
+## First-Slice Records
+
+```text
+DataLibrary
+  Sample
+  SampleSession
+  Measurement
+  DatasetArtifact
+  AttachmentArtifact
+  ParameterSnapshot
+  CodeProvenanceSummary
+  Event/AuditRecord
+  OperatorProfile
+```
+
+## Storage Responsibilities
+
+| Area | Responsibility |
+| --- | --- |
+| Catalog | Stable record IDs, display names, timestamps, lifecycle state, links. |
+| Dataset payloads | Arrow-compatible chunked facts and append positions. |
+| Dataset semantics | Variable roles, labels, units, scan axes, dependencies, duplicate policy, display hints. |
+| Events | Measurement lifecycle, notes, corrections, export/recovery/system actions. |
+| Checkpoints | Backup/restore and migration safety. |
+| Export manifests | Portable read-only package identity, checksums, selected metadata. |
+
+## Compatibility Policy Hooks
+
+Storage must expose:
+
+- data-library format version
+- feature/capability flags where needed
+- migration state and last successful checkpoint
+- active writer/import/export/migration blockers
+- enough metadata for clients to fail before writes
+
+## v0.1 Reuse Candidates
+
+- Arrow IPC chunk concepts
+- append-only record IDs
+- semantic manifest validation ideas
+- logical-index sidecars if they fit the v0.2 scan schema model
+- dataset archive checksum and manifest concepts
+
+## v0.1 Redesign Candidates
+
+- `.fricon_workspace.json` as user-facing root identity
+- dataset-only SQLite catalog
+- dataset-local ownership of favorite/status/tag meaning that belongs to
+  measurement or sample/session context
+- archive/import/export formats that cannot carry data-library and
+  measurement-centered provenance
+
+## ADRs Needed
+
+- data-library layout and migration policy
+- measurement table versus generic activity-run table
+- dataset artifact storage for fixed arrays and variable-length traces
+- event/audit record schema
+- export bundle format
+- local actor/token storage

--- a/docs-next/architecture/storage-model.md
+++ b/docs-next/architecture/storage-model.md
@@ -15,6 +15,8 @@ DataLibrary
   AttachmentArtifact
   ParameterSnapshot
   CodeProvenanceSummary
+  SetupProvenanceSummary
+  ProcedureSummary
   Event/AuditRecord
   OperatorProfile
 ```
@@ -26,7 +28,10 @@ DataLibrary
 | Catalog | Stable record IDs, display names, timestamps, lifecycle state, links. |
 | Dataset payloads | Arrow-compatible chunked facts and append positions. |
 | Dataset semantics | Variable roles, labels, units, scan axes, dependencies, duplicate policy, display hints. |
+| Scan shape semantics | Regular grid, partial grid, irregular/adaptive points, repeated points, fixed arrays, and variable-length traces. |
+| Internal payload grouping | Optional internal stream-like groups for storage/export/read APIs without making streams a normal user concept. |
 | Events | Measurement lifecycle, notes, corrections, export/recovery/system actions. |
+| Provenance summaries | Code provenance, passive setup/device/environment summaries, passive procedure summaries, and optional parameter snapshots. |
 | Checkpoints | Backup/restore and migration safety. |
 | Export manifests | Portable read-only package identity, checksums, selected metadata. |
 
@@ -62,6 +67,9 @@ Storage must expose:
 - data-library layout and migration policy
 - measurement table versus generic activity-run table
 - dataset artifact storage for fixed arrays and variable-length traces
+- scan shape and partial-read semantics
+- internal stream/subpayload representation, if needed
+- external asset/reference hooks for future detector files and images
 - event/audit record schema
 - export bundle format
 - local actor/token storage

--- a/docs-next/architecture/system-overview.md
+++ b/docs-next/architecture/system-overview.md
@@ -1,0 +1,63 @@
+# System Overview
+
+## Status
+
+Draft v0.2+ architecture baseline.
+
+## C4: System Context
+
+```text
+Experimentalist / Analyst / Lab Maintainer
+  -> Fricon Desktop
+  -> fricon Python SDK
+  -> fricon CLI
+
+Fricon Desktop / Python SDK / CLI
+  -> local Fricon service
+  -> one local Fricon data library
+```
+
+## Target Containers
+
+| Container | Responsibility | Notes |
+| --- | --- | --- |
+| Fricon Desktop | Local GUI, measurement console, live/history views, setup, diagnostics, export/offline viewer shell. | Tauri shell plus browser-capable React app. |
+| Python SDK | Measurement creation, dataset writes, reopen, export reads, service discovery diagnostics. | First-class acquisition surface. |
+| CLI | Setup, diagnostics, service control, developer workflows. | Not the broad ordinary-user workflow surface. |
+| Local Service | Compatibility gate, data-library coordination, catalog, writes, live events, export, migration. | Authoritative data backend. |
+| Data Library Storage | SQLite/catalog, artifact payloads, manifests, events, checkpoints. | Local only in v0.2. |
+
+## Key Architecture Decisions To Preserve
+
+- The local service owns coordinated data-library mutations.
+- Desktop may launch or supervise the service but does not own durable data.
+- Python, Desktop, and CLI converge on one service API compatibility boundary.
+- Dataset payload transfer uses binary Arrow-compatible chunks where practical,
+  not row-by-row JSON.
+- Live views are noncritical consumers and must not block acquisition writes.
+- The reset is a domain-model reset, not a mandatory rewrite of every reusable
+  infrastructure component.
+
+## Current Implementation Relationship
+
+Current v0.1 modules are implementation source material, not v0.2 boundaries.
+
+Reusable or adaptable:
+
+- Rust/Python/frontend build infrastructure
+- Arrow payload IO concepts
+- append-only dataset writer/read path concepts
+- record IDs and semantic manifest ideas
+- chart rendering after DTO/model changes
+- Tauri packaging and frontend stack
+- testing and release infrastructure
+
+High redesign risk:
+
+- workspace mental model
+- dataset catalog schema and metadata ownership
+- Python dataset creation API
+- desktop dataset-first navigation
+- IPC/protobuf public contract assumptions
+- archive/import/export formats
+- setup/update/service compatibility assumptions

--- a/docs-next/architecture/system-overview.md
+++ b/docs-next/architecture/system-overview.md
@@ -34,6 +34,8 @@ Fricon Desktop / Python SDK / CLI
 - Python, Desktop, and CLI converge on one service API compatibility boundary.
 - Dataset payload transfer uses binary Arrow-compatible chunks where practical,
   not row-by-row JSON.
+- Measurement-first UI does not remove first-class dataset artifact discovery
+  and direct open flows.
 - Live views are noncritical consumers and must not block acquisition writes.
 - The reset is a domain-model reset, not a mandatory rewrite of every reusable
   infrastructure component.

--- a/docs-next/decisions/ADR-000-template.md
+++ b/docs-next/decisions/ADR-000-template.md
@@ -1,0 +1,27 @@
+# ADR-000: Template
+
+## Status
+
+Template.
+
+## Context
+
+What problem or decision pressure exists?
+
+## Decision
+
+What is the decision?
+
+## Consequences
+
+What becomes easier, harder, required, or forbidden?
+
+## Alternatives Considered
+
+- Alternative A
+- Alternative B
+
+## Revisit Triggers
+
+- Trigger 1
+- Trigger 2

--- a/docs-next/decisions/ADR-001-v02-clean-reset-boundary.md
+++ b/docs-next/decisions/ADR-001-v02-clean-reset-boundary.md
@@ -1,0 +1,59 @@
+# ADR-001: v0.2 Clean Reset Boundary
+
+## Status
+
+Accepted.
+
+## Context
+
+Fricon v0.1 is a useful prototype, but its user-facing model is
+workspace/dataset-first. The desired v0.2+ product model is a local lab data
+library centered on measurements, dataset artifacts, optional sample/session
+context, lifecycle history, provenance, and export.
+
+The old `dev-docs/` area also mixed current implementation notes, historical
+proposal inputs, AI-agent process guidance, and new v0.2 design direction. That
+made it too easy for future work to preserve v0.1 assumptions accidentally.
+
+## Decision
+
+v0.2 will be designed as a clean reset. It may break pre-v0.2:
+
+- workspace/storage layout
+- public Python workspace/dataset APIs
+- IPC/gRPC/protobuf assumptions
+- desktop dataset-first navigation
+- archive/import/export formats
+- setup/update/service compatibility assumptions
+
+Compatibility with old local test workspaces is not a design constraint unless
+a later ADR defines a narrow migration/import route.
+
+Useful infrastructure may be reused or adapted, but compatibility must not keep
+the wrong user model alive.
+
+## Consequences
+
+- `docs-next/` becomes the v0.2+ design baseline.
+- `dev-docs/` remains useful for current implementation facts and historical
+  rationale, not as the v0.2 source of truth.
+- Early implementation work should prefer replacing current domain boundaries
+  in place over building a permanent parallel `fricon-v2` project.
+- The first v0.2 implementation must still protect data created by v0.2 once
+  real lab data exists.
+
+## Alternatives Considered
+
+- Preserve v0.1 workspace compatibility while adding measurement records. This
+  would reduce short-term breakage but preserve the old organizing model.
+- Fork a separate v2 project. This would isolate experimentation but duplicate
+  build, packaging, testing, and release infrastructure.
+- Keep all planning under `dev-docs/v0.2`. This would continue the current
+  confusion between historical proposals and accepted v0.2+ baseline.
+
+## Revisit Triggers
+
+- Real pre-v0.2 user data appears and needs a migration path.
+- A reusable v0.1 component cannot be adapted without preserving old public
+  semantics.
+- The project adopts a stable post-v0.x compatibility promise.

--- a/docs-next/decisions/ADR-002-documentation-governance.md
+++ b/docs-next/decisions/ADR-002-documentation-governance.md
@@ -1,0 +1,65 @@
+# ADR-002: Documentation Governance For v0.2+
+
+## Status
+
+Accepted.
+
+## Context
+
+Fricon is an architecture-sensitive system with Rust core/service code, Python
+bindings, CLI, desktop UI, local storage, protocol boundaries, and future
+automation surfaces. Feature-local specs alone are not enough to preserve the
+domain model.
+
+## Decision
+
+Use `docs-next/` as the v0.2+ documentation baseline with these artifact
+classes:
+
+- product: vision, personas, capability map, story map, glossary, traceability
+- domain: conceptual model, context map, lifecycle, invariants
+- architecture: overview, module boundaries, data flow, API/storage,
+  compatibility, risks
+- decisions: ADRs for durable decisions
+- specs: system-slice specs derived from the global baseline
+- implementation plans: milestone execution and quality gates
+- postmortems: reset lessons
+- ai: project context, steering, and doc update policy
+- user: future public documentation plan
+
+Documents use explicit status values: Draft, Proposed, Accepted,
+Implementing, Implemented, Superseded, Deprecated.
+
+Important IDs are stable:
+
+- CAP-### for capabilities
+- US-### for user stories
+- SPEC-### for specs
+- REQ-### inside specs
+- ADR-### for decisions
+- M# for milestones
+
+## Consequences
+
+- Do not implement major v0.2 features from chat history or archived proposals
+  alone.
+- New domain vocabulary must update domain docs before or with implementation.
+- Specs must trace to capabilities, stories, domain concepts, architecture
+  docs, ADRs, modules, tests, compatibility, and non-goals.
+- Old documents are not deleted by default; supersede or deprecate them with
+  status and links.
+
+## Alternatives Considered
+
+- Keep only a roadmap and issue list. This is too weak for cross-module
+  semantics.
+- Put all design detail in ADRs. ADRs are good for decisions but poor as the
+  full product/domain model.
+- Put all design detail in implementation specs. Specs become too local and
+  make global concepts hard to find.
+
+## Revisit Triggers
+
+- The documentation baseline becomes too large to maintain.
+- The project moves from v0.x exploration to stable long-term compatibility.
+- A new contributor workflow proves that the reading order is inefficient.

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -1,0 +1,69 @@
+# Conceptual Model
+
+## Status
+
+Draft.
+
+## First v0.2 Model
+
+```text
+DataLibrary
+  contains records:
+    Sample
+    SampleSession
+    Measurement
+    DatasetArtifact
+    AttachmentArtifact
+    ParameterSnapshot
+    CodeProvenanceSummary
+    Event/AuditRecord
+    OperatorProfile
+
+  links:
+    SampleSession -> Sample
+    Measurement -> optional SampleSession
+    Measurement -> produces -> DatasetArtifact | AttachmentArtifact
+    Measurement -> optional ParameterSnapshot
+    Measurement -> optional CodeProvenanceSummary
+    Event/AuditRecord -> subject record
+    Event/AuditRecord -> optional OperatorProfile or service actor
+```
+
+## Concept Ownership
+
+| Concept | Owns | Must Not Own |
+| --- | --- | --- |
+| DataLibrary | Library identity, format version, catalog root, remembered local configuration. | Measurement code source as editable code repository, multi-user organization. |
+| Sample | Physical object identity, aliases, custom fields, long-lived notes, lifecycle. | Measurement lifecycle, dataset facts. |
+| SampleSession | Cooldown/mount/probing/campaign context for a sample. | New physical sample identity unless the object changed. |
+| Measurement | Data-taking intent, lifecycle, context links, produced artifacts, notes, favorites, parameter/code links. | Dataset payload facts, global parameter profile mutation, device communication. |
+| DatasetArtifact | Typed table facts, append state, scan schema, variable roles, dataset-local display hints. | Sample identity, measurement notes, code provenance, calibration decisions. |
+| AttachmentArtifact | Light measurement files, images, or logs. | Full artifact management or row-linked large binary storage before an ADR. |
+| ParameterSnapshot | Immutable run facts. | Mutable profile management or calibration promotion. |
+| CodeProvenanceSummary | Provenance level and display summary. | Automatic reproducibility claims for unmanaged code. |
+| Event/AuditRecord | Lifecycle events, notes, corrections, actor labels, system actions. | Fine-grained permission enforcement. |
+
+## Reserved Future Model
+
+```text
+DataLibrary
+  records:
+    ActivityRun(kind: measurement | analysis | import | simulation | calibration)
+    Artifact(kind: dataset | result | report | log | attachment | parameter_proposal | device_snapshot)
+    ParameterProfile
+    ParameterSnapshot
+    CodeSnapshot
+    ScriptRun
+    DeviceIdentity
+    DeviceSnapshot
+    Event/AuditRecord
+
+  links:
+    ActivityRun -> consumes -> Artifact | ParameterSnapshot | ActivityRun
+    ActivityRun -> produces -> Artifact
+    ScriptRun -> optional CodeSnapshot
+    Calibration -> coordinates -> Measurement + Analysis + ParameterProposal
+```
+
+`ActivityRun` is an internal modeling pattern. Users should see concrete words:
+Measurement, Analysis, Import, Simulation, and Calibration.

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -16,6 +16,8 @@ DataLibrary
     AttachmentArtifact
     ParameterSnapshot
     CodeProvenanceSummary
+    SetupProvenanceSummary
+    ProcedureSummary
     Event/AuditRecord
     OperatorProfile
 
@@ -25,6 +27,8 @@ DataLibrary
     Measurement -> produces -> DatasetArtifact | AttachmentArtifact
     Measurement -> optional ParameterSnapshot
     Measurement -> optional CodeProvenanceSummary
+    Measurement -> optional SetupProvenanceSummary
+    Measurement -> optional ProcedureSummary
     Event/AuditRecord -> subject record
     Event/AuditRecord -> optional OperatorProfile or service actor
 ```
@@ -41,7 +45,32 @@ DataLibrary
 | AttachmentArtifact | Light measurement files, images, or logs. | Full artifact management or row-linked large binary storage before an ADR. |
 | ParameterSnapshot | Immutable run facts. | Mutable profile management or calibration promotion. |
 | CodeProvenanceSummary | Provenance level and display summary. | Automatic reproducibility claims for unmanaged code. |
+| SetupProvenanceSummary | Passive setup, device, driver, environment, method, or clock facts supplied by the user or integration. | Device control, resource locking, readback enforcement, or reproducibility claims. |
+| ProcedureSummary | Passive summary of unmanaged script, external runner, or declared plan context. | Managed execution, scan-point checkpointing, task scheduling, or device/resource ownership. |
 | Event/AuditRecord | Lifecycle events, notes, corrections, actor labels, system actions. | Fine-grained permission enforcement. |
+
+## Dataset Artifact Shape
+
+`DatasetArtifact` remains first-class. It is produced by a measurement in the
+normal path, but it can also be imported, derived by future analysis, or opened
+directly from Python/Desktop.
+
+v0.2 should optimize for scan and trace facts:
+
+- regular grids
+- partial grids with missing expected points
+- irregular or adaptive point clouds
+- repeated points with declared duplicate/display policy
+- fixed-shape arrays or traces
+- variable-length traces with their own coordinate values and settings
+
+Large detector files, images, and external binary assets are ADR-gated. The
+model should reserve artifact/reference hooks without making them the first
+v0.2 storage problem.
+
+A dataset artifact is one user-facing artifact. Storage, export, or read APIs
+may model internal stream-like groups when needed, but streams should not become
+a normal v0.2 user-facing concept.
 
 ## Reserved Future Model
 

--- a/docs-next/domain/context-map.md
+++ b/docs-next/domain/context-map.md
@@ -12,7 +12,7 @@ Draft.
 | Measurement | Data-taking records, lifecycle, annotations, produced artifacts, context links. | Measurement, lifecycle, note, marker, event. | Uses Sample, DatasetArtifact, ParameterSnapshot, CodeProvenanceSummary. |
 | Dataset Artifact | Table facts, schema, scan semantics, projections, live append state. | DatasetArtifact, variable, role, scan schema, projection. | Produced by Measurement; read by Desktop, Python, Export, Analysis later. |
 | Sample Context | Samples, sample sessions, active context, corrections. | Sample, SampleSession, active context. | Used by Measurement and views. |
-| Provenance | Code provenance, parameter snapshot, actor/event records. | CodeProvenanceSummary, ParameterSnapshot, Actor, Event. | Linked by Measurement; extended by future runner/calibration. |
+| Provenance | Code provenance, setup summaries, procedure summaries, parameter snapshot, actor/event records. | CodeProvenanceSummary, SetupProvenanceSummary, ProcedureSummary, ParameterSnapshot, Actor, Event. | Linked by Measurement; extended by future runner/calibration. |
 | Service/API | Client compatibility, mutations, events, binary payload transfer. | Service API, capability, write session, event stream. | Exposes domain contexts to Desktop, Python SDK, CLI. |
 | Desktop Experience | Measurement console, live views, sample/session UX, diagnostics. | Console, live list, detail, detached view. | Downstream of Service/API. |
 | Python SDK | Measurement creation, dataset writes, reopen, export reads. | Library handle, Measurement handle, Dataset writer. | Downstream of Service/API. |
@@ -22,6 +22,8 @@ Draft.
 
 - Dataset metadata may display measurement or sample context but must not own
   it.
+- Dataset artifacts remain directly searchable and openable; measurement-first
+  navigation must not make datasets invisible implementation details.
 - Desktop UI state must not become the durable data backend.
 - Python SDK convenience APIs must not bypass service compatibility checks for
   mutating operations.
@@ -29,3 +31,7 @@ Draft.
   must not imply shared identity with the source data library.
 - Future AI, calibration, or automation actions must enter through audited
   domain mutations, not direct storage edits.
+- Passive setup summaries describe context only. Device control and resource
+  ownership belong to later ADR-gated device or runner contexts.
+- Passive procedure summaries describe what was intended or invoked. They do
+  not imply managed execution, resume support, or runner ownership.

--- a/docs-next/domain/context-map.md
+++ b/docs-next/domain/context-map.md
@@ -1,0 +1,31 @@
+# Context Map
+
+## Status
+
+Draft.
+
+## Bounded Contexts
+
+| Context | Responsibility | Primary Terms | Upstream/Downstream |
+| --- | --- | --- | --- |
+| Data Library | Local root, identity, catalog, compatibility, backup/restore. | DataLibrary, format version, checkpoint. | Upstream to all data contexts. |
+| Measurement | Data-taking records, lifecycle, annotations, produced artifacts, context links. | Measurement, lifecycle, note, marker, event. | Uses Sample, DatasetArtifact, ParameterSnapshot, CodeProvenanceSummary. |
+| Dataset Artifact | Table facts, schema, scan semantics, projections, live append state. | DatasetArtifact, variable, role, scan schema, projection. | Produced by Measurement; read by Desktop, Python, Export, Analysis later. |
+| Sample Context | Samples, sample sessions, active context, corrections. | Sample, SampleSession, active context. | Used by Measurement and views. |
+| Provenance | Code provenance, parameter snapshot, actor/event records. | CodeProvenanceSummary, ParameterSnapshot, Actor, Event. | Linked by Measurement; extended by future runner/calibration. |
+| Service/API | Client compatibility, mutations, events, binary payload transfer. | Service API, capability, write session, event stream. | Exposes domain contexts to Desktop, Python SDK, CLI. |
+| Desktop Experience | Measurement console, live views, sample/session UX, diagnostics. | Console, live list, detail, detached view. | Downstream of Service/API. |
+| Python SDK | Measurement creation, dataset writes, reopen, export reads. | Library handle, Measurement handle, Dataset writer. | Downstream of Service/API. |
+| Export | Measurement-centered portable bundles. | ExportBundle, manifest, checksum, offline reader. | Downstream of Measurement and Dataset Artifact. |
+
+## Anti-Corruption Rules
+
+- Dataset metadata may display measurement or sample context but must not own
+  it.
+- Desktop UI state must not become the durable data backend.
+- Python SDK convenience APIs must not bypass service compatibility checks for
+  mutating operations.
+- Export bundles carry copies for portability; importing or reading an export
+  must not imply shared identity with the source data library.
+- Future AI, calibration, or automation actions must enter through audited
+  domain mutations, not direct storage edits.

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -1,0 +1,50 @@
+# Domain Invariants
+
+## Status
+
+Draft.
+
+## Data Library
+
+- A data library has a generated durable UUID.
+- A data library has a storage/format compatibility version.
+- Mutating clients must pass compatibility checks before writes.
+- The active editable data library is local to the owning machine/service.
+- Direct multi-machine shared-folder access to one database-backed data library
+  is not supported.
+
+## Measurement
+
+- Measurement identity is stable and independent of display title.
+- Measurement display identity prioritizes title/name, start time, and
+  sample/session label when available.
+- Measurement sample/session links are optional and correctable with history.
+- Measurement lifecycle transitions are recorded as events.
+- Partial/interrupted measurements remain readable.
+- Rerun creates a new linked measurement by default.
+
+## Dataset Artifact
+
+- Dataset facts are append-only while a writer is active.
+- Completed dataset facts are immutable.
+- Dataset artifacts own dataset-local variable metadata and scan schema.
+- Dataset artifacts do not own sample identity, measurement notes, parameter
+  history, or code provenance.
+- Datasets intended for plotting require explicit scan schema at creation time.
+- System-owned fields use a reserved prefix and are hidden from ordinary reads
+  unless explicitly requested.
+
+## Provenance And Audit
+
+- Non-managed code provenance must not be presented as reproducible history.
+- Mutating actions should record an actor label when practical.
+- AI-assisted mutating actions require explicit review and durable audit
+  records.
+- Corrections preserve history rather than overwriting meaning silently.
+
+## Export
+
+- Measurement-centered export is read-only by default.
+- Export bundles carry source library identity, export identity, format version,
+  stable record IDs, and checksums where practical.
+- Sensitive local paths or provenance details are previewed or opt-in.

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -21,6 +21,7 @@ Draft.
 - Measurement sample/session links are optional and correctable with history.
 - Measurement lifecycle transitions are recorded as events.
 - Partial/interrupted measurements remain readable.
+- Readable partials are guaranteed before resumable execution is promised.
 - Rerun creates a new linked measurement by default.
 
 ## Dataset Artifact
@@ -31,12 +32,19 @@ Draft.
 - Dataset artifacts do not own sample identity, measurement notes, parameter
   history, or code provenance.
 - Datasets intended for plotting require explicit scan schema at creation time.
+- Scan schema supports regular grids, partial grids, irregular/adaptive points,
+  repeated points, fixed-shape traces, and variable-length traces.
+- Dataset artifacts remain first-class searchable/openable records.
 - System-owned fields use a reserved prefix and are hidden from ordinary reads
   unless explicitly requested.
 
 ## Provenance And Audit
 
 - Non-managed code provenance must not be presented as reproducible history.
+- Passive setup/device/environment summaries must not be presented as device
+  control or complete reproducibility records.
+- Passive procedure summaries must not be presented as managed execution
+  records or resumable plans.
 - Mutating actions should record an actor label when practical.
 - AI-assisted mutating actions require explicit review and durable audit
   records.

--- a/docs-next/domain/lifecycle-model.md
+++ b/docs-next/domain/lifecycle-model.md
@@ -48,9 +48,14 @@ finished | interrupted | failed
 Rules:
 
 - Partial facts remain visible after interruption or failure.
+- Read APIs expose partial or missing expected points when scan schema declares
+  an expected shape.
 - Rerun creates a new linked measurement by default.
 - Appending to an older measurement requires explicit resume intent and
   compatibility checks.
+- Resumable execution is not promised in v0.2. Pause/resume events may be
+  recorded when supplied by external code, but scan-point checkpoint and resume
+  semantics belong to a future managed-runner design.
 - Cleanup uses trash/recover before hard delete.
 
 ## Dataset Artifact Lifecycle
@@ -74,6 +79,8 @@ Rules:
 
 - Facts are appendable while writing.
 - Facts are immutable after complete.
+- Partial grid, irregular/adaptive, repeated-point, and trace semantics are
+  dataset-local read semantics, not only lifecycle labels.
 - Corrections create events or derived artifacts rather than silent fact edits.
 - Live readers tail explicit append positions and may drop preview updates, but
   committed data is never dropped.

--- a/docs-next/domain/lifecycle-model.md
+++ b/docs-next/domain/lifecycle-model.md
@@ -1,0 +1,92 @@
+# Lifecycle Model
+
+## Status
+
+Draft.
+
+## Data Library Lifecycle
+
+```text
+created
+  -> opened
+  -> idle
+  -> active
+  -> draining
+  -> migrating
+  -> idle
+  -> backed_up/restored
+```
+
+Rules:
+
+- Migrations require idle or draining state with no active writers.
+- Backup/restore is a user-visible safety path.
+- Incompatible clients fail before writes.
+
+## Measurement Lifecycle
+
+```text
+draft/created
+  -> active
+  -> finishing
+  -> finished
+
+active
+  -> interrupted
+  -> failed
+  -> aborted
+
+finished | interrupted | failed | aborted
+  -> trashed
+  -> recovered
+
+finished | interrupted | failed
+  -> invalidated
+  -> superseded
+```
+
+Rules:
+
+- Partial facts remain visible after interruption or failure.
+- Rerun creates a new linked measurement by default.
+- Appending to an older measurement requires explicit resume intent and
+  compatibility checks.
+- Cleanup uses trash/recover before hard delete.
+
+## Dataset Artifact Lifecycle
+
+```text
+declared
+  -> writing
+  -> finishing
+  -> complete
+
+writing
+  -> interrupted
+  -> aborted
+
+complete | interrupted
+  -> exported
+  -> consumed_by_analysis_later
+```
+
+Rules:
+
+- Facts are appendable while writing.
+- Facts are immutable after complete.
+- Corrections create events or derived artifacts rather than silent fact edits.
+- Live readers tail explicit append positions and may drop preview updates, but
+  committed data is never dropped.
+
+## Event Timeline
+
+Measurement timelines combine:
+
+- lifecycle events
+- notes and markers
+- context corrections
+- provenance updates
+- system events
+- export or recovery actions
+
+Events should carry an actor label when practical.

--- a/docs-next/implementation-plans/M1-baseline.md
+++ b/docs-next/implementation-plans/M1-baseline.md
@@ -1,0 +1,61 @@
+# M1: v0.2 Foundation Baseline
+
+## Status
+
+Draft implementation plan.
+
+## Goal
+
+Build the first coherent v0.2 foundation for a local data library with
+measurement-scoped dataset artifacts, enough lifecycle/provenance to recover
+and inspect runs, and enough service/API shape to avoid another dataset-first
+dead end.
+
+## Scope
+
+M1 should prove:
+
+- local data library identity and open/create flow
+- explicit measurement record
+- optional sample/session link
+- measurement-scoped dataset artifact writer
+- explicit scan schema for plotted datasets
+- nonblocking live status/event flow
+- partial/interrupted measurement visibility
+- Python reopen through stable IDs
+- early compatibility negotiation before writes
+
+## Out Of Scope
+
+- full legacy workspace migration
+- direct LabRAD/Data Vault import
+- remote mode
+- full parameter registry
+- managed code execution
+- broad device framework
+- calibration workflows
+- AI mutating automation
+
+## Suggested Work Sequence
+
+1. Accept or revise ADRs for reset, data-library storage, service API, and
+   dataset artifact storage.
+2. Finalize `SPEC-001-data-library-measurement-foundation`.
+3. Create vertical slices for data library, measurement, dataset artifact, and
+   service API.
+4. Implement Python measurement writer ergonomics against the service.
+5. Replace the Desktop first screen with a measurement console skeleton.
+6. Add live read path and nonblocking chart/table preview.
+7. Add lifecycle, recovery, and trash/recover basics.
+8. Add Python reopen snippets and semantic read APIs.
+9. Add focused validation and docs sync.
+
+## Readiness Gate
+
+M1 is ready to implement when:
+
+- `SPEC-001` status is Accepted
+- ADRs exist for storage layout and service API direction
+- lifecycle state vocabulary is accepted
+- tests and validation plan cover Rust, Python, Desktop, and compatibility
+- migration/import stance for pre-v0.2 data is explicit

--- a/docs-next/implementation-plans/M1-baseline.md
+++ b/docs-next/implementation-plans/M1-baseline.md
@@ -19,9 +19,14 @@ M1 should prove:
 - explicit measurement record
 - optional sample/session link
 - measurement-scoped dataset artifact writer
-- explicit scan schema for plotted datasets
+- dataset artifact direct search/open path
+- explicit scan schema and shape modes for plotted datasets
+- scan schema helpers for common 1D/2D/N-D scans and traces
+- internal stream/subpayload policy for dataset artifacts
 - nonblocking live status/event flow
-- partial/interrupted measurement visibility
+- readable partial/interrupted measurement data
+- optional passive setup summary
+- optional passive procedure summary
 - Python reopen through stable IDs
 - early compatibility negotiation before writes
 
@@ -32,7 +37,10 @@ M1 should prove:
 - remote mode
 - full parameter registry
 - managed code execution
+- resumable scan-point checkpoint execution
+- user-facing stream concepts inside dataset artifacts
 - broad device framework
+- large external detector-file/image management
 - calibration workflows
 - AI mutating automation
 
@@ -45,10 +53,13 @@ M1 should prove:
    service API.
 4. Implement Python measurement writer ergonomics against the service.
 5. Replace the Desktop first screen with a measurement console skeleton.
-6. Add live read path and nonblocking chart/table preview.
-7. Add lifecycle, recovery, and trash/recover basics.
-8. Add Python reopen snippets and semantic read APIs.
-9. Add focused validation and docs sync.
+6. Add dataset direct search/open entry points.
+7. Add live read path and nonblocking chart/table preview.
+8. Add lifecycle, readable partial data, and trash/recover basics.
+9. Add Python reopen snippets and semantic read APIs.
+10. Split measurement-centered export into SPEC-002 and keep it aligned with
+    SPEC-001 semantic reads.
+11. Add focused validation and docs sync.
 
 ## Readiness Gate
 
@@ -57,5 +68,7 @@ M1 is ready to implement when:
 - `SPEC-001` status is Accepted
 - ADRs exist for storage layout and service API direction
 - lifecycle state vocabulary is accepted
+- scan shape and readable-partial semantics are accepted
+- scan helper and internal stream policies are accepted
 - tests and validation plan cover Rust, Python, Desktop, and compatibility
 - migration/import stance for pre-v0.2 data is explicit

--- a/docs-next/implementation-plans/M1-baseline.md
+++ b/docs-next/implementation-plans/M1-baseline.md
@@ -21,7 +21,7 @@ M1 should prove:
 - measurement-scoped dataset artifact writer
 - dataset artifact direct search/open path
 - explicit scan schema and shape modes for plotted datasets
-- scan schema helpers for common 1D/2D/N-D scans and traces
+- Python-native scan-plan/schema helpers for common 1D/2D/N-D scans and traces
 - internal stream/subpayload policy for dataset artifacts
 - nonblocking live status/event flow
 - readable partial/interrupted measurement data
@@ -69,6 +69,6 @@ M1 is ready to implement when:
 - ADRs exist for storage layout and service API direction
 - lifecycle state vocabulary is accepted
 - scan shape and readable-partial semantics are accepted
-- scan helper and internal stream policies are accepted
+- scan-plan/helper and internal stream policies are accepted
 - tests and validation plan cover Rust, Python, Desktop, and compatibility
 - migration/import stance for pre-v0.2 data is explicit

--- a/docs-next/postmortems/v0-lessons.md
+++ b/docs-next/postmortems/v0-lessons.md
@@ -1,0 +1,78 @@
+# v0 Prototype Lessons
+
+## Status
+
+Draft reset postmortem.
+
+## Purpose
+
+Capture the lessons from the v0.1 workspace/dataset-first prototype that must
+shape the v0.2+ reset.
+
+## What Worked
+
+- Local-first operation is the right product posture for lab computers.
+- Python-led data recording is the right acquisition entry point.
+- Arrow-compatible table payloads are a useful base for scientific data.
+- Dataset record IDs, append-only facts, chunked payloads, and semantic
+  manifests are reusable concepts.
+- The Tauri/React desktop stack and Rust/Python build infrastructure are worth
+  preserving where they do not force the old model.
+- Explicit architecture and maintenance notes helped AI-assisted work avoid
+  uncontrolled drift.
+
+## What Failed Or Aged Poorly
+
+- The user-facing model became workspace/dataset-first, but the desired product
+  is measurement-history-first.
+- Dataset metadata started carrying meaning that belongs to measurements,
+  samples, sessions, parameters, code provenance, or lifecycle history.
+- Compatibility notes focused on preserving current workspaces before the
+  project had real adoption or a stable domain model.
+- v0.2 planning, archived proposals, AI process notes, and current
+  implementation facts accumulated in the same `dev-docs/` space.
+- The desktop UI was naturally organized as a dataset explorer instead of a
+  measurement console.
+- Protocol and service boundaries were shaped around current IPC/gRPC needs,
+  not a single future client/service contract shared by Desktop, CLI, and
+  Python.
+- Future concepts such as parameter snapshots, runner execution, code
+  provenance, calibration, and AI automation were discussed before the central
+  measurement record was made first-class.
+
+## Concepts That Were Implicit But Need First-Class Treatment
+
+| Concept | Why It Must Be Explicit In v0.2+ |
+| --- | --- |
+| Data Library | Replaces user-facing workspace as the local root and catalog. |
+| Measurement | Owns the data-taking attempt, lifecycle, notes, produced artifacts, and context. |
+| Dataset Artifact | Owns table facts and dataset-local semantics, not whole-run meaning. |
+| Sample | Represents the measured physical object when known. |
+| Sample Session | Represents cooldown, mount, probing, campaign, or setup context. |
+| Parameter Snapshot | Captures run facts without requiring a full parameter registry first. |
+| Code Provenance Summary | States honestly whether code provenance is unmanaged, user-supplied, or managed. |
+| Event/Audit Record | Records lifecycle changes, notes, corrections, and actor labels. |
+| Export Bundle | Provides measurement-centered portability without importing into another library. |
+
+## Compatibility Lessons
+
+Pre-v0.2 test workspaces are not product data. Preserving them must not shape
+the new model.
+
+After v0.2 records real lab data, the compatibility promise changes:
+
+- preserve recorded data durability
+- require explicit migrations or recovery paths
+- fail before writes when client/service/library versions are incompatible
+- keep v0.x API and protocol shapes free to break when required
+
+## Lessons For Future Agents
+
+- Do not implement from archived proposal files directly.
+- Do not treat current v0.1 public docs as v0.2 product direction.
+- Do not put measurement, sample, parameter, code, or lifecycle meaning into
+  dataset-local metadata for convenience.
+- Do not add future runner, device, calibration, or AI automation surfaces
+  before the measurement foundation is coherent.
+- If a local feature introduces a new domain noun, update `docs-next/domain/`
+  and traceability before implementation.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -1,0 +1,39 @@
+# Capability Map
+
+## Status
+
+Draft.
+
+## ID Rules
+
+Capability IDs are stable. Do not reuse or renumber them.
+
+## Capabilities
+
+| ID | Capability | v0.2 Target | Notes |
+| --- | --- | --- | --- |
+| CAP-001 | Local data library | In scope | One primary local data library per normal lab computer. |
+| CAP-002 | Install and launch local Fricon | In scope | Desktop bundles compatible local service and CLI. |
+| CAP-003 | Python measurement recording | In scope | Explicit but short measurement API. |
+| CAP-004 | Optional sample/session context | In scope | Visible, correctable, not required for quick runs. |
+| CAP-005 | Dataset artifact recording | In scope | Table-shaped facts, append while active, immutable after finish. |
+| CAP-006 | Dataset scan semantics | In scope | Explicit roles and axes for plotted data. |
+| CAP-007 | Live inspection | In scope | Noncritical table, line/scatter, heatmap, trace views. |
+| CAP-008 | Lifecycle and partial recovery | In scope | Active, finished, interrupted, failed, aborted, trashed, recovered. |
+| CAP-009 | Notes, markers, favorites, tags | In scope | Measurement-first annotation. |
+| CAP-010 | Python reopen | In scope | Stable IDs and public SDK snippets. |
+| CAP-011 | Measurement-centered export | In scope | Read-only bundles for offline analysis. |
+| CAP-012 | Backup, restore, migration checkpoints | In scope | User-visible safety paths. |
+| CAP-013 | Compatibility diagnostics | In scope | Client/service/library checks before writes. |
+| CAP-014 | Code provenance summary | In scope | Honest unmanaged/user-supplied/future managed levels. |
+| CAP-015 | Flexible parameter snapshot | In scope | Minimal snapshot without registry/profile UI. |
+| CAP-016 | Light attachments | In scope | Small files, images, logs attached to measurements. |
+| CAP-017 | Operator profile and audit actor | In scope | Lightweight local actor labels, not accounts. |
+| CAP-018 | Read-only remote monitoring | Later | Candidate v0.3. |
+| CAP-019 | Rich sample maps and saved views | Later | Candidate v0.3. |
+| CAP-020 | Measurement-code source setup | Later | Configure/update lab code sources without becoming a Git host. |
+| CAP-021 | Parameter profiles and proposals | Later | Candidate v0.4 automation foundation. |
+| CAP-022 | Analysis and calibration records | Later | Consume artifacts, produce derived artifacts or proposals. |
+| CAP-023 | Managed code snapshots and execution | Later | Requires ADR before implementation. |
+| CAP-024 | Device boundary and managed device communication | Later | Reserve boundary, do not build broad framework in v0.2. |
+| CAP-025 | AI-assisted reviewed automation | Later | Read/suggest first; mutating actions require review and audit. |

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -11,6 +11,13 @@ Capability IDs are stable. Do not reuse or renumber them.
 Keep this file compact. Put detailed acceptance notes in epics, user stories,
 or specs instead of expanding this map into a large table.
 
+## Vision Alignment
+
+The v0.2 capability baseline serves one MVP goal: replace the simple LabRAD
+Data Vault/Grapher loop for new measurements. Capabilities should support that
+loop without importing old history, emulating LabRAD, or pulling v0.3+
+parameter, code-management, runner, device, or automation systems into v0.2.
+
 ## v0.2 Foundation Capabilities
 
 ### Local Adoption
@@ -49,12 +56,13 @@ CAP-013: Compatibility diagnostics and fail-before-write checks.
   library format.
 - Excludes: accepting best-effort writes from unknown or stale clients.
 
-### New Measurement Replacement
+### v0.2 MVP Measurement Replacement
 
 CAP-003: Python measurement recording.
 
-- Promise: a Python script can explicitly create a measurement with low
-  ceremony and append measurement facts through public APIs.
+- Promise: a Python script or notebook can explicitly create an unmanaged
+  measurement with low ceremony and append measurement facts through public
+  APIs.
 - Includes: title, start/end lifecycle, optional context links, concurrent local
   writers, and readable crash outcomes.
 - Excludes: managed runner, task queue, visual sweep builder, and device
@@ -84,10 +92,10 @@ CAP-007: Nonblocking live inspection.
   trace inspection, and stale/lag indicators.
 - Excludes: live consumers as required write acknowledgements.
 
-CAP-028: Scan schema authoring helpers plus raw schema escape hatch.
+CAP-028: doAnd-style scan helpers plus raw schema escape hatch.
 
-- Promise: common scan shapes are easy to declare while uncommon schemas remain
-  possible.
+- Promise: common scan shapes are easy to declare in Python while uncommon
+  schemas remain possible.
 - Includes: helper APIs for common 1D, 2D, N-D, and trace cases plus raw schema
   construction for advanced users.
 - Excludes: a visual sweep builder or managed execution plan.
@@ -119,14 +127,14 @@ CAP-014: Honest code provenance summary.
   signal, user-supplied summary, and privacy-aware export handling.
 - Excludes: automatic notebook state capture and managed code snapshots.
 
-CAP-015: Flexible parameter snapshot without a registry UI.
+CAP-015: Light parameter context summary without a registry UI.
 
-- Promise: a measurement can keep an inspectable parameter snapshot even before
-  Fricon has parameter profiles or calibration workflows.
-- Includes: structured or semi-structured parameter values, units where
-  supplied, and links to measurement context.
-- Excludes: global parameter registry, proposal workflow, and calibration
-  promotion.
+- Promise: a measurement can keep optional parameter context before Fricon has
+  parameter profiles, effective snapshots, or calibration workflows.
+- Includes: user-supplied structured or semi-structured parameter summaries,
+  units where supplied, and links to measurement context.
+- Excludes: global parameter registry, immutable profile binding, override
+  semantics, proposal workflow, and calibration promotion.
 
 CAP-017: Lightweight operator profile and audit actor.
 
@@ -228,7 +236,8 @@ CAP-021: Parameter profiles and proposals.
 
 - Intent: promote repeated parameter snapshots into reusable profiles and
   reviewed proposals.
-- Boundary: v0.2 keeps flexible snapshots without a registry UI.
+- Boundary: v0.2 keeps only light parameter context summaries without a
+  registry UI or effective-configuration model.
 
 CAP-022: Analysis and calibration records.
 
@@ -262,8 +271,8 @@ CAP-025: AI-assisted reviewed automation.
 Use these planning groups when routing product work:
 
 - Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
-- New measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007, CAP-028,
-  CAP-030.
+- v0.2 MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007,
+  CAP-028, CAP-030.
 - Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
   CAP-029.
 - Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## ID Rules
 

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -13,43 +13,253 @@ or specs instead of expanding this map into a large table.
 
 ## v0.2 Foundation Capabilities
 
-- CAP-001: Local data library.
-- CAP-002: Install and launch local Fricon.
-- CAP-003: Python measurement recording.
-- CAP-004: Optional, visible, correctable sample/session context.
-- CAP-005: Dataset artifact recording.
-- CAP-006: Dataset scan semantics.
-- CAP-007: Nonblocking live inspection.
-- CAP-008: Lifecycle and readable partial recovery.
-- CAP-009: Notes, markers, favorites, pins, and optional tags.
-- CAP-010: Python reopen through stable IDs and public APIs.
-- CAP-011: Measurement-centered export.
-- CAP-012: Backup, restore, and migration checkpoints.
-- CAP-013: Compatibility diagnostics and fail-before-write checks.
-- CAP-014: Honest code provenance summary.
-- CAP-015: Flexible parameter snapshot without a registry UI.
-- CAP-016: Light measurement attachments.
-- CAP-017: Lightweight operator profile and audit actor.
-- CAP-026: Dataset artifact discovery and direct open.
-- CAP-027: Passive setup and environment summary.
-- CAP-028: Scan schema authoring helpers plus raw schema escape hatch.
-- CAP-029: Passive procedure summary.
-- CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
+### Local Adoption
+
+CAP-001: Local data library.
+
+- Promise: one normal lab computer can own a Fricon data library with durable
+  identity, remembered location, and format version.
+- Includes: create/open, recent-library memory, library identity, and clear
+  handling for locked or unsupported libraries.
+- Excludes: hosted service, shared-folder multi-writer database semantics, and
+  multi-user administration.
+
+CAP-002: Install and launch local Fricon.
+
+- Promise: Desktop, bundled service, bundled CLI, and Python SDK are delivered
+  as one coherent local product.
+- Includes: first-run setup, local service startup/connection, and headless
+  Python use when Desktop is closed.
+- Excludes: polished enterprise deployment and third-party service protocol
+  stability.
+
+CAP-012: Backup, restore, and migration checkpoints.
+
+- Promise: format-changing operations have a recovery posture before user data
+  is mutated.
+- Includes: backup/restore guidance, repair or migration checkpoints, and
+  ordinary recoverable cleanup paths.
+- Excludes: full legacy-system migration and distributed backup service.
+
+CAP-013: Compatibility diagnostics and fail-before-write checks.
+
+- Promise: incompatible client, service, or library combinations fail before
+  mutation with actionable diagnostics.
+- Includes: version negotiation for Desktop, service, CLI, Python SDK, and data
+  library format.
+- Excludes: accepting best-effort writes from unknown or stale clients.
+
+### New Measurement Replacement
+
+CAP-003: Python measurement recording.
+
+- Promise: a Python script can explicitly create a measurement with low
+  ceremony and append measurement facts through public APIs.
+- Includes: title, start/end lifecycle, optional context links, concurrent local
+  writers, and readable crash outcomes.
+- Excludes: managed runner, task queue, visual sweep builder, and device
+  control.
+
+CAP-005: Dataset artifact recording.
+
+- Promise: one measurement can produce one or more first-class dataset
+  artifacts with stable IDs and semantic metadata.
+- Includes: measurement-scoped writers, lifecycle sharing by default, and
+  storage/export hooks for internal streams when needed.
+- Excludes: making internal streams the normal user-facing concept.
+
+CAP-006: Dataset scan semantics.
+
+- Promise: plotted datasets carry explicit scan or trace meaning instead of
+  relying on column-position guesses.
+- Includes: variable roles, labels, units, dependencies, axis structure,
+  partial grids, irregular/adaptive points, repeated points, and trace shapes.
+- Excludes: requiring every advanced acquisition to fit a regular grid.
+
+CAP-007: Nonblocking live inspection.
+
+- Promise: Desktop can watch active data without slowing or breaking acquisition
+  writes.
+- Includes: live events, table view, line/scatter plot, basic heatmap, simple
+  trace inspection, and stale/lag indicators.
+- Excludes: live consumers as required write acknowledgements.
+
+CAP-028: Scan schema authoring helpers plus raw schema escape hatch.
+
+- Promise: common scan shapes are easy to declare while uncommon schemas remain
+  possible.
+- Includes: helper APIs for common 1D, 2D, N-D, and trace cases plus raw schema
+  construction for advanced users.
+- Excludes: a visual sweep builder or managed execution plan.
+
+CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
+
+- Promise: users can translate new Data Vault-style scripts to Fricon writers
+  without a full experiment-stack rewrite.
+- Includes: natural mapping for independent/dependent variables, labels, units,
+  legends, old path aliases, and numbered legacy titles as metadata.
+- Excludes: a LabRAD compatibility server, built-in Data Vault parser, or old
+  history browser.
+
+### Context And Provenance
+
+CAP-004: Optional, visible, correctable sample/session context.
+
+- Promise: sample and sample-session context can explain a measurement when it
+  matters, without blocking quick exploratory work.
+- Includes: optional active context, visible context on creation, and correction
+  after a run.
+- Excludes: requiring a complete sample registry before recording data.
+
+CAP-014: Honest code provenance summary.
+
+- Promise: Fricon records what it can honestly know about unmanaged Python code
+  without pretending it owns execution.
+- Includes: unmanaged labels, optional script path, Git summary, dirty-state
+  signal, user-supplied summary, and privacy-aware export handling.
+- Excludes: automatic notebook state capture and managed code snapshots.
+
+CAP-015: Flexible parameter snapshot without a registry UI.
+
+- Promise: a measurement can keep an inspectable parameter snapshot even before
+  Fricon has parameter profiles or calibration workflows.
+- Includes: structured or semi-structured parameter values, units where
+  supplied, and links to measurement context.
+- Excludes: global parameter registry, proposal workflow, and calibration
+  promotion.
+
+CAP-017: Lightweight operator profile and audit actor.
+
+- Promise: notes, corrections, lifecycle events, and exports can name the local
+  operator or actor responsible.
+- Includes: local operator label, audit actor on events, and correction history.
+- Excludes: accounts, permissions, teams, and identity-provider integration.
+
+CAP-027: Passive setup and environment summary.
+
+- Promise: measurements can record setup, device, method, software, or
+  environment context without controlling the lab setup.
+- Includes: optional labels, freeform summaries, external references, and
+  privacy-aware export selection.
+- Excludes: device identity registry, calibration records, and communication
+  with instruments.
+
+CAP-029: Passive procedure summary.
+
+- Promise: users can describe the procedure that produced data even when Fricon
+  did not execute that procedure.
+- Includes: unmanaged script summary, external-runner reference, declared plan
+  summary, and operator correction.
+- Excludes: managed measurement plans, resumable execution, and scan-point
+  checkpoints.
+
+### Review And Analysis
+
+CAP-008: Lifecycle and readable partial recovery.
+
+- Promise: interrupted or failed work remains understandable and readable.
+- Includes: lifecycle states, partial data reads, missing expected points where
+  schema supports them, trash/recover, and failure/interruption visibility.
+- Excludes: resuming unmanaged execution from the last scan point.
+
+CAP-009: Notes, markers, favorites, pins, and optional tags.
+
+- Promise: users can mark what matters during and after measurement work without
+  turning Fricon into a full ELN.
+- Includes: measurement notes, dataset notes, markers, favorites, pins, optional
+  tags, and correction events.
+- Excludes: publication notebook replacement and rich collaborative review.
+
+CAP-010: Python reopen through stable IDs and public APIs.
+
+- Promise: Python can reopen measurements, dataset artifacts, and exports
+  without depending on storage paths.
+- Includes: stable IDs, typed read APIs, schema-aware reads, partial-data
+  semantics, and Desktop-visible snippets.
+- Excludes: path-based storage contracts and private file layout coupling.
+
+CAP-011: Measurement-centered export.
+
+- Promise: a completed or interrupted measurement can become a portable bundle
+  for offline analysis.
+- Includes: produced datasets, semantic metadata, selected provenance,
+  integrity metadata, and common analysis-oriented output paths.
+- Excludes: importing old history and a fully polished offline Desktop viewer
+  before the write/reopen loop is proven.
+
+CAP-016: Light measurement attachments.
+
+- Promise: a measurement can reference small supporting files needed to
+  understand or analyze the run.
+- Includes: lightweight attachments, labels, source metadata, and export
+  selection.
+- Excludes: large detector-file management and general media asset library.
+
+CAP-026: Dataset artifact discovery and direct open.
+
+- Promise: dataset artifacts remain searchable and directly openable even when
+  the Desktop home is measurement-first.
+- Includes: stable artifact IDs, measurement context, search/open entry points,
+  and direct navigation to table or plot views.
+- Excludes: returning to a dataset-first product model.
 
 ## Later Capabilities
 
-- CAP-018: Read-only remote monitoring.
-- CAP-019: Rich sample maps and saved views.
-- CAP-020: Measurement-code source setup and approved code update flows.
-- CAP-021: Parameter profiles and proposals.
-- CAP-022: Analysis and calibration records.
-- CAP-023: Managed code snapshots and execution.
-- CAP-024: Device boundary and managed device communication.
-- CAP-025: AI-assisted reviewed automation.
+CAP-018: Read-only remote monitoring.
+
+- Intent: allow trusted users on the lab network to watch measurements without
+  editing the data library.
+- Boundary: v0.2 may keep APIs observable, but should not promise remote access
+  or shared editing.
+
+CAP-019: Rich sample maps and saved views.
+
+- Intent: support spatial sample maps, richer sample metadata, and saved
+  comparison views after the local data-library loop works.
+- Boundary: v0.2 only needs optional sample/session context and correction.
+
+CAP-020: Measurement-code source setup and approved code update flows.
+
+- Intent: help labs manage code source locations and reviewed updates for
+  measurement scripts.
+- Boundary: v0.2 records honest provenance but does not own code deployment.
+
+CAP-021: Parameter profiles and proposals.
+
+- Intent: promote repeated parameter snapshots into reusable profiles and
+  reviewed proposals.
+- Boundary: v0.2 keeps flexible snapshots without a registry UI.
+
+CAP-022: Analysis and calibration records.
+
+- Intent: model downstream analysis, calibration, and derived-result activity
+  as first-class records.
+- Boundary: v0.2 may export analysis-ready data but does not manage calibration
+  promotion.
+
+CAP-023: Managed code snapshots and execution.
+
+- Intent: run selected measurement code under Fricon control with reproducible
+  snapshots and lifecycle supervision.
+- Boundary: v0.2 records unmanaged execution context only.
+
+CAP-024: Device boundary and managed device communication.
+
+- Intent: introduce explicit device identity, configuration, and communication
+  boundaries when Fricon begins controlling instruments.
+- Boundary: v0.2 may record passive setup/device summaries but does not talk to
+  instruments.
+
+CAP-025: AI-assisted reviewed automation.
+
+- Intent: let AI propose actions or analysis steps that are reviewed before
+  mutating the data library.
+- Boundary: v0.2 should preserve auditability, not implement mutating AI
+  automation.
 
 ## Product Grouping
 
-For planning, group capabilities by user outcome:
+Use these planning groups when routing product work:
 
 - Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
 - New measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007, CAP-028,

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -8,36 +8,53 @@ Draft.
 
 Capability IDs are stable. Do not reuse or renumber them.
 
-## Capabilities
+Keep this file compact. Put detailed acceptance notes in epics, user stories,
+or specs instead of expanding this map into a large table.
 
-| ID | Capability | v0.2 Target | Notes |
-| --- | --- | --- | --- |
-| CAP-001 | Local data library | In scope | One primary local data library per normal lab computer. |
-| CAP-002 | Install and launch local Fricon | In scope | Desktop bundles compatible local service and CLI. |
-| CAP-003 | Python measurement recording | In scope | Explicit but short measurement API. |
-| CAP-004 | Optional sample/session context | In scope | Visible, correctable, not required for quick runs. |
-| CAP-005 | Dataset artifact recording | In scope | Table-shaped facts, append while active, immutable after finish. |
-| CAP-006 | Dataset scan semantics | In scope | Explicit roles and axes for plotted data. |
-| CAP-007 | Live inspection | In scope | Noncritical table, line/scatter, heatmap, trace views. |
-| CAP-008 | Lifecycle and partial recovery | In scope | Active, finished, interrupted, failed, aborted, trashed, recovered. |
-| CAP-009 | Notes, markers, favorites, tags | In scope | Measurement-first annotation. |
-| CAP-010 | Python reopen | In scope | Stable IDs and public SDK snippets. |
-| CAP-011 | Measurement-centered export | In scope | Read-only bundles for offline analysis. |
-| CAP-012 | Backup, restore, migration checkpoints | In scope | User-visible safety paths. |
-| CAP-013 | Compatibility diagnostics | In scope | Client/service/library checks before writes. |
-| CAP-014 | Code provenance summary | In scope | Honest unmanaged/user-supplied/future managed levels. |
-| CAP-015 | Flexible parameter snapshot | In scope | Minimal snapshot without registry/profile UI. |
-| CAP-016 | Light attachments | In scope | Small files, images, logs attached to measurements. |
-| CAP-017 | Operator profile and audit actor | In scope | Lightweight local actor labels, not accounts. |
-| CAP-018 | Read-only remote monitoring | Later | Candidate v0.3. |
-| CAP-019 | Rich sample maps and saved views | Later | Candidate v0.3. |
-| CAP-020 | Measurement-code source setup | Later | Configure/update lab code sources without becoming a Git host. |
-| CAP-021 | Parameter profiles and proposals | Later | Candidate v0.4 automation foundation. |
-| CAP-022 | Analysis and calibration records | Later | Consume artifacts, produce derived artifacts or proposals. |
-| CAP-023 | Managed code snapshots and execution | Later | Requires ADR before implementation. |
-| CAP-024 | Device boundary and managed device communication | Later | Reserve boundary, do not build broad framework in v0.2. |
-| CAP-025 | AI-assisted reviewed automation | Later | Read/suggest first; mutating actions require review and audit. |
-| CAP-026 | Dataset artifact discovery and direct open | In scope | Datasets are first-class searchable/openable artifacts even in a measurement-first UI. |
-| CAP-027 | Passive setup and environment summary | In scope | Optional setup/device/environment facts without device control or reproducibility overclaiming. |
-| CAP-028 | Scan schema authoring helpers | In scope | Short helpers for common scan/trace shapes plus raw schema for advanced cases. |
-| CAP-029 | Passive procedure summary | In scope | Optional unmanaged script, external runner, or declared-plan summary without managed execution. |
+## v0.2 Foundation Capabilities
+
+- CAP-001: Local data library.
+- CAP-002: Install and launch local Fricon.
+- CAP-003: Python measurement recording.
+- CAP-004: Optional, visible, correctable sample/session context.
+- CAP-005: Dataset artifact recording.
+- CAP-006: Dataset scan semantics.
+- CAP-007: Nonblocking live inspection.
+- CAP-008: Lifecycle and readable partial recovery.
+- CAP-009: Notes, markers, favorites, pins, and optional tags.
+- CAP-010: Python reopen through stable IDs and public APIs.
+- CAP-011: Measurement-centered export.
+- CAP-012: Backup, restore, and migration checkpoints.
+- CAP-013: Compatibility diagnostics and fail-before-write checks.
+- CAP-014: Honest code provenance summary.
+- CAP-015: Flexible parameter snapshot without a registry UI.
+- CAP-016: Light measurement attachments.
+- CAP-017: Lightweight operator profile and audit actor.
+- CAP-026: Dataset artifact discovery and direct open.
+- CAP-027: Passive setup and environment summary.
+- CAP-028: Scan schema authoring helpers plus raw schema escape hatch.
+- CAP-029: Passive procedure summary.
+- CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
+
+## Later Capabilities
+
+- CAP-018: Read-only remote monitoring.
+- CAP-019: Rich sample maps and saved views.
+- CAP-020: Measurement-code source setup and approved code update flows.
+- CAP-021: Parameter profiles and proposals.
+- CAP-022: Analysis and calibration records.
+- CAP-023: Managed code snapshots and execution.
+- CAP-024: Device boundary and managed device communication.
+- CAP-025: AI-assisted reviewed automation.
+
+## Product Grouping
+
+For planning, group capabilities by user outcome:
+
+- Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
+- New measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007, CAP-028,
+  CAP-030.
+- Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
+  CAP-029.
+- Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
+- Future automation foundation: CAP-018 through CAP-025.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -96,7 +96,7 @@ CAP-007: Nonblocking live inspection.
   trace inspection, and stale/lag indicators.
 - Excludes: live consumers as required write acknowledgements.
 
-CAP-028: doAnd-style scan helpers plus raw schema escape hatch.
+CAP-028: doNd-style scan helpers plus raw schema escape hatch.
 
 - Promise: common scan shapes are easy to declare in Python while uncommon
   schemas remain possible.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -13,12 +13,16 @@ or specs instead of expanding this map into a large table.
 
 ## Vision Alignment
 
-The v0.2 capability baseline serves one MVP goal: replace the simple LabRAD
-Data Vault/Grapher loop for new measurements. Capabilities should support that
-loop without importing old history, emulating LabRAD, or pulling v0.3+
-parameter, code-management, runner, device, or automation systems into v0.2.
+The capability baseline serves one MVP goal: replace the simple LabRAD Data
+Vault/Grapher loop for new measurements. Capabilities should support that loop
+without importing old history, emulating LabRAD, or pulling post-MVP parameter,
+code-management, runner, device, or automation systems into the MVP.
 
-## v0.2 Foundation Capabilities
+Release versions are not product-horizon labels. Compatible post-MVP
+capabilities may still ship on the same compatible release line; use MVP,
+post-MVP priority, and ADR-gated labels for product planning.
+
+## MVP Foundation Capabilities
 
 ### Local Adoption
 
@@ -56,7 +60,7 @@ CAP-013: Compatibility diagnostics and fail-before-write checks.
   library format.
 - Excludes: accepting best-effort writes from unknown or stale clients.
 
-### v0.2 MVP Measurement Replacement
+### MVP Measurement Replacement
 
 CAP-003: Python measurement recording.
 
@@ -211,59 +215,59 @@ CAP-026: Dataset artifact discovery and direct open.
   and direct navigation to table or plot views.
 - Excludes: returning to a dataset-first product model.
 
-## Later Capabilities
+## Post-MVP Capabilities
 
 CAP-018: Read-only remote monitoring.
 
 - Intent: allow trusted users on the lab network to watch measurements without
   editing the data library.
-- Boundary: v0.2 may keep APIs observable, but should not promise remote access
-  or shared editing.
+- Boundary: the MVP may keep APIs observable, but should not promise remote
+  access or shared editing.
 
 CAP-019: Rich sample maps and saved views.
 
 - Intent: support spatial sample maps, richer sample metadata, and saved
   comparison views after the local data-library loop works.
-- Boundary: v0.2 only needs optional sample/session context and correction.
+- Boundary: the MVP only needs optional sample/session context and correction.
 
 CAP-020: Measurement-code source setup and approved code update flows.
 
 - Intent: help labs manage code source locations and reviewed updates for
   measurement scripts.
-- Boundary: v0.2 records honest provenance but does not own code deployment.
+- Boundary: the MVP records honest provenance but does not own code deployment.
 
 CAP-021: Parameter profiles and proposals.
 
 - Intent: promote repeated parameter snapshots into reusable profiles and
   reviewed proposals.
-- Boundary: v0.2 keeps only light parameter context summaries without a
+- Boundary: the MVP keeps only light parameter context summaries without a
   registry UI or effective-configuration model.
 
 CAP-022: Analysis and calibration records.
 
 - Intent: model downstream analysis, calibration, and derived-result activity
   as first-class records.
-- Boundary: v0.2 may export analysis-ready data but does not manage calibration
-  promotion.
+- Boundary: the MVP may export analysis-ready data but does not manage
+  calibration promotion.
 
 CAP-023: Managed code snapshots and execution.
 
 - Intent: run selected measurement code under Fricon control with reproducible
   snapshots and lifecycle supervision.
-- Boundary: v0.2 records unmanaged execution context only.
+- Boundary: the MVP records unmanaged execution context only.
 
 CAP-024: Device boundary and managed device communication.
 
 - Intent: introduce explicit device identity, configuration, and communication
   boundaries when Fricon begins controlling instruments.
-- Boundary: v0.2 may record passive setup/device summaries but does not talk to
-  instruments.
+- Boundary: the MVP may record passive setup/device summaries but does not talk
+  to instruments.
 
 CAP-025: AI-assisted reviewed automation.
 
 - Intent: let AI propose actions or analysis steps that are reviewed before
   mutating the data library.
-- Boundary: v0.2 should preserve auditability, not implement mutating AI
+- Boundary: the MVP should preserve auditability, not implement mutating AI
   automation.
 
 ## Product Grouping
@@ -271,9 +275,9 @@ CAP-025: AI-assisted reviewed automation.
 Use these planning groups when routing product work:
 
 - Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
-- v0.2 MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007,
+- MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007,
   CAP-028, CAP-030.
 - Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
   CAP-029.
 - Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
-- Future automation foundation: CAP-018 through CAP-025.
+- Post-MVP foundation: CAP-018 through CAP-025.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -37,3 +37,7 @@ Capability IDs are stable. Do not reuse or renumber them.
 | CAP-023 | Managed code snapshots and execution | Later | Requires ADR before implementation. |
 | CAP-024 | Device boundary and managed device communication | Later | Reserve boundary, do not build broad framework in v0.2. |
 | CAP-025 | AI-assisted reviewed automation | Later | Read/suggest first; mutating actions require review and audit. |
+| CAP-026 | Dataset artifact discovery and direct open | In scope | Datasets are first-class searchable/openable artifacts even in a measurement-first UI. |
+| CAP-027 | Passive setup and environment summary | In scope | Optional setup/device/environment facts without device control or reproducibility overclaiming. |
+| CAP-028 | Scan schema authoring helpers | In scope | Short helpers for common scan/trace shapes plus raw schema for advanced cases. |
+| CAP-029 | Passive procedure summary | In scope | Optional unmanaged script, external runner, or declared-plan summary without managed execution. |

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -226,9 +226,13 @@ CAP-018: Read-only remote monitoring.
 
 CAP-019: Rich sample maps and saved views.
 
-- Intent: support spatial sample maps, richer sample metadata, and saved
-  comparison views after the local data-library loop works.
+- Intent: support user-defined spatial sample maps, richer sample metadata, and
+  saved comparison views after the local data-library loop works.
 - Boundary: the MVP only needs optional sample/session context and correction.
+  Post-MVP map configs or DSLs may map parameter row keys and user labels to
+  visual regions, and color or label those regions from parameter snapshot
+  queries, but should not force a sample-component ontology. Config placement,
+  query syntax, and schema-evolution behavior need a later spec or ADR.
 
 CAP-020: Measurement-code source setup and approved code update flows.
 
@@ -245,8 +249,8 @@ CAP-021: Parameter profiles and proposals.
 
 CAP-022: Analysis and calibration records.
 
-- Intent: model downstream analysis, calibration, and derived-result activity
-  as first-class records.
+- Intent: model downstream analysis, fit attempts, anomaly review,
+  calibration, and derived-result activity as first-class records.
 - Boundary: the MVP may export analysis-ready data but does not manage
   calibration promotion.
 
@@ -270,6 +274,21 @@ CAP-025: AI-assisted reviewed automation.
 - Boundary: the MVP should preserve auditability, not implement mutating AI
   automation.
 
+CAP-031: Run manifest and failure investigation.
+
+- Intent: give managed or high-provenance runs a compact manifest linking
+  parameter snapshots, target keys, code/environment summary, lifecycle, logs,
+  artifacts, operator, timestamps, and diagnostics.
+- Boundary: the first slice supports compare, handoff, export, and anomaly
+  investigation; it is not a scheduler or resume engine.
+
+CAP-032: Routine recipes and reviewed replay.
+
+- Intent: capture repeated compare, run, and analyze routines as previewable
+  recipes so tedious lab work can be replayed without hidden mutation.
+- Boundary: read-only batch compare or triage can arrive before
+  mutation-capable automation; durable mutation requires review and audit.
+
 ## Product Grouping
 
 Use these planning groups when routing product work:
@@ -280,4 +299,4 @@ Use these planning groups when routing product work:
 - Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
   CAP-029.
 - Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
-- Post-MVP foundation: CAP-018 through CAP-025.
+- Post-MVP foundation: CAP-018 through CAP-025, CAP-031, CAP-032.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -96,13 +96,16 @@ CAP-007: Nonblocking live inspection.
   trace inspection, and stale/lag indicators.
 - Excludes: live consumers as required write acknowledgements.
 
-CAP-028: doNd-style scan helpers plus raw schema escape hatch.
+CAP-028: Python-native scan plans plus raw schema escape hatch.
 
-- Promise: common scan shapes are easy to declare in Python while uncommon
-  schemas remain possible.
-- Includes: helper APIs for common 1D, 2D, N-D, and trace cases plus raw schema
-  construction for advanced users.
-- Excludes: a visual sweep builder or managed execution plan.
+- Promise: common scan shapes are easy to declare in ordinary Python while
+  uncommon schemas remain possible.
+- Includes: a low-ceremony scan-plan shape for common 1D, 2D, N-D, and trace
+  cases; dict/literal-friendly authoring where useful; optional convenience
+  helpers; and raw schema construction for advanced users.
+- Excludes: a fixed framework-specific helper name, a framework-specific
+  parameter-object model, treating first-draft helper syntax as accepted
+  without usage feedback, a visual sweep builder, or a managed execution plan.
 
 CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
 

--- a/docs-next/product/epics/EPIC-001-local-setup-data-library.md
+++ b/docs-next/product/epics/EPIC-001-local-setup-data-library.md
@@ -1,0 +1,31 @@
+# EPIC-001: Local Setup And Data Library
+
+## Status
+
+Draft.
+
+## Product Goal
+
+An experimentalist can install Fricon, create or open one local data library,
+and run Python scripts against it without assembling mismatched Desktop, CLI,
+service, and SDK pieces.
+
+## v0.2 Scope
+
+- Coherent local Fricon release for Desktop, bundled service, bundled CLI, and
+  Python SDK compatibility.
+- First-run data-library location choice and durable library identity.
+- Guided diagnostics for service, library, and version mismatch problems.
+- Basic backup/restore and fail-before-write compatibility checks.
+
+## Not v0.2
+
+- Hosted service, multi-user administration, or direct shared-folder database
+  access.
+- Full auto-update polish or third-party protocol stability.
+
+## Key Stories
+
+- US-001: Install and launch Fricon on a lab computer.
+- US-002: Create or open one local data library.
+- US-010: Update without corrupting measurement work.

--- a/docs-next/product/epics/EPIC-001-local-setup-data-library.md
+++ b/docs-next/product/epics/EPIC-001-local-setup-data-library.md
@@ -10,7 +10,7 @@ An experimentalist can install Fricon, create or open one local data library,
 and run Python scripts against it without assembling mismatched Desktop, CLI,
 service, and SDK pieces.
 
-## v0.2 Scope
+## MVP Scope
 
 - Coherent local Fricon release for Desktop, bundled service, bundled CLI, and
   Python SDK compatibility.
@@ -18,7 +18,7 @@ service, and SDK pieces.
 - Guided diagnostics for service, library, and version mismatch problems.
 - Basic backup/restore and fail-before-write compatibility checks.
 
-## Not v0.2
+## Not MVP
 
 - Hosted service, multi-user administration, or direct shared-folder database
   access.

--- a/docs-next/product/epics/EPIC-001-local-setup-data-library.md
+++ b/docs-next/product/epics/EPIC-001-local-setup-data-library.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Product Goal
 

--- a/docs-next/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs-next/product/epics/EPIC-002-new-measurement-logging.md
@@ -18,8 +18,8 @@ measurement scripts instead of becoming a managed automation framework.
 - Explicit but low-ceremony Python measurement creation.
 - Measurement-scoped dataset artifact writers.
 - Dataset artifacts remain directly searchable and openable.
-- Scan helpers for common 1D/2D/N-D scans and traces, with raw schema for
-  advanced cases.
+- Python-native scan plans or helpers for common 1D/2D/N-D scans and traces,
+  with raw schema for advanced cases.
 - Explicit scan semantics for reliable live and historical plots.
 
 ## Not MVP

--- a/docs-next/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs-next/product/epics/EPIC-002-new-measurement-logging.md
@@ -30,4 +30,9 @@ later without manual file/folder discipline.
 - US-003: Run an exploratory measurement from Python.
 - US-004: Produce dataset artifacts from a measurement.
 - US-015: Declare common scan shapes quickly.
-- US-017: Migrate a Data Vault-style script to Fricon writers.
+
+## Related Migration Pressure
+
+US-017 is owned by EPIC-005. EPIC-002 should stay focused on the new writer
+model, but that model must remain ergonomic enough for Data Vault-style
+measurement scripts to migrate without a full old-system importer.

--- a/docs-next/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs-next/product/epics/EPIC-002-new-measurement-logging.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Product Goal
 

--- a/docs-next/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs-next/product/epics/EPIC-002-new-measurement-logging.md
@@ -10,6 +10,9 @@ Replace the simple LabRAD Data Vault/Grapher loop for new measurements:
 declare measured data, append values from Python, watch it live, and reopen it
 later without manual file/folder discipline.
 
+This is the center of the v0.2 MVP. It should stay close to ordinary Python
+measurement scripts instead of becoming a managed automation framework.
+
 ## v0.2 Scope
 
 - Explicit but low-ceremony Python measurement creation.

--- a/docs-next/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs-next/product/epics/EPIC-002-new-measurement-logging.md
@@ -10,10 +10,10 @@ Replace the simple LabRAD Data Vault/Grapher loop for new measurements:
 declare measured data, append values from Python, watch it live, and reopen it
 later without manual file/folder discipline.
 
-This is the center of the v0.2 MVP. It should stay close to ordinary Python
+This is the center of the MVP. It should stay close to ordinary Python
 measurement scripts instead of becoming a managed automation framework.
 
-## v0.2 Scope
+## MVP Scope
 
 - Explicit but low-ceremony Python measurement creation.
 - Measurement-scoped dataset artifact writers.
@@ -22,7 +22,7 @@ measurement scripts instead of becoming a managed automation framework.
   advanced cases.
 - Explicit scan semantics for reliable live and historical plots.
 
-## Not v0.2
+## Not MVP
 
 - LabRAD compatibility server or built-in Data Vault parser.
 - Visual sweep builder as the primary acquisition model.
@@ -30,7 +30,7 @@ measurement scripts instead of becoming a managed automation framework.
 
 ## Key Stories
 
-- US-003: Run an exploratory measurement from Python.
+- US-003: Run an interactive unmanaged measurement from Python.
 - US-004: Produce dataset artifacts from a measurement.
 - US-015: Declare common scan shapes quickly.
 

--- a/docs-next/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs-next/product/epics/EPIC-002-new-measurement-logging.md
@@ -1,0 +1,33 @@
+# EPIC-002: New Measurement Logging Replacement
+
+## Status
+
+Draft.
+
+## Product Goal
+
+Replace the simple LabRAD Data Vault/Grapher loop for new measurements:
+declare measured data, append values from Python, watch it live, and reopen it
+later without manual file/folder discipline.
+
+## v0.2 Scope
+
+- Explicit but low-ceremony Python measurement creation.
+- Measurement-scoped dataset artifact writers.
+- Dataset artifacts remain directly searchable and openable.
+- Scan helpers for common 1D/2D/N-D scans and traces, with raw schema for
+  advanced cases.
+- Explicit scan semantics for reliable live and historical plots.
+
+## Not v0.2
+
+- LabRAD compatibility server or built-in Data Vault parser.
+- Visual sweep builder as the primary acquisition model.
+- Full managed runner, device control, or parameter registry.
+
+## Key Stories
+
+- US-003: Run an exploratory measurement from Python.
+- US-004: Produce dataset artifacts from a measurement.
+- US-015: Declare common scan shapes quickly.
+- US-017: Migrate a Data Vault-style script to Fricon writers.

--- a/docs-next/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs-next/product/epics/EPIC-003-measurement-console-inspection.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Product Goal
 

--- a/docs-next/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs-next/product/epics/EPIC-003-measurement-console-inspection.md
@@ -1,0 +1,31 @@
+# EPIC-003: Measurement Console And Inspection
+
+## Status
+
+Draft.
+
+## Product Goal
+
+Fricon Desktop opens to current lab work: active/recent measurements, live
+datasets, quick plots, notes, favorites, partial/failed runs, and direct reopen
+actions.
+
+## v0.2 Scope
+
+- Measurement-first console.
+- Active and recent measurement list.
+- Live table, line/scatter, basic heatmap, and simple trace inspection.
+- Dataset direct-open entry points.
+- Favorites, notes, lifecycle flags, and basic search shortcuts.
+
+## Not v0.2
+
+- Publication plotting.
+- Generic dashboard builder.
+- Rich saved views and comparison workflows beyond the minimal console.
+
+## Key Stories
+
+- US-005: Watch and inspect live data.
+- US-007: Annotate at the right level.
+- US-013: Find and open a dataset artifact directly.

--- a/docs-next/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs-next/product/epics/EPIC-003-measurement-console-inspection.md
@@ -10,7 +10,7 @@ Fricon Desktop opens to current lab work: active/recent measurements, live
 datasets, quick plots, notes, favorites, partial/failed runs, and direct reopen
 actions.
 
-## v0.2 Scope
+## MVP Scope
 
 - Measurement-first console.
 - Active and recent measurement list.
@@ -18,7 +18,7 @@ actions.
 - Dataset direct-open entry points.
 - Favorites, notes, lifecycle flags, and basic search shortcuts.
 
-## Not v0.2
+## Not MVP
 
 - Publication plotting.
 - Generic dashboard builder.

--- a/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
@@ -28,4 +28,3 @@ reopen data from Python, and export a measurement for offline analysis.
 - US-006: Recover a partial measurement.
 - US-008: Reopen measurement outputs from Python.
 - US-009: Export a measurement for offline analysis.
-- US-018: Start new work in Fricon while old history stays in the old system.

--- a/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
@@ -1,0 +1,31 @@
+# EPIC-004: Recovery, Reopen, And Export
+
+## Status
+
+Draft.
+
+## Product Goal
+
+Interrupted or completed measurements remain useful. Users can recover context,
+reopen data from Python, and export a measurement for offline analysis.
+
+## v0.2 Scope
+
+- Readable partial data and visible lifecycle state.
+- Trash/recover instead of normal hard delete.
+- Python reopen snippets using stable IDs.
+- Measurement-centered export through SPEC-002.
+- Privacy preview for sensitive provenance in exports.
+
+## Not v0.2
+
+- Resumable managed execution.
+- Full offline viewer polish before the write/reopen loop works.
+- Importing old history as a built-in migration path.
+
+## Key Stories
+
+- US-006: Recover a partial measurement.
+- US-008: Reopen measurement outputs from Python.
+- US-009: Export a measurement for offline analysis.
+- US-018: Start new work in Fricon while old history stays in the old system.

--- a/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
@@ -9,7 +9,7 @@ Accepted.
 Interrupted or completed measurements remain useful. Users can recover context,
 reopen data from Python, and export a measurement for offline analysis.
 
-## v0.2 Scope
+## MVP Scope
 
 - Readable partial data and visible lifecycle state.
 - Trash/recover instead of normal hard delete.
@@ -17,7 +17,7 @@ reopen data from Python, and export a measurement for offline analysis.
 - Measurement-centered export through SPEC-002.
 - Privacy preview for sensitive provenance in exports.
 
-## Not v0.2
+## Not MVP
 
 - Resumable managed execution.
 - Full offline viewer polish before the write/reopen loop works.

--- a/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs-next/product/epics/EPIC-004-recovery-reopen-export.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Product Goal
 

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -34,3 +34,4 @@ automation stack on day one.
 - US-014: Record passive setup context.
 - US-016: Record passive procedure context.
 - US-017: Migrate a Data Vault-style script to Fricon writers.
+- US-018: Start new work in Fricon while old history stays in the old system.

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -7,10 +7,10 @@ Accepted.
 ## Product Goal
 
 Help labs adopt Fricon for new measurements while old loggers, copied folders,
-and historical data remain where they are. This epic protects the v0.2 MVP
-from becoming a legacy import project or a full automation stack.
+and historical data remain where they are. This epic protects the MVP from
+becoming a legacy import project or a full automation stack.
 
-## v0.2 Scope
+## MVP Scope
 
 - Data Vault-style script migration guidance for new measurements.
 - Source aliases and old-system references as metadata, not primary identity.
@@ -18,7 +18,7 @@ from becoming a legacy import project or a full automation stack.
 - Light contextual summaries for setup, environment, procedure, and parameters.
 - Optional sample/session context that can be corrected after a run.
 
-## Later Scope
+## Post-MVP Scope
 
 - User-written import helpers for old data when generic APIs mature.
 - Read-only LAN viewing.

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -6,21 +6,21 @@ Accepted.
 
 ## Product Goal
 
-Help labs move from copied folders, old loggers, and ad hoc parameter files
-toward a local data-library workflow without forcing a hosted service or a full
-automation stack on day one.
+Help labs adopt Fricon for new measurements while old loggers, copied folders,
+and historical data remain where they are. This epic protects the v0.2 MVP
+from becoming a legacy import project or a full automation stack.
 
 ## v0.2 Scope
 
-- Generic APIs that make user-written import scripts possible later.
-- Source aliases and metadata for old-system references when users bring data
-  forward.
-- Honest code provenance for unmanaged Python.
-- Passive setup, environment, and procedure summaries.
+- Data Vault-style script migration guidance for new measurements.
+- Source aliases and old-system references as metadata, not primary identity.
+- Honest code provenance for interactive unmanaged Python.
+- Light contextual summaries for setup, environment, procedure, and parameters.
 - Optional sample/session context that can be corrected after a run.
 
 ## Later Scope
 
+- User-written import helpers for old data when generic APIs mature.
 - Read-only LAN viewing.
 - Measurement-code source setup and approved code update flows.
 - Rich sample maps, saved views, comparison, and context correction UX.

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Product Goal
 

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -1,0 +1,36 @@
+# EPIC-005: Migration Ergonomics And Future Lab Scaling
+
+## Status
+
+Draft.
+
+## Product Goal
+
+Help labs move from copied folders, old loggers, and ad hoc parameter files
+toward a local data-library workflow without forcing a hosted service or a full
+automation stack on day one.
+
+## v0.2 Scope
+
+- Generic APIs that make user-written import scripts possible later.
+- Source aliases and metadata for old-system references when users bring data
+  forward.
+- Honest code provenance for unmanaged Python.
+- Passive setup, environment, and procedure summaries.
+- Optional sample/session context that can be corrected after a run.
+
+## Later Scope
+
+- Read-only LAN viewing.
+- Measurement-code source setup and approved code update flows.
+- Rich sample maps, saved views, comparison, and context correction UX.
+- Parameter profiles, calibration records, managed execution, device
+  communication, and AI-assisted reviewed automation.
+
+## Key Stories
+
+- US-011: Record code provenance honestly.
+- US-012: Register a sample and sample session when useful.
+- US-014: Record passive setup context.
+- US-016: Record passive procedure context.
+- US-017: Migrate a Data Vault-style script to Fricon writers.

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft future ledger.
+Accepted future ledger.
 
 ## Purpose
 

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -17,21 +17,28 @@ to use.
 
 ## Candidate v0.3 Product Assistance
 
-- FC-001: Read-only LAN monitoring for viewing, browsing, and export without
-  remote writes.
-- FC-002: Rich sample fields, 2D sample maps, and saved views.
+- FC-004: Parameter profiles, immutable snapshot binding, history, proposals,
+  and diff views. This is the first v0.3+ product direction because large
+  parameter sets are already a standalone user pain.
 - FC-003: Measurement-code source setup that replaces copied-code folders with
   approved-code update flows, local checkout/environment guidance, and no
   central Fricon server.
+- FC-007: Managed code snapshots and opt-in managed run capture. Design early
+  because useful run history depends on automatic capture, not manual entry.
+- FC-014: Measurement history, compare, and operator handoff generated from
+  captured parameter, code, setup, lifecycle, and artifact facts.
+- FC-001: Read-only LAN monitoring for viewing, browsing, and export without
+  remote writes.
+- FC-002: Rich sample fields, 2D sample maps, and saved views.
 
 ## Candidate v0.4 Automation Foundation
 
-- FC-004: Parameter profiles and proposals.
 - FC-005: Analysis records that consume artifacts and produce derived outputs.
 - FC-006: Calibration records with reviewable proposals.
-- FC-007: Managed code snapshots and execution.
 - FC-008: Device identity and managed communication.
 - FC-009: Managed measurement plans.
+- FC-015: Workflow preview layer for calibration, benchmark, and reviewed
+  automation flows.
 
 ## Later Or ADR-Gated
 
@@ -41,6 +48,29 @@ to use.
   waveforms.
 - FC-013: User-facing dataset streams, if internal stream support proves useful
   enough to expose later.
+- FC-016: Applying stored parameter or setup state back to devices. Store and
+  diff comes first; write-back needs safety, partial-failure, readback, and
+  audit ADRs.
+
+## Interview Direction
+
+Current v0.3+ product bias:
+
+- Parameter system first.
+- Managed code source and managed run design early.
+- Useful run history is derived from captured facts rather than user-entered
+  history.
+- Lab state starts with store-and-diff, not device apply.
+- Parameter model starts as a hybrid tree: flexible structured snapshots first,
+  with selected parameters upgraded to typed definitions, units, validation,
+  and UI affordances.
+- Managed runner minimum is SDK runner integration, not a blind shell-command
+  wrapper and not a scheduler.
+- Parameter profile changes use light proposals with actor, reason, and
+  approval history, without requiring a full permissions system.
+
+Candidate future stories and requirements live in
+`product/future-stories-and-requirements.md`.
 
 ## Historical Inputs
 

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -37,7 +37,7 @@ Why first:
 Included concepts:
 
 - FC-004: Parameter profiles, immutable run-bound snapshot binding, history,
-  proposals, and diff views.
+  proposals, diff views, and table row keys usable as lightweight target keys.
 - FC-014: Measurement history and compare views generated from captured
   parameter, setup, lifecycle, code, and artifact facts.
 
@@ -47,6 +47,9 @@ Boundary:
   selected parameters upgraded to typed definitions, units, validation, and UI
   affordances.
 - Use lightweight proposals with actor, reason, and approval history.
+- Treat sample target binding as a convention first: parameter table row keys
+  may be reused by visualization code and snapshot queries, but Fricon does
+  not need a mandatory sample-component ontology in the first parameter slice.
 - Do not require a full permissions system, strict global registry, or device
   write-back for the first parameter slice.
 
@@ -68,12 +71,17 @@ Included concepts:
   central Fricon server.
 - FC-007: Managed code snapshots and opt-in managed run capture.
 - FC-014: Operator handoff and run history views generated from captured facts.
+- FC-017: Run manifest and investigation record linking parameter snapshot,
+  target keys, code/environment summary, lifecycle, logs, artifacts, and
+  failure/anomaly evidence.
 
 Boundary:
 
 - The first managed-run slice is SDK runner integration, not a blind
   shell-command wrapper and not a scheduler.
 - Ordinary interactive unmanaged Python remains valid and clearly labeled.
+- Capture enough context for compare and failure investigation before designing
+  queues, resumable scan points, or autonomous automation.
 - Queues, resource leases, retries, workflow DAGs, and resumable execution are
   later or ADR-gated.
 
@@ -98,6 +106,8 @@ Included concepts:
 - FC-015: Workflow preview layer for calibration, benchmark, and reviewed
   automation flows.
 - FC-010: AI-assisted automation after the audit model exists.
+- FC-018: Routine recipes, reviewed replay, and batch compare for repetitive
+  work after parameter and run facts are trustworthy.
 
 Boundary:
 
@@ -105,6 +115,8 @@ Boundary:
   back to devices.
 - Device write-back, resumable execution, and AI-assisted mutation need safety,
   readback, partial-failure, and audit ADRs.
+- Read-only compare, triage, and preview workflows may arrive before
+  mutation-capable automation if they reuse the same record and review model.
 - A broad workflow DAG engine is not the normal way to run ordinary
   measurements.
 
@@ -112,7 +124,10 @@ Boundary:
 
 - FC-001: Read-only LAN monitoring for viewing, browsing, and export without
   remote writes.
-- FC-002: Rich sample fields, 2D sample maps, and saved views.
+- FC-002: Rich sample fields, user-defined 2D sample-map configs/DSLs, sample
+  visualizers, and saved views. These may map parameter row keys or user labels
+  to visual regions and color/query parameter snapshots without owning sample
+  identity or sample geometry.
 - FC-011: Resumable execution checkpoints with a managed runner.
 - FC-012: External large asset references for detector files, images, and
   waveforms.
@@ -122,6 +137,14 @@ Boundary:
 
 Candidate post-MVP stories and requirements live in
 `product/future-stories-and-requirements.md`.
+
+## Deferred Discussion Topics
+
+- Whether sample-map configs should be stored with Sample, Sample Session, or a
+  separate visualization record for easier discovery.
+- How visualizers declare the parameter snapshot schema they expect.
+- How Fricon reports, disables, migrates, or versions visualizers when a
+  parameter snapshot schema changes.
 
 ## Historical Inputs
 

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -33,6 +33,9 @@ A future concept can move into v0.2 implementation only after:
 | FC-008 | Device identity and managed communication | Candidate v0.4+ | Reserve boundary, but do not build broad framework in v0.2. |
 | FC-009 | Managed measurement plans | Candidate v0.4+ | Optional for repeated/automation-heavy work; imperative Python remains valid. |
 | FC-010 | AI-assisted automation | Candidate after audit model | Read/suggest first; mutating actions require explicit review and audit. |
+| FC-011 | Resumable execution checkpoints | Candidate with managed runner | Requires scan-point checkpoint semantics; v0.2 only promises readable partial data. |
+| FC-012 | External large asset references | ADR-gated | Reserve storage/export hooks for detector files, images, and waveforms, but keep scans/traces first. |
+| FC-013 | User-facing dataset streams | Candidate later | v0.2 may allow internal streams, but should not expose streams as a normal user concept. |
 
 ## Historical Inputs
 

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -11,31 +11,36 @@ inflate the first v0.2 measurement slice.
 
 ## Promotion Rule
 
-A future concept can move into v0.2 implementation only after:
+A future concept can move into implementation only after it has a clear story,
+domain owner, ADR if needed, and does not make the core measurement loop harder
+to use.
 
-- it has a clear user story and capability mapping
-- it has a domain owner
-- it has an ADR if it changes storage, service API, compatibility, or mutation
-  audit behavior
-- it does not make the core measurement loop harder to use
+## Candidate v0.3 Product Assistance
 
-## Concepts
+- FC-001: Read-only LAN monitoring for viewing, browsing, and export without
+  remote writes.
+- FC-002: Rich sample fields, 2D sample maps, and saved views.
+- FC-003: Measurement-code source setup that replaces copied-code folders with
+  approved-code update flows, local checkout/environment guidance, and no
+  central Fricon server.
 
-| ID | Concept | Current Status | Notes |
-| --- | --- | --- | --- |
-| FC-001 | Read-only LAN monitoring | Candidate v0.3 | Remote viewing, browsing, and export only; no remote writes. |
-| FC-002 | Rich sample fields and 2D sample maps | Candidate v0.3 | Useful secondary view and filter entry after minimal sample/session support. |
-| FC-003 | Measurement code source setup | Candidate v0.3+ | Help install/update approved code without becoming a Git host. |
-| FC-004 | Parameter profiles and proposals | Candidate v0.4 | Requires measurement records, parameter snapshots, and audit model first. |
-| FC-005 | Analysis records | Candidate v0.3+ | Consume artifacts and produce derived artifacts/results without mutating facts. |
-| FC-006 | Calibration records | Candidate v0.4 | Reviewable proposals and accepted/rejected parameter changes. |
-| FC-007 | Managed code snapshots and execution | Candidate v0.4 | Requires code source, snapshot, ScriptRun, and resource boundary ADRs. |
-| FC-008 | Device identity and managed communication | Candidate v0.4+ | Reserve boundary, but do not build broad framework in v0.2. |
-| FC-009 | Managed measurement plans | Candidate v0.4+ | Optional for repeated/automation-heavy work; imperative Python remains valid. |
-| FC-010 | AI-assisted automation | Candidate after audit model | Read/suggest first; mutating actions require explicit review and audit. |
-| FC-011 | Resumable execution checkpoints | Candidate with managed runner | Requires scan-point checkpoint semantics; v0.2 only promises readable partial data. |
-| FC-012 | External large asset references | ADR-gated | Reserve storage/export hooks for detector files, images, and waveforms, but keep scans/traces first. |
-| FC-013 | User-facing dataset streams | Candidate later | v0.2 may allow internal streams, but should not expose streams as a normal user concept. |
+## Candidate v0.4 Automation Foundation
+
+- FC-004: Parameter profiles and proposals.
+- FC-005: Analysis records that consume artifacts and produce derived outputs.
+- FC-006: Calibration records with reviewable proposals.
+- FC-007: Managed code snapshots and execution.
+- FC-008: Device identity and managed communication.
+- FC-009: Managed measurement plans.
+
+## Later Or ADR-Gated
+
+- FC-010: AI-assisted automation after the audit model exists.
+- FC-011: Resumable execution checkpoints with a managed runner.
+- FC-012: External large asset references for detector files, images, and
+  waveforms.
+- FC-013: User-facing dataset streams, if internal stream support proves useful
+  enough to expose later.
 
 ## Historical Inputs
 

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -6,8 +6,12 @@ Accepted future ledger.
 
 ## Purpose
 
-Preserve important v0.3+ and v0.4+ direction without letting future systems
-inflate the first v0.2 measurement slice.
+Preserve important post-MVP directions without letting future systems inflate
+the MVP measurement loop.
+
+These are product priority horizons, not semantic-version promises. Compatible
+capabilities may ship on the same release line as the MVP if the compatibility,
+storage, and API policies allow it.
 
 ## Promotion Rule
 
@@ -15,11 +19,11 @@ A future concept can move into implementation only after it has a clear story,
 domain owner, ADR if needed, and does not make the core measurement loop harder
 to use.
 
-## Candidate v0.3 Product Assistance
+## Post-MVP Priority: Product Assistance
 
 - FC-004: Parameter profiles, immutable snapshot binding, history, proposals,
-  and diff views. This is the first v0.3+ product direction because large
-  parameter sets are already a standalone user pain.
+  and diff views. This is the highest-priority post-MVP direction because
+  large parameter sets are already a standalone user pain.
 - FC-003: Measurement-code source setup that replaces copied-code folders with
   approved-code update flows, local checkout/environment guidance, and no
   central Fricon server.
@@ -31,7 +35,7 @@ to use.
   remote writes.
 - FC-002: Rich sample fields, 2D sample maps, and saved views.
 
-## Candidate v0.4 Automation Foundation
+## Post-MVP Priority: Automation Foundation
 
 - FC-005: Analysis records that consume artifacts and produce derived outputs.
 - FC-006: Calibration records with reviewable proposals.
@@ -54,7 +58,7 @@ to use.
 
 ## Interview Direction
 
-Current v0.3+ product bias:
+Current post-MVP product bias:
 
 - Parameter system first.
 - Managed code source and managed run design early.

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -1,0 +1,41 @@
+# Future Concepts
+
+## Status
+
+Draft future ledger.
+
+## Purpose
+
+Preserve important v0.3+ and v0.4+ direction without letting future systems
+inflate the first v0.2 measurement slice.
+
+## Promotion Rule
+
+A future concept can move into v0.2 implementation only after:
+
+- it has a clear user story and capability mapping
+- it has a domain owner
+- it has an ADR if it changes storage, service API, compatibility, or mutation
+  audit behavior
+- it does not make the core measurement loop harder to use
+
+## Concepts
+
+| ID | Concept | Current Status | Notes |
+| --- | --- | --- | --- |
+| FC-001 | Read-only LAN monitoring | Candidate v0.3 | Remote viewing, browsing, and export only; no remote writes. |
+| FC-002 | Rich sample fields and 2D sample maps | Candidate v0.3 | Useful secondary view and filter entry after minimal sample/session support. |
+| FC-003 | Measurement code source setup | Candidate v0.3+ | Help install/update approved code without becoming a Git host. |
+| FC-004 | Parameter profiles and proposals | Candidate v0.4 | Requires measurement records, parameter snapshots, and audit model first. |
+| FC-005 | Analysis records | Candidate v0.3+ | Consume artifacts and produce derived artifacts/results without mutating facts. |
+| FC-006 | Calibration records | Candidate v0.4 | Reviewable proposals and accepted/rejected parameter changes. |
+| FC-007 | Managed code snapshots and execution | Candidate v0.4 | Requires code source, snapshot, ScriptRun, and resource boundary ADRs. |
+| FC-008 | Device identity and managed communication | Candidate v0.4+ | Reserve boundary, but do not build broad framework in v0.2. |
+| FC-009 | Managed measurement plans | Candidate v0.4+ | Optional for repeated/automation-heavy work; imperative Python remains valid. |
+| FC-010 | AI-assisted automation | Candidate after audit model | Read/suggest first; mutating actions require explicit review and audit. |
+
+## Historical Inputs
+
+Use `dev-docs/v0.2/future-concepts.md` and files under
+`dev-docs/v0.2/archive/` as source material only. If they conflict with
+accepted `docs-next/` documents, the accepted `docs-next/` document wins.

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted future ledger.
+Accepted post-MVP priority ledger.
 
 ## Purpose
 
@@ -19,23 +19,77 @@ A future concept can move into implementation only after it has a clear story,
 domain owner, ADR if needed, and does not make the core measurement loop harder
 to use.
 
-## Post-MVP Priority: Product Assistance
+The priority order is a planning default, not a release-number commitment. A
+lower-priority item can move earlier only when it is small, compatible, and does
+not weaken the higher-priority product model.
 
-- FC-004: Parameter profiles, immutable snapshot binding, history, proposals,
-  and diff views. This is the highest-priority post-MVP direction because
-  large parameter sets are already a standalone user pain.
+## Priority 1: Parameter System
+
+Why first:
+
+- Fricon's core motivation is dissatisfaction with existing parameter
+  management and code management around physical measurements.
+- Parameter state directly shapes whether a completed measurement can be
+  understood, compared, repeated, or promoted into better lab practice.
+- Managed runs and automation workflows need a parameter model to avoid
+  recording only half of the experiment record.
+
+Included concepts:
+
+- FC-004: Parameter profiles, immutable run-bound snapshot binding, history,
+  proposals, and diff views.
+- FC-014: Measurement history and compare views generated from captured
+  parameter, setup, lifecycle, code, and artifact facts.
+
+Boundary:
+
+- Start with a hybrid parameter tree: flexible structured values first, with
+  selected parameters upgraded to typed definitions, units, validation, and UI
+  affordances.
+- Use lightweight proposals with actor, reason, and approval history.
+- Do not require a full permissions system, strict global registry, or device
+  write-back for the first parameter slice.
+
+## Priority 2: Managed Run
+
+Why second:
+
+- Managed run turns the SDK from an honest unmanaged logger into a higher
+  provenance experiment runner when users opt in.
+- Useful run history depends on captured code, parameters, lifecycle, logs, and
+  produced artifacts, not manual entry.
+- Managed run should grow from ordinary importable Python code, not from a
+  separate experiment DSL.
+
+Included concepts:
+
 - FC-003: Measurement-code source setup that replaces copied-code folders with
   approved-code update flows, local checkout/environment guidance, and no
   central Fricon server.
-- FC-007: Managed code snapshots and opt-in managed run capture. Design early
-  because useful run history depends on automatic capture, not manual entry.
-- FC-014: Measurement history, compare, and operator handoff generated from
-  captured parameter, code, setup, lifecycle, and artifact facts.
-- FC-001: Read-only LAN monitoring for viewing, browsing, and export without
-  remote writes.
-- FC-002: Rich sample fields, 2D sample maps, and saved views.
+- FC-007: Managed code snapshots and opt-in managed run capture.
+- FC-014: Operator handoff and run history views generated from captured facts.
 
-## Post-MVP Priority: Automation Foundation
+Boundary:
+
+- The first managed-run slice is SDK runner integration, not a blind
+  shell-command wrapper and not a scheduler.
+- Ordinary interactive unmanaged Python remains valid and clearly labeled.
+- Queues, resource leases, retries, workflow DAGs, and resumable execution are
+  later or ADR-gated.
+
+## Priority 3: Reviewable Automation Workflow
+
+Why third:
+
+- Automation should reuse the parameter system and managed run record instead
+  of becoming an independent workflow engine.
+- The experiment UX risk is hidden mutation. The product value is preview,
+  review, audit, and explicit approval around changes to parameters, setup,
+  code, devices, or data-library state.
+- AI-assisted workflow is only acceptable after the audit and review model
+  exists.
+
+Included concepts:
 
 - FC-005: Analysis records that consume artifacts and produce derived outputs.
 - FC-006: Calibration records with reviewable proposals.
@@ -43,37 +97,30 @@ to use.
 - FC-009: Managed measurement plans.
 - FC-015: Workflow preview layer for calibration, benchmark, and reviewed
   automation flows.
-
-## Later Or ADR-Gated
-
 - FC-010: AI-assisted automation after the audit model exists.
+
+Boundary:
+
+- Store and diff setup, device, and calibration state before applying settings
+  back to devices.
+- Device write-back, resumable execution, and AI-assisted mutation need safety,
+  readback, partial-failure, and audit ADRs.
+- A broad workflow DAG engine is not the normal way to run ordinary
+  measurements.
+
+## Supporting Or Lower-Priority Concepts
+
+- FC-001: Read-only LAN monitoring for viewing, browsing, and export without
+  remote writes.
+- FC-002: Rich sample fields, 2D sample maps, and saved views.
 - FC-011: Resumable execution checkpoints with a managed runner.
 - FC-012: External large asset references for detector files, images, and
   waveforms.
 - FC-013: User-facing dataset streams, if internal stream support proves useful
   enough to expose later.
-- FC-016: Applying stored parameter or setup state back to devices. Store and
-  diff comes first; write-back needs safety, partial-failure, readback, and
-  audit ADRs.
+- FC-016: Applying stored parameter or setup state back to devices.
 
-## Interview Direction
-
-Current post-MVP product bias:
-
-- Parameter system first.
-- Managed code source and managed run design early.
-- Useful run history is derived from captured facts rather than user-entered
-  history.
-- Lab state starts with store-and-diff, not device apply.
-- Parameter model starts as a hybrid tree: flexible structured snapshots first,
-  with selected parameters upgraded to typed definitions, units, validation,
-  and UI affordances.
-- Managed runner minimum is SDK runner integration, not a blind shell-command
-  wrapper and not a scheduler.
-- Parameter profile changes use light proposals with actor, reason, and
-  approval history, without requiring a full permissions system.
-
-Candidate future stories and requirements live in
+Candidate post-MVP stories and requirements live in
 `product/future-stories-and-requirements.md`.
 
 ## Historical Inputs

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -2,19 +2,23 @@
 
 ## Status
 
-Proposed v0.3+ planning note.
+Proposed post-MVP planning note.
 
 ## Purpose
 
-Capture candidate v0.3+ user stories and product requirements before they
+Capture candidate post-MVP user stories and product requirements before they
 become accepted product scope.
 
-These items are intentionally outside the accepted v0.2 slice. They exist so
-v0.2 storage, domain, and API choices do not block likely future needs.
+These items are intentionally outside the accepted MVP. They exist so MVP
+storage, domain, and API choices do not block likely future needs.
+
+This file uses priority horizons, not semantic-version labels. A compatible
+feature can still ship on the same release line as the MVP if the relevant
+compatibility, storage, and API policies allow it.
 
 ## Planning Stance
 
-v0.3+ should prioritize:
+Post-MVP work should prioritize:
 
 - parameter system first
 - managed code source and managed run design early
@@ -26,7 +30,7 @@ v0.3+ should prioritize:
 The product rule is: the system captures context automatically where practical;
 the user confirms, annotates, or corrects it.
 
-## Candidate v0.3 Epics
+## Candidate Post-MVP Epics
 
 FEPIC-001: Parameter System And Snapshot Binding.
 
@@ -116,8 +120,8 @@ FUS-007: Run through an opt-in SDK runner.
   lifecycle, warnings, abort/fail reason, and produced artifacts.
 - Success: the unmanaged Python path still works; managed runner is opt-in
   until its safety model is accepted.
-- Success: v0.3 runner does not need queues, resource scheduling, retries, or
-  broad workflow DAG execution.
+- Success: the first managed-runner slice does not need queues, resource
+  scheduling, retries, or broad workflow DAG execution.
 
 FUS-008: Run like a previous measurement.
 
@@ -174,7 +178,8 @@ can compare profile, proposal, effective run snapshot, and override layers.
 
 FREQ-005: Parameter profile updates use lightweight proposals with source run
 or source snapshot, changed fields, actor, reason, approval/rejection outcome,
-and timestamp. They do not require a permissions system in v0.3.
+and timestamp. They do not require a permissions system in the first parameter
+workflow slice.
 
 FREQ-006: Managed code provenance records source URI/path, selected revision,
 dirty state, source hashes where practical, SDK runner entry point, runner
@@ -183,12 +188,12 @@ invocation, and environment summary.
 FREQ-007: Fricon shows provenance confidence instead of claiming
 reproducibility from Git metadata alone.
 
-FREQ-008: v0.3 managed runner minimum is SDK runner integration. It captures
+FREQ-008: The first managed-runner slice is SDK runner integration. It captures
 stdout/stderr excerpts or logs, start/end timestamps, status, abort/fail
 reason, produced artifacts, and diagnostic warnings.
 
-FREQ-009: v0.3 managed runner is not a scheduler. Queues, resource management,
-retries, and workflow DAG execution are later or ADR-gated.
+FREQ-009: The first managed-runner slice is not a scheduler. Queues, resource
+management, retries, and workflow DAG execution are later or ADR-gated.
 
 FREQ-010: Run history and compare views are generated from recorded facts:
 parameters, code, setup, lifecycle events, notes, operator labels, and
@@ -200,8 +205,9 @@ diff before any device write-back is implemented.
 FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
 separate ADRs covering safety, readback, partial failure, and audit behavior.
 
-FREQ-013: v0.3+ remains local-first: no cloud account, hosted dashboard, or
-central Fricon server is required for core parameter or run capture workflows.
+FREQ-013: Post-MVP improvements remain local-first: no cloud account, hosted
+dashboard, or central Fricon server is required for core parameter or run
+capture workflows.
 
 ## Explicit Non-Goals Until ADR-Gated
 

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -1,0 +1,214 @@
+# Future Stories And Requirements
+
+## Status
+
+Proposed v0.3+ planning note.
+
+## Purpose
+
+Capture candidate v0.3+ user stories and product requirements before they
+become accepted product scope.
+
+These items are intentionally outside the accepted v0.2 slice. They exist so
+v0.2 storage, domain, and API choices do not block likely future needs.
+
+## Planning Stance
+
+v0.3+ should prioritize:
+
+- parameter system first
+- managed code source and managed run design early
+- run history as a generated view over captured facts
+- setup, device, and calibration state as store-and-diff before device apply
+- hybrid parameter tree before strict registry
+- SDK runner before scheduler
+
+The product rule is: the system captures context automatically where practical;
+the user confirms, annotates, or corrects it.
+
+## Candidate v0.3 Epics
+
+FEPIC-001: Parameter System And Snapshot Binding.
+
+- Users manage large parameter sets as named profiles or refs.
+- Measurement start resolves refs into immutable effective snapshots.
+- Diffs explain what changed between runs, profiles, proposals, and overrides.
+- The base model is a structured parameter tree; selected parameters can gain
+  typed definitions, units, validation, and richer UI later.
+
+FEPIC-002: Managed Code Source And Run Capture.
+
+- Users configure measurement code sources without copying folders by hand.
+- Fricon can capture code snapshot, SDK runner entry point, environment
+  summary, stdout/stderr, status, and produced artifacts.
+- Ordinary unmanaged Python remains possible, but shows lower provenance
+  confidence.
+
+FEPIC-003: Measurement History, Compare, And Handoff.
+
+- Measurement history is assembled from parameter snapshots, code snapshots,
+  setup summaries, lifecycle events, operator labels, and artifact links.
+- Users compare runs and see what changed since the last session.
+
+FEPIC-004: Setup And Calibration State Store/Diff.
+
+- Users record setup/device/calibration state as structured snapshots and
+  ledgers.
+- Fricon can diff and bind state to runs without applying settings to devices.
+
+## Candidate User Stories
+
+FUS-001: Maintain named parameter profiles.
+
+- As an experimentalist, I want refs such as `main`, `latest-good`, or
+  `cooldown-2026-05` so that large parameter sets have memorable identities.
+- Success: refs can move, but each run records the immutable snapshot revision
+  actually used.
+- Success: ordinary parameters can remain flexible tree nodes; important
+  parameters can be promoted to typed definitions with unit and validation.
+
+FUS-002: Bind effective parameters at run start.
+
+- As an experimentalist, I want a measurement to capture the resolved parameter
+  snapshot and runtime overrides automatically so that later analysis can
+  explain the exact effective settings.
+- Success: overrides are separate facts with actor, time, source, and optional
+  reason.
+
+FUS-003: Compare parameters across runs and proposals.
+
+- As an experimentalist, I want to diff two runs, snapshots, or profiles so
+  that I can find parameter drift without reading JSON files by hand.
+- Success: diffs preserve path, value, unit, source profile, override status,
+  actor, and linked run or proposal.
+
+FUS-004: Promote a good run into a parameter proposal.
+
+- As an experimentalist, I want to turn the effective settings from a successful
+  run into a reviewed proposal so that useful adjustments can become a named
+  profile intentionally.
+- Success: promotion records source run, changed fields, reviewer/actor, and
+  approval or rejection outcome.
+- Success: this is a lightweight proposal flow, not a permissions or compliance
+  system.
+
+FUS-005: Configure a measurement code source.
+
+- As an experimentalist, I want to register a local or remote code source,
+  entry point, and environment hint so that Fricon can stop relying on copied
+  folders as the only code provenance story.
+- Success: source location, selected revision, environment file, and local
+  checkout status are visible before a managed run.
+
+FUS-006: Capture a managed code snapshot.
+
+- As an experimentalist, I want Fricon to capture Git commit, dirty state,
+  source hashes, dependency summary, SDK runner entry point, and runner
+  invocation when it starts a managed run so that measurement history is not
+  hand-entered.
+- Success: provenance confidence is visible as unmanaged, observed, or managed
+  snapshot.
+
+FUS-007: Run through an opt-in SDK runner.
+
+- As an experimentalist, I want selected scripts to integrate with a Fricon SDK
+  runner so that Fricon can capture parameters, code snapshot, stdout, stderr,
+  lifecycle, warnings, abort/fail reason, and produced artifacts.
+- Success: the unmanaged Python path still works; managed runner is opt-in
+  until its safety model is accepted.
+- Success: v0.3 runner does not need queues, resource scheduling, retries, or
+  broad workflow DAG execution.
+
+FUS-008: Run like a previous measurement.
+
+- As an experimentalist, I want to start from a previous measurement's scan
+  schema, parameter snapshot, code source, sample/session context, and plot
+  layout so that repeat work is faster without hiding what changed.
+- Success: reused facts are copied by reference or snapshot, and changes are
+  shown before the new run starts.
+
+FUS-009: Compare two measurements.
+
+- As an experimentalist, I want to compare runs by parameters, code, sample,
+  setup, calibration status, lifecycle, notes, and output artifacts so that I
+  can explain why results differ.
+- Success: comparison is generated from recorded facts, not a manual report.
+
+FUS-010: See operator handoff.
+
+- As a shared-lab user, I want to see what changed since my last session so
+  that I can trust the lab computer state before starting work.
+- Success: handoff includes parameter ref changes, setup snapshot changes,
+  calibration due/expired state, failed runs, imports, exports, and notes.
+
+FUS-011: Store and diff setup snapshots.
+
+- As an experimentalist, I want structured setup snapshots for devices,
+  software, firmware, driver versions, connection labels, and readback
+  freshness so that setup drift is inspectable.
+- Success: Fricon can diff snapshots and bind a snapshot to a run without
+  controlling devices.
+
+FUS-012: Track calibration state.
+
+- As an experimentalist, I want calibration records with due dates,
+  certificates, as-found/as-left values, pass/fail status, and affected-run
+  links so that questionable data can be reviewed.
+- Success: out-of-tolerance records can flag a review window without silently
+  invalidating data.
+
+## Candidate Product Requirements
+
+FREQ-001: The parameter model is a hybrid structured tree. Flexible nodes are
+valid by default, and selected nodes can carry typed definitions, units,
+validation, display hints, and documentation.
+
+FREQ-002: Named parameter refs resolve to immutable snapshots before a managed
+or unmanaged measurement records data.
+
+FREQ-003: Runtime parameter overrides are recorded separately from profile
+snapshots, with actor, time, source, and optional reason.
+
+FREQ-004: Parameter diffs are path-aware, unit-aware where units exist, and
+can compare profile, proposal, effective run snapshot, and override layers.
+
+FREQ-005: Parameter profile updates use lightweight proposals with source run
+or source snapshot, changed fields, actor, reason, approval/rejection outcome,
+and timestamp. They do not require a permissions system in v0.3.
+
+FREQ-006: Managed code provenance records source URI/path, selected revision,
+dirty state, source hashes where practical, SDK runner entry point, runner
+invocation, and environment summary.
+
+FREQ-007: Fricon shows provenance confidence instead of claiming
+reproducibility from Git metadata alone.
+
+FREQ-008: v0.3 managed runner minimum is SDK runner integration. It captures
+stdout/stderr excerpts or logs, start/end timestamps, status, abort/fail
+reason, produced artifacts, and diagnostic warnings.
+
+FREQ-009: v0.3 managed runner is not a scheduler. Queues, resource management,
+retries, and workflow DAG execution are later or ADR-gated.
+
+FREQ-010: Run history and compare views are generated from recorded facts:
+parameters, code, setup, lifecycle events, notes, operator labels, and
+artifacts.
+
+FREQ-011: Setup/device/calibration state supports store, bind, search, and
+diff before any device write-back is implemented.
+
+FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
+separate ADRs covering safety, readback, partial failure, and audit behavior.
+
+FREQ-013: v0.3+ remains local-first: no cloud account, hosted dashboard, or
+central Fricon server is required for core parameter or run capture workflows.
+
+## Explicit Non-Goals Until ADR-Gated
+
+- Fricon as a full ELN, LIMS, or compliance system.
+- Fricon as a Git host or broad package manager.
+- Cloud-first experiment tracking dashboards.
+- Model registry, hyperparameter leaderboard, or ML sweep controller concepts
+  as primary product nouns.
+- Device write-back before store/diff is useful and safe.
+- Workflow DAG engine as the normal way to run ordinary measurements.

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed post-MVP planning note.
+Proposed post-MVP planning backlog.
 
 ## Purpose
 
@@ -21,46 +21,24 @@ compatibility, storage, and API policies allow it.
 Post-MVP work should prioritize:
 
 - parameter system first
-- managed code source and managed run design early
-- run history as a generated view over captured facts
-- setup, device, and calibration state as store-and-diff before device apply
-- hybrid parameter tree before strict registry
-- SDK runner before scheduler
+- managed run second
+- reviewable automation workflow third
 
 The product rule is: the system captures context automatically where practical;
-the user confirms, annotates, or corrects it.
+the user confirms, annotates, or corrects it. Any workflow that mutates
+parameters, setup, devices, code, or data-library state needs explicit preview,
+review, and audit semantics.
 
-## Candidate Post-MVP Epics
+## Priority 1: Parameter System
 
 FEPIC-001: Parameter System And Snapshot Binding.
 
 - Users manage large parameter sets as named profiles or refs.
-- Measurement start resolves refs into immutable effective snapshots.
+- Measurement start resolves refs into immutable run-bound snapshots.
 - Diffs explain what changed between runs, profiles, proposals, and overrides.
-- The base model is a structured parameter tree; selected parameters can gain
-  typed definitions, units, validation, and richer UI later.
-
-FEPIC-002: Managed Code Source And Run Capture.
-
-- Users configure measurement code sources without copying folders by hand.
-- Fricon can capture code snapshot, SDK runner entry point, environment
-  summary, stdout/stderr, status, and produced artifacts.
-- Ordinary unmanaged Python remains possible, but shows lower provenance
-  confidence.
-
-FEPIC-003: Measurement History, Compare, And Handoff.
-
-- Measurement history is assembled from parameter snapshots, code snapshots,
-  setup summaries, lifecycle events, operator labels, and artifact links.
-- Users compare runs and see what changed since the last session.
-
-FEPIC-004: Setup And Calibration State Store/Diff.
-
-- Users record setup/device/calibration state as structured snapshots and
-  ledgers.
-- Fricon can diff and bind state to runs without applying settings to devices.
-
-## Candidate User Stories
+- The base model is a hybrid parameter tree: flexible structured values first,
+  with selected parameters upgraded to typed definitions, units, validation,
+  display hints, and UI affordances.
 
 FUS-001: Maintain named parameter profiles.
 
@@ -74,8 +52,8 @@ FUS-001: Maintain named parameter profiles.
 FUS-002: Bind effective parameters at run start.
 
 - As an experimentalist, I want a measurement to capture the resolved parameter
-  snapshot and runtime overrides automatically so that later analysis can
-  explain the exact effective settings.
+  snapshot and runtime overrides so that later analysis can explain the exact
+  effective settings.
 - Success: overrides are separate facts with actor, time, source, and optional
   reason.
 
@@ -95,6 +73,54 @@ FUS-004: Promote a good run into a parameter proposal.
   approval or rejection outcome.
 - Success: this is a lightweight proposal flow, not a permissions or compliance
   system.
+
+FUS-008: Run like a previous measurement.
+
+- As an experimentalist, I want to start from a previous measurement's scan
+  schema, parameter snapshot, code source, sample/session context, and plot
+  layout so that repeat work is faster without hiding what changed.
+- Success: reused facts are copied by reference or snapshot, and changes are
+  shown before the new run starts.
+
+Parameter requirements:
+
+- FREQ-001: The parameter model is a hybrid structured tree. Flexible nodes are
+  valid by default, and selected nodes can carry typed definitions, units,
+  validation, display hints, and documentation.
+- FREQ-002: Named parameter refs resolve to immutable snapshots before a
+  managed or unmanaged measurement records data.
+- FREQ-003: Runtime parameter overrides are recorded separately from profile
+  snapshots, with actor, time, source, and optional reason.
+- FREQ-004: Parameter diffs are path-aware, unit-aware where units exist, and
+  can compare profile, proposal, effective run snapshot, and override layers.
+- FREQ-005: Parameter profile updates use lightweight proposals with source run
+  or source snapshot, changed fields, actor, reason, approval/rejection
+  outcome, and timestamp. They do not require a permissions system in the first
+  parameter workflow slice.
+
+Not first parameter slice:
+
+- Device write-back.
+- Strict global registry for every parameter.
+- Permissions, compliance, or multi-user approval system.
+- Automatic tracing of every parameter read without explicit design.
+
+## Priority 2: Managed Run
+
+FEPIC-002: Managed Code Source And Run Capture.
+
+- Users configure measurement code sources without copying folders by hand.
+- Users can mark importable Python entry points for opt-in Fricon management.
+- Fricon can capture code snapshot, SDK runner entry point, environment
+  summary, stdout/stderr, status, diagnostics, and produced artifacts.
+- Ordinary interactive unmanaged Python remains possible, but shows lower
+  provenance confidence.
+
+FEPIC-003: Measurement History, Compare, And Handoff.
+
+- Measurement history is assembled from parameter snapshots, code snapshots,
+  setup summaries, lifecycle events, operator labels, and artifact links.
+- Users compare runs and see what changed since the last session.
 
 FUS-005: Configure a measurement code source.
 
@@ -123,14 +149,6 @@ FUS-007: Run through an opt-in SDK runner.
 - Success: the first managed-runner slice does not need queues, resource
   scheduling, retries, or broad workflow DAG execution.
 
-FUS-008: Run like a previous measurement.
-
-- As an experimentalist, I want to start from a previous measurement's scan
-  schema, parameter snapshot, code source, sample/session context, and plot
-  layout so that repeat work is faster without hiding what changed.
-- Success: reused facts are copied by reference or snapshot, and changes are
-  shown before the new run starts.
-
 FUS-009: Compare two measurements.
 
 - As an experimentalist, I want to compare runs by parameters, code, sample,
@@ -144,6 +162,46 @@ FUS-010: See operator handoff.
   that I can trust the lab computer state before starting work.
 - Success: handoff includes parameter ref changes, setup snapshot changes,
   calibration due/expired state, failed runs, imports, exports, and notes.
+
+Managed-run requirements:
+
+- FREQ-006: Managed code provenance records source URI/path, selected revision,
+  dirty state, source hashes where practical, SDK runner entry point, runner
+  invocation, and environment summary.
+- FREQ-007: Fricon shows provenance confidence instead of claiming
+  reproducibility from Git metadata alone.
+- FREQ-008: The first managed-runner slice is SDK runner integration. It
+  captures stdout/stderr excerpts or logs, start/end timestamps, status,
+  abort/fail reason, produced artifacts, and diagnostic warnings.
+- FREQ-009: The first managed-runner slice is not a scheduler. Queues, resource
+  management, retries, and workflow DAG execution are later or ADR-gated.
+- FREQ-010: Run history and compare views are generated from recorded facts:
+  parameters, code, setup, lifecycle events, notes, operator labels, and
+  artifacts.
+
+Not first managed-run slice:
+
+- Scheduler, queues, resource leases, broad retry policy, or workflow DAG.
+- Resumable scan-point execution.
+- Making managed execution mandatory for ordinary exploratory scripts.
+- Treating shell-command wrapping as the primary runner UX.
+
+## Priority 3: Reviewable Automation Workflow
+
+FEPIC-004: Setup And Calibration State Store/Diff.
+
+- Users record setup/device/calibration state as structured snapshots and
+  ledgers.
+- Fricon can diff and bind state to runs without applying settings to devices.
+
+FEPIC-005: Reviewable Automation Workflow.
+
+- Users can preview automation actions before they mutate Fricon state, device
+  state, parameter refs, or calibration records.
+- Automation proposals record intended inputs, expected mutations, affected
+  objects, actor, review outcome, and audit events.
+- Automation grows from parameter system and managed run records instead of
+  becoming an unrelated workflow engine.
 
 FUS-011: Store and diff setup snapshots.
 
@@ -161,60 +219,49 @@ FUS-012: Track calibration state.
 - Success: out-of-tolerance records can flag a review window without silently
   invalidating data.
 
-## Candidate Product Requirements
+FUS-013: Preview an automation workflow.
 
-FREQ-001: The parameter model is a hybrid structured tree. Flexible nodes are
-valid by default, and selected nodes can carry typed definitions, units,
-validation, display hints, and documentation.
+- As an experimentalist, I want a proposed automation workflow to show what it
+  will read, run, and mutate before execution so that hidden state changes do
+  not surprise me.
+- Success: preview separates parameter changes, setup/device changes, managed
+  runs, analysis steps, calibration proposals, and data-library mutations.
 
-FREQ-002: Named parameter refs resolve to immutable snapshots before a managed
-or unmanaged measurement records data.
+FUS-014: Review and apply automation proposals.
 
-FREQ-003: Runtime parameter overrides are recorded separately from profile
-snapshots, with actor, time, source, and optional reason.
+- As a lab maintainer, I want automation proposals to require explicit review
+  before mutating durable lab state so that automation remains accountable.
+- Success: approval, rejection, actor, reason, timestamp, and affected objects
+  are recorded.
 
-FREQ-004: Parameter diffs are path-aware, unit-aware where units exist, and
-can compare profile, proposal, effective run snapshot, and override layers.
+Automation requirements:
 
-FREQ-005: Parameter profile updates use lightweight proposals with source run
-or source snapshot, changed fields, actor, reason, approval/rejection outcome,
-and timestamp. They do not require a permissions system in the first parameter
-workflow slice.
+- FREQ-011: Setup/device/calibration state supports store, bind, search, and
+  diff before any device write-back is implemented.
+- FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
+  separate ADRs covering safety, readback, partial failure, and audit behavior.
+- FREQ-013: Post-MVP improvements remain local-first: no cloud account, hosted
+  dashboard, or central Fricon server is required for core parameter, run, or
+  automation workflows.
+- FREQ-014: Reviewable automation must produce a preview of intended reads,
+  writes, device interactions, generated records, and failure handling before
+  mutation starts.
+- FREQ-015: Automation records must preserve actor, trigger, reviewed plan,
+  accepted or rejected changes, execution status, produced artifacts, and audit
+  events.
 
-FREQ-006: Managed code provenance records source URI/path, selected revision,
-dirty state, source hashes where practical, SDK runner entry point, runner
-invocation, and environment summary.
+Not first automation slice:
 
-FREQ-007: Fricon shows provenance confidence instead of claiming
-reproducibility from Git metadata alone.
+- AI autonomous mutation.
+- Device write-back before store/diff, readback, safety, and partial-failure
+  behavior are accepted by ADR.
+- Generic workflow DAG engine as the normal way to run ordinary measurements.
+- Cloud-first dashboard, account, or team-permission system.
 
-FREQ-008: The first managed-runner slice is SDK runner integration. It captures
-stdout/stderr excerpts or logs, start/end timestamps, status, abort/fail
-reason, produced artifacts, and diagnostic warnings.
+## Supporting Candidates
 
-FREQ-009: The first managed-runner slice is not a scheduler. Queues, resource
-management, retries, and workflow DAG execution are later or ADR-gated.
-
-FREQ-010: Run history and compare views are generated from recorded facts:
-parameters, code, setup, lifecycle events, notes, operator labels, and
-artifacts.
-
-FREQ-011: Setup/device/calibration state supports store, bind, search, and
-diff before any device write-back is implemented.
-
-FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
-separate ADRs covering safety, readback, partial failure, and audit behavior.
-
-FREQ-013: Post-MVP improvements remain local-first: no cloud account, hosted
-dashboard, or central Fricon server is required for core parameter or run
-capture workflows.
-
-## Explicit Non-Goals Until ADR-Gated
-
-- Fricon as a full ELN, LIMS, or compliance system.
-- Fricon as a Git host or broad package manager.
-- Cloud-first experiment tracking dashboards.
-- Model registry, hyperparameter leaderboard, or ML sweep controller concepts
-  as primary product nouns.
-- Device write-back before store/diff is useful and safe.
-- Workflow DAG engine as the normal way to run ordinary measurements.
+- Read-only LAN monitoring for local lab viewing without remote writes.
+- Rich sample fields, 2D sample maps, and saved comparison views.
+- External large asset references for detector files, images, and waveforms.
+- User-facing dataset streams, if internal stream support proves useful enough
+  to expose later.

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -39,6 +39,8 @@ FEPIC-001: Parameter System And Snapshot Binding.
 - The base model is a hybrid parameter tree: flexible structured values first,
   with selected parameters upgraded to typed definitions, units, validation,
   display hints, and UI affordances.
+- Table sections can expose user-defined row keys that later visualization
+  tools can treat as target keys.
 
 FUS-001: Maintain named parameter profiles.
 
@@ -82,6 +84,20 @@ FUS-008: Run like a previous measurement.
 - Success: reused facts are copied by reference or snapshot, and changes are
   shown before the new run starts.
 
+FUS-015: Use parameter row keys as visual targets.
+
+- As an experimentalist, I want parameter table row keys to carry enough
+  user-defined target identity that a sample visualization can locate objects
+  without Fricon imposing a sample-component ontology.
+- Success: a row key can be matched to a user-authored sample-map config, DSL,
+  or lab script when such a view exists.
+- Success: color maps and numeric labels can be derived from parameter snapshot
+  queries, not from hardcoded sample object fields.
+- Success: a visualizer definition can be discoverable near the relevant sample
+  or session without making its shape model part of core sample identity.
+- Success: unmatched or ambiguous keys remain visible as data-quality issues,
+  not hidden failures.
+
 Parameter requirements:
 
 - FREQ-001: The parameter model is a hybrid structured tree. Flexible nodes are
@@ -97,6 +113,13 @@ Parameter requirements:
   or source snapshot, changed fields, actor, reason, approval/rejection
   outcome, and timestamp. They do not require a permissions system in the first
   parameter workflow slice.
+- FREQ-016: Parameter table rows can expose stable, user-defined target keys
+  for visualization and compare views. Fricon must not require those keys to
+  imply a first-class physical sample-component model.
+- FREQ-020: Sample visualizers, when introduced, should be modeled as views
+  over parameter snapshots and snapshot query results. Their storage location,
+  query language, and schema-evolution policy remain deferred until a dedicated
+  spec or ADR.
 
 Not first parameter slice:
 
@@ -104,6 +127,9 @@ Not first parameter slice:
 - Strict global registry for every parameter.
 - Permissions, compliance, or multi-user approval system.
 - Automatic tracing of every parameter read without explicit design.
+- Heavyweight sample-component ontology.
+- Mandatory 2D sample-map authoring.
+- Visualizer schema migration or compatibility policy.
 
 ## Priority 2: Managed Run
 
@@ -113,6 +139,8 @@ FEPIC-002: Managed Code Source And Run Capture.
 - Users can mark importable Python entry points for opt-in Fricon management.
 - Fricon can capture code snapshot, SDK runner entry point, environment
   summary, stdout/stderr, status, diagnostics, and produced artifacts.
+- Fricon can assemble a compact run manifest for compare, handoff, export, and
+  failure investigation.
 - Ordinary interactive unmanaged Python remains possible, but shows lower
   provenance confidence.
 
@@ -163,6 +191,27 @@ FUS-010: See operator handoff.
 - Success: handoff includes parameter ref changes, setup snapshot changes,
   calibration due/expired state, failed runs, imports, exports, and notes.
 
+FUS-016: Inspect a run manifest.
+
+- As an experimentalist, I want a single run manifest that links the
+  measurement, parameter snapshot, row/target keys, code/environment summary,
+  lifecycle, logs, artifacts, operator, and timestamps so that I can understand
+  a run without opening several unrelated stores.
+- Success: the manifest can be opened from Desktop, Python, and export bundles.
+- Success: the manifest states provenance confidence instead of implying that
+  unmanaged work was fully captured.
+
+FUS-017: Investigate a failed fit or anomalous measurement.
+
+- As an experimentalist, I want to follow a suspicious result back to inputs,
+  parameter changes, code/environment state, setup labels, logs, and analysis
+  attempts so that tedious failure investigation is not a manual archaeology
+  task.
+- Success: failed or questionable analysis/fit attempts can be recorded with
+  input artifacts, method/code reference, quality metrics, failure reason, and
+  produced outputs when available.
+- Success: comparison to a previous-good run is generated from recorded facts.
+
 Managed-run requirements:
 
 - FREQ-006: Managed code provenance records source URI/path, selected revision,
@@ -178,6 +227,13 @@ Managed-run requirements:
 - FREQ-010: Run history and compare views are generated from recorded facts:
   parameters, code, setup, lifecycle events, notes, operator labels, and
   artifacts.
+- FREQ-017: A run manifest links the durable measurement identity to parameter
+  snapshot/ref facts, row/target keys when present, code/environment summary,
+  lifecycle/log events, artifacts, operator, timestamps, and provenance
+  confidence.
+- FREQ-018: Analysis or fit attempts can be represented as investigation
+  records with inputs, method/code reference, status, diagnostics, quality
+  metrics, failure reason, and outputs when available.
 
 Not first managed-run slice:
 
@@ -234,6 +290,16 @@ FUS-014: Review and apply automation proposals.
 - Success: approval, rejection, actor, reason, timestamp, and affected objects
   are recorded.
 
+FUS-018: Replay a routine recipe after review.
+
+- As an experimentalist, I want common compare, run, and analyze routines to be
+  captured as reviewable recipes so that repetitive work is faster without
+  hiding what will change.
+- Success: preview shows parameter refs or overrides, code entry point,
+  expected artifacts, analysis steps, and durable mutations before execution.
+- Success: read-only batch compare or triage can be useful before
+  mutation-capable automation exists.
+
 Automation requirements:
 
 - FREQ-011: Setup/device/calibration state supports store, bind, search, and
@@ -249,10 +315,15 @@ Automation requirements:
 - FREQ-015: Automation records must preserve actor, trigger, reviewed plan,
   accepted or rejected changes, execution status, produced artifacts, and audit
   events.
+- FREQ-019: Routine recipes and reviewed replay use parameter snapshots and
+  run manifests as inputs. Read-only compare or triage may run first; mutation
+  requires preview, review, execution status, and audit records.
 
 Not first automation slice:
 
 - AI autonomous mutation.
+- Unreviewed recipe replay that mutates parameters, setup, devices, code
+  sources, or data-library state.
 - Device write-back before store/diff, readback, safety, and partial-failure
   behavior are accepted by ADR.
 - Generic workflow DAG engine as the normal way to run ordinary measurements.
@@ -261,7 +332,8 @@ Not first automation slice:
 ## Supporting Candidates
 
 - Read-only LAN monitoring for local lab viewing without remote writes.
-- Rich sample fields, 2D sample maps, and saved comparison views.
+- User-defined 2D sample-map configs/DSLs that map parameter row keys or user
+  labels to visual regions, plus saved comparison views.
 - External large asset references for detector files, images, and waveforms.
 - User-facing dataset streams, if internal stream support proves useful enough
   to expose later.

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -1,0 +1,30 @@
+# Glossary
+
+## Status
+
+Draft.
+
+## Terms
+
+| Term | Meaning | Public In v0.2? |
+| --- | --- | --- |
+| Data Library | The local Fricon root and catalog for measurements, samples, artifacts, and provenance. | Yes |
+| Workspace | v0.1 user-facing term for a managed directory. In v0.2+, keep only as historical or internal implementation wording unless an ADR says otherwise. | No |
+| Sample | The measured physical object, device, chip, wafer, batch, or specimen. | Yes |
+| Sample Session | A cooldown, mount, probing, campaign, or setup period for a sample. | Yes |
+| Measurement | A data-taking attempt that may produce artifacts and carry context, lifecycle, notes, parameters, and code provenance. | Yes |
+| Dataset Artifact | A table-shaped artifact produced or consumed by work. It owns dataset-local facts and semantics. | Yes |
+| Artifact | A durable input or output linked through provenance. Dataset is the first concrete type. | Mostly advanced |
+| Attachment Artifact | A small file, image, log, or supporting artifact attached to a measurement. | Yes, light |
+| Parameter Snapshot | Immutable parameter facts captured for a measurement. | Yes, minimal |
+| Parameter Profile | A mutable named reference to a useful parameter state. | Later |
+| Code Provenance Summary | Human-readable summary of code context and provenance level. | Yes |
+| Measurement Code Source | Configured upstream source for lab measurement code, such as Git/Gitea, package, mirror, or folder. | Later |
+| Code Snapshot | Immutable resolved code state used by future managed execution. | Later |
+| ActivityRun | Internal shared pattern for measurement, analysis, import, simulation, and calibration work. | No |
+| Analysis | Later work that consumes artifacts and may produce results, reports, or derived datasets. | Later |
+| Calibration | Later reviewable workflow that turns measurements/analysis into parameter proposals or approved updates. | Later |
+| Operator Profile | Lightweight local actor label for mutating actions on a shared lab computer. | Yes, optional |
+| Event/Audit Record | Timeline record for lifecycle, note, correction, system action, or actor-labeled mutation. | Yes |
+| Export Bundle | Read-only portable package for analysis without importing into another data library. | Yes |
+| Experiment | Informal scientific wording or possible future grouping/template. Not the first public acquisition record. | No, informal |

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -17,7 +17,8 @@ Accepted.
   dataset-local facts and semantics.
 - Attachment Artifact: small file, image, log, or supporting artifact attached
   to a measurement.
-- Parameter Snapshot: immutable parameter facts captured for a measurement.
+- Parameter Summary: optional light parameter context recorded for a
+  measurement; not a full profile or effective-configuration model.
 - Code Provenance Summary: human-readable code context and provenance level.
 - Setup Summary: optional passive setup, device, driver, environment, clock, or
   method context; describes, does not control.
@@ -34,6 +35,8 @@ Accepted.
 
 - Artifact: durable input or output linked through provenance. Dataset is the
   first concrete type.
+- Parameter Snapshot: immutable parameter facts captured by future parameter
+  profile or managed-run workflows.
 - Parameter Profile: mutable named reference to a useful parameter state.
 - Measurement Code Source: configured upstream source for lab measurement code,
   such as Git/Gitea, package, mirror, or folder.

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Public v0.2 Terms
 

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -4,7 +4,7 @@
 
 Accepted.
 
-## Public v0.2 Terms
+## Public MVP Terms
 
 - Data Library: local Fricon root and catalog for measurements, samples,
   artifacts, and provenance.
@@ -47,13 +47,14 @@ Accepted.
 - Calibration: later workflow that turns measurements/analysis into parameter
   proposals or approved updates.
 
-## Avoid As Primary v0.2 User Terms
+## Avoid As Primary MVP User Terms
 
-- Workspace: v0.1 user-facing term. In v0.2+, keep only as historical or
-  internal implementation wording unless an ADR says otherwise.
+- Workspace: v0.1 user-facing term. In the clean-reset product model, keep only
+  as historical or internal implementation wording unless an ADR says
+  otherwise.
 - ActivityRun: internal shared pattern for measurement, analysis, import,
   simulation, and calibration work.
 - Stream: internal or advanced substructure for grouped payloads such as
-  primary/baseline data. Not a first v0.2 user-facing concept.
+  primary/baseline data. Not an MVP user-facing concept.
 - Experiment: informal scientific wording or possible future grouping/template,
   not the first public acquisition record.

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -4,30 +4,53 @@
 
 Draft.
 
-## Terms
+## Public v0.2 Terms
 
-| Term | Meaning | Public In v0.2? |
-| --- | --- | --- |
-| Data Library | The local Fricon root and catalog for measurements, samples, artifacts, and provenance. | Yes |
-| Workspace | v0.1 user-facing term for a managed directory. In v0.2+, keep only as historical or internal implementation wording unless an ADR says otherwise. | No |
-| Sample | The measured physical object, device, chip, wafer, batch, or specimen. | Yes |
-| Sample Session | A cooldown, mount, probing, campaign, or setup period for a sample. | Yes |
-| Measurement | A data-taking attempt that may produce artifacts and carry context, lifecycle, notes, parameters, and code provenance. | Yes |
-| Dataset Artifact | A table-shaped artifact produced or consumed by work. It owns dataset-local facts and semantics. | Yes |
-| Artifact | A durable input or output linked through provenance. Dataset is the first concrete type. | Mostly advanced |
-| Attachment Artifact | A small file, image, log, or supporting artifact attached to a measurement. | Yes, light |
-| Parameter Snapshot | Immutable parameter facts captured for a measurement. | Yes, minimal |
-| Parameter Profile | A mutable named reference to a useful parameter state. | Later |
-| Code Provenance Summary | Human-readable summary of code context and provenance level. | Yes |
-| Setup Summary | Optional passive summary of setup, device, driver, environment, clock, or method context. It describes context and does not control devices. | Yes, minimal |
-| Procedure Summary | Optional passive summary of the measurement procedure, such as unmanaged script, external runner, or declared plan context. It does not imply managed execution. | Yes, minimal |
-| Measurement Code Source | Configured upstream source for lab measurement code, such as Git/Gitea, package, mirror, or folder. | Later |
-| Code Snapshot | Immutable resolved code state used by future managed execution. | Later |
-| ActivityRun | Internal shared pattern for measurement, analysis, import, simulation, and calibration work. | No |
-| Analysis | Later work that consumes artifacts and may produce results, reports, or derived datasets. | Later |
-| Calibration | Later reviewable workflow that turns measurements/analysis into parameter proposals or approved updates. | Later |
-| Operator Profile | Lightweight local actor label for mutating actions on a shared lab computer. | Yes, optional |
-| Event/Audit Record | Timeline record for lifecycle, note, correction, system action, or actor-labeled mutation. | Yes |
-| Export Bundle | Read-only portable package for analysis without importing into another data library. | Yes |
-| Stream | Internal or advanced substructure for grouped payloads such as primary/baseline data. Not a first v0.2 user-facing concept. | No |
-| Experiment | Informal scientific wording or possible future grouping/template. Not the first public acquisition record. | No, informal |
+- Data Library: local Fricon root and catalog for measurements, samples,
+  artifacts, and provenance.
+- Sample: measured physical object, device, chip, wafer, batch, or specimen.
+- Sample Session: cooldown, mount, probing, campaign, or setup period for a
+  sample.
+- Measurement: data-taking attempt that may produce artifacts and carry
+  context, lifecycle, notes, parameters, and code provenance.
+- Dataset Artifact: table-shaped artifact produced or consumed by work; owns
+  dataset-local facts and semantics.
+- Attachment Artifact: small file, image, log, or supporting artifact attached
+  to a measurement.
+- Parameter Snapshot: immutable parameter facts captured for a measurement.
+- Code Provenance Summary: human-readable code context and provenance level.
+- Setup Summary: optional passive setup, device, driver, environment, clock, or
+  method context; describes, does not control.
+- Procedure Summary: optional passive procedure context such as unmanaged
+  script, external runner, or declared plan; does not imply managed execution.
+- Operator Profile: lightweight local actor label for mutating actions on a
+  shared lab computer.
+- Event/Audit Record: timeline record for lifecycle, note, correction, system
+  action, or actor-labeled mutation.
+- Export Bundle: read-only portable package for analysis without importing into
+  another data library.
+
+## Later Or Advanced Terms
+
+- Artifact: durable input or output linked through provenance. Dataset is the
+  first concrete type.
+- Parameter Profile: mutable named reference to a useful parameter state.
+- Measurement Code Source: configured upstream source for lab measurement code,
+  such as Git/Gitea, package, mirror, or folder.
+- Code Snapshot: immutable resolved code state used by future managed
+  execution.
+- Analysis: later work that consumes artifacts and may produce results,
+  reports, or derived datasets.
+- Calibration: later workflow that turns measurements/analysis into parameter
+  proposals or approved updates.
+
+## Avoid As Primary v0.2 User Terms
+
+- Workspace: v0.1 user-facing term. In v0.2+, keep only as historical or
+  internal implementation wording unless an ADR says otherwise.
+- ActivityRun: internal shared pattern for measurement, analysis, import,
+  simulation, and calibration work.
+- Stream: internal or advanced substructure for grouped payloads such as
+  primary/baseline data. Not a first v0.2 user-facing concept.
+- Experiment: informal scientific wording or possible future grouping/template,
+  not the first public acquisition record.

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -19,6 +19,8 @@ Draft.
 | Parameter Snapshot | Immutable parameter facts captured for a measurement. | Yes, minimal |
 | Parameter Profile | A mutable named reference to a useful parameter state. | Later |
 | Code Provenance Summary | Human-readable summary of code context and provenance level. | Yes |
+| Setup Summary | Optional passive summary of setup, device, driver, environment, clock, or method context. It describes context and does not control devices. | Yes, minimal |
+| Procedure Summary | Optional passive summary of the measurement procedure, such as unmanaged script, external runner, or declared plan context. It does not imply managed execution. | Yes, minimal |
 | Measurement Code Source | Configured upstream source for lab measurement code, such as Git/Gitea, package, mirror, or folder. | Later |
 | Code Snapshot | Immutable resolved code state used by future managed execution. | Later |
 | ActivityRun | Internal shared pattern for measurement, analysis, import, simulation, and calibration work. | No |
@@ -27,4 +29,5 @@ Draft.
 | Operator Profile | Lightweight local actor label for mutating actions on a shared lab computer. | Yes, optional |
 | Event/Audit Record | Timeline record for lifecycle, note, correction, system action, or actor-labeled mutation. | Yes |
 | Export Bundle | Read-only portable package for analysis without importing into another data library. | Yes |
+| Stream | Internal or advanced substructure for grouped payloads such as primary/baseline data. Not a first v0.2 user-facing concept. | No |
 | Experiment | Informal scientific wording or possible future grouping/template. Not the first public acquisition record. | No, informal |

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -38,14 +38,34 @@ Accepted.
 - Parameter Snapshot: immutable parameter facts captured by future parameter
   profile or managed-run workflows.
 - Parameter Profile: mutable named reference to a useful parameter state.
+- Target Key: user-defined parameter table row key or label that a visualization
+  may use to locate a sample-map element. It is not durable sample identity by
+  itself.
+- Sample Map Config: user-authored JSON or DSL-style description of a 2D sample
+  layout and optional mapping from target keys or labels to visual regions. It
+  may be stored near a sample for discovery, but its schema compatibility rules
+  are a deferred design topic.
+- Sample Visualizer: user-authored view that renders parameter snapshot query
+  results onto a sample map or other lab-specific visualization. Fricon should
+  not assume it understands the physical sample shape.
+- Snapshot Query: later product concept for selecting values from a parameter
+  snapshot to drive labels, color maps, comparisons, or visualizer state.
 - Measurement Code Source: configured upstream source for lab measurement code,
   such as Git/Gitea, package, mirror, or folder.
 - Code Snapshot: immutable resolved code state used by future managed
   execution.
+- Run Manifest: compact immutable summary linking one run to parameters,
+  code/environment context, lifecycle, logs, artifacts, actor, timestamps, and
+  diagnostics.
 - Analysis: later work that consumes artifacts and may produce results,
   reports, or derived datasets.
+- Analysis/Fit Attempt: recorded analysis execution or fit attempt with inputs,
+  method/code reference, status, diagnostics, quality metrics, failure reason,
+  and outputs when available.
 - Calibration: later workflow that turns measurements/analysis into parameter
   proposals or approved updates.
+- Routine Recipe: reviewable description of a repeated compare, run, or analyze
+  routine that can be previewed before replay.
 
 ## Avoid As Primary MVP User Terms
 

--- a/docs-next/product/personas.md
+++ b/docs-next/product/personas.md
@@ -27,14 +27,14 @@ Constraints:
 
 ## P-002 Lab Maintainer
 
-The person who helps keep lab measurement code, setup profiles, and computers
+The person who helps keep lab measurement code, setup context, and computers
 usable.
 
 Needs:
 
 - clear installation and diagnostics
-- explicit split between Fricon install, data-library location, measurement
-  code source, and Python environment
+- explicit split between Fricon install, data-library location, Python
+  environment, and later measurement-code management
 - support for sharing approved measurement code without copying random folders
 - exportable support bundles that are local and redacted by default
 

--- a/docs-next/product/personas.md
+++ b/docs-next/product/personas.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## P-001 Experimentalist
 

--- a/docs-next/product/personas.md
+++ b/docs-next/product/personas.md
@@ -1,0 +1,62 @@
+# Personas
+
+## Status
+
+Draft.
+
+## P-001 Experimentalist
+
+Researchers with entry-level Python ability who run measurement scripts or
+notebooks on lab computers.
+
+Needs:
+
+- low-boilerplate Python recording
+- live feedback while a measurement is running
+- reliable recovery from interrupted runs
+- easy reopening and export for later analysis
+- no requirement to understand Rust, IPC, storage layout, or database internals
+
+Constraints:
+
+- may use Windows lab computers
+- may work on locked-down or offline machines
+- may pin Python environments with `uv.lock`, virtual environments, or lab
+  setup scripts
+- may not update Desktop, service, CLI, and Python SDK together
+
+## P-002 Lab Maintainer
+
+The person who helps keep lab measurement code, setup profiles, and computers
+usable.
+
+Needs:
+
+- clear installation and diagnostics
+- explicit split between Fricon install, data-library location, measurement
+  code source, and Python environment
+- support for sharing approved measurement code without copying random folders
+- exportable support bundles that are local and redacted by default
+
+## P-003 Analyst
+
+The person who reopens completed measurements for notebooks, reports, or HPC
+analysis.
+
+Needs:
+
+- stable IDs and Python reopen snippets
+- direct read access to export bundles
+- metadata and units preserved well enough to understand the data away from the
+  acquisition computer
+
+## P-004 Future Automation Author
+
+A later user or maintainer who builds calibration, managed execution, or
+AI-assisted workflows.
+
+Needs:
+
+- explicit measurement, artifact, parameter, code, and event boundaries
+- audit records for accepted/rejected mutating actions
+- no hidden mutation of completed dataset facts

--- a/docs-next/product/python-sdk-ux.md
+++ b/docs-next/product/python-sdk-ux.md
@@ -26,7 +26,7 @@ concepts:
 - a visible notebook context for the current local library and lab context
 - an interactive unmanaged path for exploratory runs
 - an importable decorated managed-run path for higher provenance
-- concise doAnd-style helpers for routine scans
+- concise doNd-style helpers for routine scans
 - public reopen/export APIs for later analysis
 
 The main ergonomic constraint is low ceremony. Fricon should ask for structure
@@ -51,7 +51,7 @@ into an importable managed-run entry point. The same measurement logic should
 remain normal Python that can be reviewed and tested, but Fricon can run it
 under management when the user opts in.
 
-Routine scans should not force users to build schemas by hand. doAnd-style
+Routine scans should not force users to build schemas by hand. doNd-style
 helpers should make common scan shapes concise while still leaving manual
 writers and raw schema available for advanced or unusual data.
 
@@ -96,7 +96,7 @@ with ctx.measurement("gate sweep") as run:
         data.append(gate=gate, current=dmm.read())
 ```
 
-doAnd-style helper for a routine scan:
+doNd-style helper for a routine scan:
 
 ```python
 result = fc.do2d(

--- a/docs-next/product/python-sdk-ux.md
+++ b/docs-next/product/python-sdk-ux.md
@@ -1,0 +1,142 @@
+# Python SDK Usage Guideline
+
+## Status
+
+Proposed product-level SDK usage guideline.
+
+## Purpose
+
+Capture the Python SDK experience that changes how users think about Fricon,
+without prematurely accepting exact API syntax, parameter-capture mechanics, or
+runner internals.
+
+Most Fricon users will define and execute experiments through Python scripts or
+notebooks. The SDK is therefore a primary product surface. Old code sketches in
+`dev-docs/` should be interpreted as UX sketches unless an ADR accepts exact
+syntax.
+
+This file is intentionally not a detailed API design. It records only the SDK
+shapes that would be expensive to change after users build habits around them.
+
+## Usage Stance
+
+Fricon should feel like ordinary Python with a small number of explicit product
+concepts:
+
+- a visible notebook context for the current local library and lab context
+- an interactive unmanaged path for exploratory runs
+- an importable decorated managed-run path for higher provenance
+- concise doAnd-style helpers for routine scans
+- public reopen/export APIs for later analysis
+
+The main ergonomic constraint is low ceremony. Fricon should ask for structure
+only where it changes user understanding: which context is active, whether a
+run is unmanaged or managed, what scan shape should be plotted, and how results
+are reopened later.
+
+## Expected Running Model
+
+Users should be able to start from an ordinary Python session, not from a new
+framework runtime. A notebook or script should first establish a visible Fricon
+context for the local library and optional lab context. That context is cheap
+to keep around, inspect, reset, and pass explicitly.
+
+The default exploratory path is unmanaged: the user's Python process remains in
+control, and Fricon records measurements, datasets, notes, lifecycle, and
+honest provenance as the script runs. This keeps notebooks, debugging, and
+manual device work natural.
+
+When users want higher provenance, they should be able to move selected code
+into an importable managed-run entry point. The same measurement logic should
+remain normal Python that can be reviewed and tested, but Fricon can run it
+under management when the user opts in.
+
+Routine scans should not force users to build schemas by hand. doAnd-style
+helpers should make common scan shapes concise while still leaving manual
+writers and raw schema available for advanced or unusual data.
+
+## Low-Ceremony Expectations
+
+Every public example should be readable as ordinary Python. Fricon-specific
+ceremony should be justified by one of these user-visible benefits:
+
+- selecting or inspecting the current library and lab context
+- creating a real measurement rather than a loose file or anonymous table
+- declaring scan shape so live and historical plots know what the axes mean
+- choosing unmanaged versus managed execution honestly
+- reopening or exporting results through stable public APIs
+
+Boilerplate that exists only for transport, storage layout, service startup,
+local tokens, object graph construction, or future parameter machinery should
+stay out of first-contact examples.
+
+## Illustrative Sketches
+
+These sketches are non-binding. They show the desired user feel, not accepted
+names, signatures, decorators, or object models.
+
+Interactive notebook setup:
+
+```python
+import fricon as fc
+
+ctx = fc.open("lab-library")
+ctx.use_sample("sample-a")
+ctx
+```
+
+Interactive unmanaged measurement:
+
+```python
+with ctx.measurement("gate sweep") as run:
+    data = run.scan1d("gate", values=gate_values, y="current")
+
+    for gate in gate_values:
+        dac.set_gate(gate)
+        data.append(gate=gate, current=dmm.read())
+```
+
+doAnd-style helper for a routine scan:
+
+```python
+result = fc.do2d(
+    ctx,
+    x=("gate", gate_values, dac.set_gate),
+    y=("bias", bias_values, dac.set_bias),
+    measure={"current": dmm.read},
+    title="gate-bias map",
+)
+```
+
+Importable managed-run entry point:
+
+```python
+import fricon as fc
+
+@fc.managed_run
+def gate_sweep(ctx, gate_values):
+    with ctx.measurement("gate sweep") as run:
+        data = run.scan1d("gate", values=gate_values, y="current")
+        for gate in gate_values:
+            dac.set_gate(gate)
+            data.append(gate=gate, current=dmm.read())
+```
+
+## Deferred Detail
+
+Do not settle these in this guideline:
+
+- exact Python names, decorator syntax, context-manager syntax, or function
+  signatures
+- parameter binding, parameter capture, override, or snapshot mechanics
+- code snapshot format, environment capture details, stdout/stderr handling, or
+  managed-run lifecycle protocol
+- dataset-writer object model, storage layout, service transport, or local
+  token mechanics
+- full scan-schema representation beyond the need for concise helper UX and a
+  raw escape hatch
+- scheduler, resource leases, queues, retries, workflow DAGs, or resume
+  protocols
+
+Those decisions belong in later ADRs, specs, or implementation design after the
+product-level usage guideline is stable.

--- a/docs-next/product/python-sdk-ux.md
+++ b/docs-next/product/python-sdk-ux.md
@@ -26,13 +26,18 @@ concepts:
 - a visible notebook context for the current local library and lab context
 - an interactive unmanaged path for exploratory runs
 - an importable decorated managed-run path for higher provenance
-- concise doNd-style helpers for routine scans
+- Python-native scan-plan authoring for routine scans
 - public reopen/export APIs for later analysis
 
 The main ergonomic constraint is low ceremony. Fricon should ask for structure
 only where it changes user understanding: which context is active, whether a
 run is unmanaged or managed, what scan shape should be plotted, and how results
 are reopened later.
+
+For common workflows, Fricon should provide appropriate simplification without
+pretending the right simplification is known before use. The exact API shape
+should be refined from real script and notebook experience, while this
+guideline preserves the product intent.
 
 ## Expected Running Model
 
@@ -51,9 +56,14 @@ into an importable managed-run entry point. The same measurement logic should
 remain normal Python that can be reviewed and tested, but Fricon can run it
 under management when the user opts in.
 
-Routine scans should not force users to build schemas by hand. doNd-style
-helpers should make common scan shapes concise while still leaving manual
+Routine scans should not force users to build schemas by hand. A Python-native
+scan plan should make common scan shapes concise while still leaving manual
 writers and raw schema available for advanced or unusual data.
+
+The product requirement is the low-ceremony scan-plan experience, not a
+specific helper name or a QCoDeS-style parameter-object model. A plan may be
+dict/literal-friendly, a small helper object, a function wrapper, or a mix of
+these after usage feedback and API design are accepted.
 
 ## Low-Ceremony Expectations
 
@@ -96,15 +106,19 @@ with ctx.measurement("gate sweep") as run:
         data.append(gate=gate, current=dmm.read())
 ```
 
-doNd-style helper for a routine scan:
+Python-native scan-plan sketch:
 
 ```python
-result = fc.do2d(
+result = fc.run_scan(
     ctx,
-    x=("gate", gate_values, dac.set_gate),
-    y=("bias", bias_values, dac.set_bias),
-    measure={"current": dmm.read},
     title="gate-bias map",
+    plan={
+        "axes": [
+            {"name": "gate", "values": gate_values, "set": dac.set_gate},
+            {"name": "bias", "values": bias_values, "set": dac.set_bias},
+        ],
+        "measure": {"current": dmm.read},
+    },
 )
 ```
 
@@ -133,8 +147,10 @@ Do not settle these in this guideline:
   managed-run lifecycle protocol
 - dataset-writer object model, storage layout, service transport, or local
   token mechanics
-- full scan-schema representation beyond the need for concise helper UX and a
-  raw escape hatch
+- full scan-schema representation beyond the need for concise scan-plan UX and
+  a raw escape hatch
+- a QCoDeS compatibility layer, fixed borrowed helper name, or
+  parameter-object model
 - scheduler, resource leases, queues, retries, workflow DAGs, or resume
   protocols
 

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -7,7 +7,8 @@ Accepted.
 ## Purpose
 
 Keep the product route readable for future AI sessions. This file is a compact
-map, not the place for full acceptance details.
+map from the product vision to v0.2 stories, not the place for full acceptance
+details.
 
 ## Backbone
 
@@ -25,6 +26,11 @@ Install and set up
 ```
 
 ## v0.2 Product Epics
+
+The v0.2 MVP route is the LabRAD Data Vault/Grapher replacement loop for new
+measurements: write from Python, watch live, recover partial data, reopen, and
+export. The epics below divide that route without making legacy import or
+managed automation part of the MVP.
 
 - EPIC-001: Local setup and data-library adoption.
 - EPIC-002: New measurement logging replacement.
@@ -53,7 +59,7 @@ Foundation:
 
 Measurement loop:
 
-- US-003: Run an exploratory measurement from Python.
+- US-003: Run an interactive unmanaged measurement from Python.
 - US-004: Produce dataset artifacts from a measurement.
 - US-005: Watch and inspect live data.
 - US-015: Declare common scan shapes quickly.
@@ -90,8 +96,13 @@ files concise: they own story-level success criteria, not implementation tasks.
 
 ## Sequencing
 
-M1 should prove enough of US-001 through US-008 to record, inspect, recover, and
-reopen a measurement while preserving first-class dataset discovery.
+M1 should prove enough of US-001 through US-008 and US-015 to record, inspect,
+recover, and reopen a Python measurement while preserving first-class dataset
+discovery.
+
+The full v0.2 MVP also needs US-009 for export and US-017/US-018 to validate
+the incremental adoption posture: users can translate new Data Vault-style
+scripts and keep old history in the old system.
 
 Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -1,0 +1,43 @@
+# Story Map
+
+## Status
+
+Draft.
+
+## Backbone
+
+```text
+Install and set up
+  -> create/open data library
+  -> select optional sample/session context
+  -> run Python measurement
+  -> record dataset artifacts
+  -> inspect live
+  -> finish/recover
+  -> annotate
+  -> reopen in Python
+  -> export
+```
+
+## v0.2 User Stories
+
+| ID | Persona | Story | Related Capabilities | Acceptance Notes |
+| --- | --- | --- | --- | --- |
+| US-001 | Experimentalist | Install and launch Fricon on a lab computer. | CAP-001, CAP-002, CAP-013 | Desktop, CLI, service, and Python SDK compatibility is explained; Desktop can start local mode; Python can diagnose service discovery. |
+| US-002 | Experimentalist | Create or open one local data library. | CAP-001, CAP-012 | First-run setup asks for location, creates UUID/display name, and does not hide experimental data without consent. |
+| US-003 | Experimentalist | Run an exploratory measurement from Python. | CAP-003, CAP-004, CAP-014, CAP-015 | Measurement creation is explicit and short; sample/session is optional; multiple local writers are isolated. |
+| US-004 | Experimentalist | Produce dataset artifacts from a measurement. | CAP-005, CAP-006 | Dataset writers share measurement lifecycle; plotted data declares roles and axes. |
+| US-005 | Experimentalist | Watch and inspect live data. | CAP-007 | Console shows active and recent measurements; live views cannot block writes. |
+| US-006 | Experimentalist | Recover a partial measurement. | CAP-008, CAP-012 | Completed facts remain readable; rerun creates a new linked measurement by default; resume requires explicit checks. |
+| US-007 | Experimentalist | Annotate at the right level. | CAP-009, CAP-017 | Favorites/pins and notes attach to measurement/sample/session by default; dataset notes are for local exceptions. |
+| US-008 | Analyst | Reopen measurement outputs from Python. | CAP-010 | Snippets use stable IDs and public SDK APIs, not storage paths. |
+| US-009 | Analyst | Export a measurement for offline analysis. | CAP-011 | Export includes datasets, selected metadata, checksums, and Python loader information; sensitive provenance is previewed or opt-in. |
+| US-010 | Lab Maintainer | Update without corrupting measurement work. | CAP-012, CAP-013 | Updates and migrations check idle state, fail before writes on incompatibility, and create checkpoints where practical. |
+| US-011 | Lab Maintainer | Record code provenance honestly. | CAP-014, CAP-020 | Non-managed code is marked unmanaged unless the user supplies a label; future managed snapshots are reserved. |
+| US-012 | Experimentalist | Register a sample and sample session when useful. | CAP-004, CAP-019 | Sample/session context is low-friction, visible, and correctable after a run. |
+
+## Sequencing
+
+M1 foundation should prove US-001 through US-008 enough to record, inspect, and
+reopen a measurement. Export, backup/restore polish, and update flows may start
+as explicit contracts before full UX polish.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -93,5 +93,9 @@ files concise: they own story-level success criteria, not implementation tasks.
 M1 should prove enough of US-001 through US-008 to record, inspect, recover, and
 reopen a measurement while preserving first-class dataset discovery.
 
+Python SDK UX is part of the product story, not only implementation detail.
+The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;
+detailed API signatures and capture mechanics belong in later ADRs/specs.
+
 SPEC-002 owns the export/offline-analysis details. Export remains a v0.2
 product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -36,6 +36,15 @@ Detailed epic notes live under `product/epics/`.
 
 ## v0.2 Story Index
 
+Ownership rules:
+
+- Epics own outcomes. A story may affect another epic, but it should have only
+  one primary owner.
+- Keep this index compact. Story-level success criteria live under
+  `product/user-stories/`.
+- Each expanded story file names its primary epic.
+- Put implementation acceptance detail in specs, not in this map.
+
 Foundation:
 
 - US-001: Install and launch Fricon on a lab computer.
@@ -69,8 +78,15 @@ Migration:
 - US-017: Migrate a Data Vault-style script to Fricon writers.
 - US-018: Start new work in Fricon while old history stays in the old system.
 
-Expanded story files live under `product/user-stories/` only when the story is
-important enough to guide product or implementation decisions.
+Migration ownership:
+
+- US-017 is owned by EPIC-005. It pressures EPIC-002 writer ergonomics but does
+  not make EPIC-002 responsible for old-system import.
+- US-018 is owned by EPIC-005. EPIC-004 owns reopen/export for Fricon data, not
+  the product migration posture.
+
+Each v0.2 story has an expanded file under `product/user-stories/`. Keep those
+files concise: they own story-level success criteria, not implementation tasks.
 
 ## Sequencing
 

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -7,7 +7,7 @@ Accepted.
 ## Purpose
 
 Keep the product route readable for future AI sessions. This file is a compact
-map from the product vision to v0.2 stories, not the place for full acceptance
+map from the product vision to MVP stories, not the place for full acceptance
 details.
 
 ## Backbone
@@ -25,9 +25,9 @@ Install and set up
   -> export
 ```
 
-## v0.2 Product Epics
+## MVP Product Epics
 
-The v0.2 MVP route is the LabRAD Data Vault/Grapher replacement loop for new
+The MVP route is the LabRAD Data Vault/Grapher replacement loop for new
 measurements: write from Python, watch live, recover partial data, reopen, and
 export. The epics below divide that route without making legacy import or
 managed automation part of the MVP.
@@ -40,7 +40,7 @@ managed automation part of the MVP.
 
 Detailed epic notes live under `product/epics/`.
 
-## v0.2 Story Index
+## MVP Story Index
 
 Ownership rules:
 
@@ -91,7 +91,7 @@ Migration ownership:
 - US-018 is owned by EPIC-005. EPIC-004 owns reopen/export for Fricon data, not
   the product migration posture.
 
-Each v0.2 story has an expanded file under `product/user-stories/`. Keep those
+Each MVP story has an expanded file under `product/user-stories/`. Keep those
 files concise: they own story-level success criteria, not implementation tasks.
 
 ## Sequencing
@@ -100,13 +100,13 @@ M1 should prove enough of US-001 through US-008 and US-015 to record, inspect,
 recover, and reopen a Python measurement while preserving first-class dataset
 discovery.
 
-The full v0.2 MVP also needs US-009 for export and US-017/US-018 to validate
-the incremental adoption posture: users can translate new Data Vault-style
-scripts and keep old history in the old system.
+The full MVP also needs US-009 for export and US-017/US-018 to validate the
+incremental adoption posture: users can translate new Data Vault-style scripts
+and keep old history in the old system.
 
 Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;
 detailed API signatures and capture mechanics belong in later ADRs/specs.
 
-SPEC-002 owns the export/offline-analysis details. Export remains a v0.2
+SPEC-002 owns the export/offline-analysis details. Export remains an MVP
 product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -35,9 +35,15 @@ Install and set up
 | US-010 | Lab Maintainer | Update without corrupting measurement work. | CAP-012, CAP-013 | Updates and migrations check idle state, fail before writes on incompatibility, and create checkpoints where practical. |
 | US-011 | Lab Maintainer | Record code provenance honestly. | CAP-014, CAP-020 | Non-managed code is marked unmanaged unless the user supplies a label; future managed snapshots are reserved. |
 | US-012 | Experimentalist | Register a sample and sample session when useful. | CAP-004, CAP-019 | Sample/session context is low-friction, visible, and correctable after a run. |
+| US-013 | Analyst | Find and open a dataset artifact directly. | CAP-005, CAP-010, CAP-026 | Dataset artifacts are searchable/openable by ID, title, source alias, measurement, time, and context when available. |
+| US-014 | Experimentalist | Record passive setup context. | CAP-014, CAP-027 | A measurement can include setup/method labels and optional passive device/environment summaries without device control. |
+| US-015 | Experimentalist | Declare common scan shapes quickly. | CAP-006, CAP-028 | Common 1D/2D/N-D scans and traces have helpers; advanced users can provide raw schema. |
+| US-016 | Experimentalist | Record passive procedure context. | CAP-014, CAP-029 | A measurement can record unmanaged script, external runner, or declared-plan summary without managed execution. |
 
 ## Sequencing
 
 M1 foundation should prove US-001 through US-008 enough to record, inspect, and
-reopen a measurement. Export, backup/restore polish, and update flows may start
-as explicit contracts before full UX polish.
+reopen a measurement, while preserving first-class dataset discovery. Export,
+backup/restore polish, and update flows may start as explicit contracts before
+full UX polish. Measurement-centered export should be split into a near-term
+SPEC-002 rather than hidden inside the foundation spec.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Purpose
 

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -4,6 +4,11 @@
 
 Draft.
 
+## Purpose
+
+Keep the product route readable for future AI sessions. This file is a compact
+map, not the place for full acceptance details.
+
 ## Backbone
 
 ```text
@@ -19,31 +24,58 @@ Install and set up
   -> export
 ```
 
-## v0.2 User Stories
+## v0.2 Product Epics
 
-| ID | Persona | Story | Related Capabilities | Acceptance Notes |
-| --- | --- | --- | --- | --- |
-| US-001 | Experimentalist | Install and launch Fricon on a lab computer. | CAP-001, CAP-002, CAP-013 | Desktop, CLI, service, and Python SDK compatibility is explained; Desktop can start local mode; Python can diagnose service discovery. |
-| US-002 | Experimentalist | Create or open one local data library. | CAP-001, CAP-012 | First-run setup asks for location, creates UUID/display name, and does not hide experimental data without consent. |
-| US-003 | Experimentalist | Run an exploratory measurement from Python. | CAP-003, CAP-004, CAP-014, CAP-015 | Measurement creation is explicit and short; sample/session is optional; multiple local writers are isolated. |
-| US-004 | Experimentalist | Produce dataset artifacts from a measurement. | CAP-005, CAP-006 | Dataset writers share measurement lifecycle; plotted data declares roles and axes. |
-| US-005 | Experimentalist | Watch and inspect live data. | CAP-007 | Console shows active and recent measurements; live views cannot block writes. |
-| US-006 | Experimentalist | Recover a partial measurement. | CAP-008, CAP-012 | Completed facts remain readable; rerun creates a new linked measurement by default; resume requires explicit checks. |
-| US-007 | Experimentalist | Annotate at the right level. | CAP-009, CAP-017 | Favorites/pins and notes attach to measurement/sample/session by default; dataset notes are for local exceptions. |
-| US-008 | Analyst | Reopen measurement outputs from Python. | CAP-010 | Snippets use stable IDs and public SDK APIs, not storage paths. |
-| US-009 | Analyst | Export a measurement for offline analysis. | CAP-011 | Export includes datasets, selected metadata, checksums, and Python loader information; sensitive provenance is previewed or opt-in. |
-| US-010 | Lab Maintainer | Update without corrupting measurement work. | CAP-012, CAP-013 | Updates and migrations check idle state, fail before writes on incompatibility, and create checkpoints where practical. |
-| US-011 | Lab Maintainer | Record code provenance honestly. | CAP-014, CAP-020 | Non-managed code is marked unmanaged unless the user supplies a label; future managed snapshots are reserved. |
-| US-012 | Experimentalist | Register a sample and sample session when useful. | CAP-004, CAP-019 | Sample/session context is low-friction, visible, and correctable after a run. |
-| US-013 | Analyst | Find and open a dataset artifact directly. | CAP-005, CAP-010, CAP-026 | Dataset artifacts are searchable/openable by ID, title, source alias, measurement, time, and context when available. |
-| US-014 | Experimentalist | Record passive setup context. | CAP-014, CAP-027 | A measurement can include setup/method labels and optional passive device/environment summaries without device control. |
-| US-015 | Experimentalist | Declare common scan shapes quickly. | CAP-006, CAP-028 | Common 1D/2D/N-D scans and traces have helpers; advanced users can provide raw schema. |
-| US-016 | Experimentalist | Record passive procedure context. | CAP-014, CAP-029 | A measurement can record unmanaged script, external runner, or declared-plan summary without managed execution. |
+- EPIC-001: Local setup and data-library adoption.
+- EPIC-002: New measurement logging replacement.
+- EPIC-003: Measurement console and inspection.
+- EPIC-004: Recovery, annotation, reopen, and export.
+- EPIC-005: Migration ergonomics and future lab scaling.
+
+Detailed epic notes live under `product/epics/`.
+
+## v0.2 Story Index
+
+Foundation:
+
+- US-001: Install and launch Fricon on a lab computer.
+- US-002: Create or open one local data library.
+- US-010: Update without corrupting measurement work.
+
+Measurement loop:
+
+- US-003: Run an exploratory measurement from Python.
+- US-004: Produce dataset artifacts from a measurement.
+- US-005: Watch and inspect live data.
+- US-015: Declare common scan shapes quickly.
+
+Context and provenance:
+
+- US-007: Annotate at the right level.
+- US-011: Record code provenance honestly.
+- US-012: Register a sample and sample session when useful.
+- US-014: Record passive setup context.
+- US-016: Record passive procedure context.
+
+Recovery and analysis:
+
+- US-006: Recover a partial measurement.
+- US-008: Reopen measurement outputs from Python.
+- US-009: Export a measurement for offline analysis.
+- US-013: Find and open a dataset artifact directly.
+
+Migration:
+
+- US-017: Migrate a Data Vault-style script to Fricon writers.
+- US-018: Start new work in Fricon while old history stays in the old system.
+
+Expanded story files live under `product/user-stories/` only when the story is
+important enough to guide product or implementation decisions.
 
 ## Sequencing
 
-M1 foundation should prove US-001 through US-008 enough to record, inspect, and
-reopen a measurement, while preserving first-class dataset discovery. Export,
-backup/restore polish, and update flows may start as explicit contracts before
-full UX polish. Measurement-centered export should be split into a near-term
-SPEC-002 rather than hidden inside the foundation spec.
+M1 should prove enough of US-001 through US-008 to record, inspect, recover, and
+reopen a measurement while preserving first-class dataset discovery.
+
+SPEC-002 owns the export/offline-analysis details. Export remains a v0.2
+product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/story-module-matrix.md
+++ b/docs-next/product/story-module-matrix.md
@@ -1,0 +1,35 @@
+# Story Module Matrix
+
+## Status
+
+Draft traceability baseline.
+
+## Module Legend
+
+| Module | Meaning |
+| --- | --- |
+| Core Domain | Rust domain/application model under `crates/fricon/src/**` after reset. |
+| Storage | SQLite/catalog, payload storage, manifests, migrations. |
+| Service API | Local service HTTP/WebSocket/binary endpoints and compatibility negotiation. |
+| Python SDK | `crates/fricon-py` user-facing Python APIs and bindings. |
+| Desktop UI | Tauri shell plus React frontend. |
+| CLI | Setup, diagnostics, service control, developer workflows. |
+| Export | Portable bundle writer/reader and offline viewer path. |
+| Docs | Public docs, docs-next, and migration guidance. |
+
+## Matrix
+
+| Story | Core Domain | Storage | Service API | Python SDK | Desktop UI | CLI | Export | Docs |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| US-001 Install and launch | X |  | X | X | X | X |  | X |
+| US-002 Create/open data library | X | X | X | X | X | X |  | X |
+| US-003 Run measurement | X | X | X | X | X |  |  | X |
+| US-004 Produce dataset artifacts | X | X | X | X | X |  | X | X |
+| US-005 Watch live data | X | X | X |  | X |  |  | X |
+| US-006 Recover partial measurement | X | X | X | X | X | X | X | X |
+| US-007 Annotate at right level | X | X | X | X | X |  | X | X |
+| US-008 Reopen from Python | X | X | X | X |  |  | X | X |
+| US-009 Export measurement | X | X | X | X | X | X | X | X |
+| US-010 Update safely | X | X | X | X | X | X |  | X |
+| US-011 Code provenance | X | X | X | X | X | X | X | X |
+| US-012 Sample/session | X | X | X | X | X |  | X | X |

--- a/docs-next/product/story-module-matrix.md
+++ b/docs-next/product/story-module-matrix.md
@@ -1,39 +1,44 @@
-# Story Module Matrix
+# Story Module Traceability
 
 ## Status
 
-Draft traceability baseline.
+Draft traceability guide.
+
+## Purpose
+
+Avoid a large story-by-module table. Use this file to route future work to the
+right code areas at epic level. Specs own precise task/file traceability.
 
 ## Module Legend
 
-| Module | Meaning |
-| --- | --- |
-| Core Domain | Rust domain/application model under `crates/fricon/src/**` after reset. |
-| Storage | SQLite/catalog, payload storage, manifests, migrations. |
-| Service API | Local service HTTP/WebSocket/binary endpoints and compatibility negotiation. |
-| Python SDK | `crates/fricon-py` user-facing Python APIs and bindings. |
-| Desktop UI | Tauri shell plus React frontend. |
-| CLI | Setup, diagnostics, service control, developer workflows. |
-| Export | Portable bundle writer/reader and offline viewer path. |
-| Docs | Public docs, docs-next, and migration guidance. |
+- Core Domain: Rust domain/application model under `crates/fricon/src/**`.
+- Storage: catalog, payload storage, manifests, migrations.
+- Service API: local service API, events, compatibility negotiation.
+- Python SDK: `crates/fricon-py`.
+- Desktop UI: Tauri shell and React frontend.
+- CLI: setup, diagnostics, service control.
+- Export: portable bundle writer/reader and offline viewer path.
+- Docs: `docs-next/`, future public docs, and migration guidance.
 
-## Matrix
+## Epic Routing
 
-| Story | Core Domain | Storage | Service API | Python SDK | Desktop UI | CLI | Export | Docs |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| US-001 Install and launch | X |  | X | X | X | X |  | X |
-| US-002 Create/open data library | X | X | X | X | X | X |  | X |
-| US-003 Run measurement | X | X | X | X | X |  |  | X |
-| US-004 Produce dataset artifacts | X | X | X | X | X |  | X | X |
-| US-005 Watch live data | X | X | X |  | X |  |  | X |
-| US-006 Recover partial measurement | X | X | X | X | X | X | X | X |
-| US-007 Annotate at right level | X | X | X | X | X |  | X | X |
-| US-008 Reopen from Python | X | X | X | X |  |  | X | X |
-| US-009 Export measurement | X | X | X | X | X | X | X | X |
-| US-010 Update safely | X | X | X | X | X | X |  | X |
-| US-011 Code provenance | X | X | X | X | X | X | X | X |
-| US-012 Sample/session | X | X | X | X | X |  | X | X |
-| US-013 Dataset direct open | X | X | X | X | X |  | X | X |
-| US-014 Passive setup context | X | X | X | X | X | X | X | X |
-| US-015 Scan schema helpers | X | X | X | X | X |  | X | X |
-| US-016 Passive procedure context | X | X | X | X | X | X | X | X |
+EPIC-001 Local setup and data-library adoption:
+Core Domain, Storage, Service API, Python SDK, Desktop UI, CLI, Docs.
+
+EPIC-002 New measurement logging replacement:
+Core Domain, Storage, Service API, Python SDK, Desktop UI, Docs.
+
+EPIC-003 Measurement console and inspection:
+Core Domain, Service API, Desktop UI, Python SDK for reopen snippets, Docs.
+
+EPIC-004 Recovery, annotation, reopen, and export:
+Core Domain, Storage, Service API, Python SDK, Desktop UI, Export, Docs.
+
+EPIC-005 Migration ergonomics and future lab scaling:
+Python SDK, Desktop UI, Docs, then later Service API, CLI, and Export as
+migration helpers mature.
+
+## Rule
+
+When a story becomes implementation-ready, add precise traceability in the
+owning spec instead of expanding this file into a matrix.

--- a/docs-next/product/story-module-matrix.md
+++ b/docs-next/product/story-module-matrix.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft traceability guide.
+Accepted traceability guide.
 
 ## Purpose
 

--- a/docs-next/product/story-module-matrix.md
+++ b/docs-next/product/story-module-matrix.md
@@ -33,3 +33,7 @@ Draft traceability baseline.
 | US-010 Update safely | X | X | X | X | X | X |  | X |
 | US-011 Code provenance | X | X | X | X | X | X | X | X |
 | US-012 Sample/session | X | X | X | X | X |  | X | X |
+| US-013 Dataset direct open | X | X | X | X | X |  | X | X |
+| US-014 Passive setup context | X | X | X | X | X | X | X | X |
+| US-015 Scan schema helpers | X | X | X | X | X |  | X | X |
+| US-016 Passive procedure context | X | X | X | X | X | X | X | X |

--- a/docs-next/product/user-stories/US-001-install-and-launch.md
+++ b/docs-next/product/user-stories/US-001-install-and-launch.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-001-install-and-launch.md
+++ b/docs-next/product/user-stories/US-001-install-and-launch.md
@@ -4,21 +4,31 @@
 
 Draft.
 
+## Primary Epic
+
+EPIC-001: Local setup and data-library adoption.
+
 ## Story
 
 As an experimentalist, I want one clear way to install and launch Fricon on a
 lab computer so that I can open Fricon Desktop and use the Python SDK against a
 local data library without assembling incompatible pieces by hand.
 
-## Acceptance Notes
+## Success Criteria
 
-- Fricon Desktop, bundled service, bundled CLI, and Python SDK compatibility is
-  visible.
+- Fricon Desktop, bundled service, bundled CLI, and Python SDK compatibility are
+  visible as one product set.
 - First-run setup asks for the data-library location.
 - Python scripts can run headlessly when Desktop is closed.
 - Diagnostics explain stopped service, wrong library, locked library, old SDK,
   incompatible service, or migration-required states.
 
-## Related
+## Not In Scope
 
-CAP-001, CAP-002, CAP-013.
+- Hosted service, multi-user administration, or direct shared-folder database
+  editing.
+- Enterprise deployment polish before the local loop works.
+
+## Related Capabilities / Specs
+
+CAP-001, CAP-002, CAP-013, SPEC-001.

--- a/docs-next/product/user-stories/US-001-install-and-launch.md
+++ b/docs-next/product/user-stories/US-001-install-and-launch.md
@@ -1,0 +1,24 @@
+# US-001: Install And Launch Fricon
+
+## Status
+
+Draft.
+
+## Story
+
+As an experimentalist, I want one clear way to install and launch Fricon on a
+lab computer so that I can open Fricon Desktop and use the Python SDK against a
+local data library without assembling incompatible pieces by hand.
+
+## Acceptance Notes
+
+- Fricon Desktop, bundled service, bundled CLI, and Python SDK compatibility is
+  visible.
+- First-run setup asks for the data-library location.
+- Python scripts can run headlessly when Desktop is closed.
+- Diagnostics explain stopped service, wrong library, locked library, old SDK,
+  incompatible service, or migration-required states.
+
+## Related
+
+CAP-001, CAP-002, CAP-013.

--- a/docs-next/product/user-stories/US-002-create-open-data-library.md
+++ b/docs-next/product/user-stories/US-002-create-open-data-library.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-002-create-open-data-library.md
+++ b/docs-next/product/user-stories/US-002-create-open-data-library.md
@@ -1,0 +1,35 @@
+# US-002: Create Or Open One Local Data Library
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-001: Local setup and data-library adoption.
+
+## Story
+
+As an experimentalist, I want to create or open one local Fricon data library
+for my lab computer so that measurements, datasets, notes, and context have a
+durable home.
+
+## Success Criteria
+
+- A new library gets a durable identity, display name, remembered location, and
+  format version.
+- Opening an existing library verifies identity and compatibility before any
+  mutation.
+- Recent-library selection is clear enough to avoid writing into the wrong
+  place.
+- Locked, unsupported, or migration-required libraries produce actionable
+  diagnostics.
+
+## Not In Scope
+
+- Multiple writers directly editing the same shared-folder database.
+- Hosted or account-based library ownership.
+
+## Related Capabilities / Specs
+
+CAP-001, CAP-012, CAP-013, SPEC-001.

--- a/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
+++ b/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
+++ b/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
@@ -4,13 +4,17 @@
 
 Draft.
 
+## Primary Epic
+
+EPIC-002: New measurement logging replacement.
+
 ## Story
 
 As an experimentalist, I want to run a measurement from Python with minimal
 boilerplate so that Fricon records the measurement, produced datasets, optional
 sample/session context, and basic provenance.
 
-## Acceptance Notes
+## Success Criteria
 
 - Measurement creation is explicit but short.
 - Sample/session context is optional and visible.
@@ -18,6 +22,11 @@ sample/session context, and basic provenance.
 - Multiple local measurement writers may be active concurrently.
 - A crashed script leaves readable partial data.
 
-## Related
+## Not In Scope
 
-CAP-003, CAP-004, CAP-005, CAP-008.
+- Managed runner, task queue, visual sweep builder, or device control.
+- Automatic notebook state capture.
+
+## Related Capabilities / Specs
+
+CAP-003, CAP-004, CAP-005, CAP-008, SPEC-001.

--- a/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
+++ b/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
@@ -1,0 +1,23 @@
+# US-003: Run An Exploratory Measurement
+
+## Status
+
+Draft.
+
+## Story
+
+As an experimentalist, I want to run a measurement from Python with minimal
+boilerplate so that Fricon records the measurement, produced datasets, optional
+sample/session context, and basic provenance.
+
+## Acceptance Notes
+
+- Measurement creation is explicit but short.
+- Sample/session context is optional and visible.
+- Dataset writers share measurement lifecycle in the normal path.
+- Multiple local measurement writers may be active concurrently.
+- A crashed script leaves readable partial data.
+
+## Related
+
+CAP-003, CAP-004, CAP-005, CAP-008.

--- a/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
+++ b/docs-next/product/user-stories/US-003-run-exploratory-measurement.md
@@ -1,4 +1,4 @@
-# US-003: Run An Exploratory Measurement
+# US-003: Run An Interactive Unmanaged Measurement
 
 ## Status
 
@@ -10,14 +10,16 @@ EPIC-002: New measurement logging replacement.
 
 ## Story
 
-As an experimentalist, I want to run a measurement from Python with minimal
-boilerplate so that Fricon records the measurement, produced datasets, optional
-sample/session context, and basic provenance.
+As an experimentalist, I want to run an interactive unmanaged measurement from
+ordinary Python with minimal boilerplate so that Fricon records the measurement,
+produced datasets, optional sample/session context, and honest provenance.
 
 ## Success Criteria
 
 - Measurement creation is explicit but short.
 - Sample/session context is optional and visible.
+- The normal exploratory path does not require Fricon to manage the Python
+  process.
 - Dataset writers share measurement lifecycle in the normal path.
 - Multiple local measurement writers may be active concurrently.
 - A crashed script leaves readable partial data.

--- a/docs-next/product/user-stories/US-004-produce-dataset-artifacts.md
+++ b/docs-next/product/user-stories/US-004-produce-dataset-artifacts.md
@@ -1,0 +1,33 @@
+# US-004: Produce Dataset Artifacts
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-002: New measurement logging replacement.
+
+## Story
+
+As an experimentalist, I want one measurement to produce one or more dataset
+artifacts so that related tables, scans, or traces stay connected without
+losing direct dataset access.
+
+## Success Criteria
+
+- A measurement can create multiple dataset artifacts with stable IDs.
+- Dataset artifacts carry scan or trace schema where plotting semantics matter.
+- Dataset writers share measurement lifecycle by default while remaining
+  individually discoverable.
+- Internal streams or subpayloads can exist below the user concept when needed
+  for storage, export, or reading.
+
+## Not In Scope
+
+- Making internal streams the normal user-facing product model.
+- Requiring one measurement to have exactly one dataset.
+
+## Related Capabilities / Specs
+
+CAP-005, CAP-006, CAP-026, CAP-028, SPEC-001.

--- a/docs-next/product/user-stories/US-004-produce-dataset-artifacts.md
+++ b/docs-next/product/user-stories/US-004-produce-dataset-artifacts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs-next/product/user-stories/US-005-watch-and-inspect.md
@@ -1,0 +1,22 @@
+# US-005: Watch And Inspect Data
+
+## Status
+
+Draft.
+
+## Story
+
+As an experimentalist, I want local live and historical table/chart views so
+that I can decide whether a measurement is working.
+
+## Acceptance Notes
+
+- Desktop starts from a measurement console.
+- Live views are noncritical consumers and cannot block writes.
+- Core views are table, line/scatter, basic heatmap, and simple trace
+  inspection.
+- Users can open produced datasets directly when needed.
+
+## Related
+
+CAP-007, CAP-026.

--- a/docs-next/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs-next/product/user-stories/US-005-watch-and-inspect.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs-next/product/user-stories/US-005-watch-and-inspect.md
@@ -4,19 +4,29 @@
 
 Draft.
 
+## Primary Epic
+
+EPIC-003: Measurement console and inspection.
+
 ## Story
 
 As an experimentalist, I want local live and historical table/chart views so
 that I can decide whether a measurement is working.
 
-## Acceptance Notes
+## Success Criteria
 
 - Desktop starts from a measurement console.
 - Live views are noncritical consumers and cannot block writes.
 - Core views are table, line/scatter, basic heatmap, and simple trace
   inspection.
 - Users can open produced datasets directly when needed.
+- Failed, interrupted, or partial runs are visibly different from completed
+  runs.
 
-## Related
+## Not In Scope
 
-CAP-007, CAP-026.
+- Publication plotting, generic dashboard building, or rich comparison views.
+
+## Related Capabilities / Specs
+
+CAP-007, CAP-008, CAP-026, SPEC-001.

--- a/docs-next/product/user-stories/US-006-recover-partial-measurement.md
+++ b/docs-next/product/user-stories/US-006-recover-partial-measurement.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-006-recover-partial-measurement.md
+++ b/docs-next/product/user-stories/US-006-recover-partial-measurement.md
@@ -1,0 +1,34 @@
+# US-006: Recover A Partial Measurement
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-004: Recovery, annotation, reopen, and export.
+
+## Story
+
+As an experimentalist, I want interrupted or failed measurements to remain
+readable so that a crash does not turn useful partial data into an opaque
+folder cleanup problem.
+
+## Success Criteria
+
+- Measurement lifecycle shows interrupted, failed, invalidated, recovered, or
+  completed state clearly.
+- Partial dataset artifacts can be reopened and inspected through public read
+  APIs.
+- Missing expected points are represented when the scan schema supports that
+  interpretation.
+- Ordinary cleanup uses trash/recover instead of immediate hard delete.
+
+## Not In Scope
+
+- Resuming unmanaged Python execution from the last scan point.
+- Hiding incomplete state to make partial data look complete.
+
+## Related Capabilities / Specs
+
+CAP-008, CAP-010, SPEC-001.

--- a/docs-next/product/user-stories/US-007-annotate-right-level.md
+++ b/docs-next/product/user-stories/US-007-annotate-right-level.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-007-annotate-right-level.md
+++ b/docs-next/product/user-stories/US-007-annotate-right-level.md
@@ -1,0 +1,32 @@
+# US-007: Annotate At The Right Level
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-003: Measurement console and inspection.
+
+## Story
+
+As an experimentalist, I want to add notes, markers, favorites, pins, and small
+corrections at the measurement or dataset level so that important lab context
+does not stay only in memory.
+
+## Success Criteria
+
+- Users can add notes to a measurement and to produced dataset artifacts.
+- Markers, favorites, pins, and optional tags help users find important work
+  again.
+- Corrections are visible as events instead of silently rewriting history.
+- Actor labels are recorded for notes and corrections when available.
+
+## Not In Scope
+
+- Full electronic lab notebook replacement.
+- Collaborative review, permissions, or publication workflow.
+
+## Related Capabilities / Specs
+
+CAP-009, CAP-017, SPEC-001.

--- a/docs-next/product/user-stories/US-008-reopen-measurement-outputs.md
+++ b/docs-next/product/user-stories/US-008-reopen-measurement-outputs.md
@@ -1,0 +1,33 @@
+# US-008: Reopen Measurement Outputs From Python
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-004: Recovery, annotation, reopen, and export.
+
+## Story
+
+As an experimentalist, I want to reopen a measurement or one of its dataset
+artifacts from Python by stable ID so that later analysis does not depend on
+remembering storage paths.
+
+## Success Criteria
+
+- Desktop and CLI can show copyable Python reopen snippets.
+- Public read APIs can open measurements, dataset artifacts, and partial data
+  by stable IDs.
+- Reopened data preserves scan schema, units, labels, lifecycle state, and
+  partial-data semantics.
+- Path-based access is not the documented normal path.
+
+## Not In Scope
+
+- Treating the private storage layout as a public API.
+- Importing old legacy-system data before new Fricon outputs can be reopened.
+
+## Related Capabilities / Specs
+
+CAP-010, CAP-026, SPEC-001.

--- a/docs-next/product/user-stories/US-008-reopen-measurement-outputs.md
+++ b/docs-next/product/user-stories/US-008-reopen-measurement-outputs.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-009-export-measurement.md
+++ b/docs-next/product/user-stories/US-009-export-measurement.md
@@ -4,13 +4,17 @@
 
 Draft. Detailed requirements live in `../../specs/SPEC-002-measurement-export-offline-analysis/`.
 
+## Primary Epic
+
+EPIC-004: Recovery, annotation, reopen, and export.
+
 ## Story
 
 As an experimentalist, I want to export a complete measurement bundle so that I
 can analyze it on another computer without setting up a Fricon data library or
 importing the data first.
 
-## Acceptance Notes
+## Success Criteria
 
 - Export starts from a measurement by default.
 - Produced datasets and semantic metadata are included.
@@ -19,6 +23,11 @@ importing the data first.
 - Sensitive provenance is previewed or opt-in.
 - Python can open the bundle directly.
 
-## Related
+## Not In Scope
+
+- Importing the bundle into another editable data library as the default path.
+- Legacy Data Vault, Labber, or HDF5 compatibility layers.
+
+## Related Capabilities / Specs
 
 CAP-010, CAP-011, SPEC-002.

--- a/docs-next/product/user-stories/US-009-export-measurement.md
+++ b/docs-next/product/user-stories/US-009-export-measurement.md
@@ -1,0 +1,24 @@
+# US-009: Export A Measurement For Offline Analysis
+
+## Status
+
+Draft. Detailed requirements live in `../../specs/SPEC-002-measurement-export-offline-analysis/`.
+
+## Story
+
+As an experimentalist, I want to export a complete measurement bundle so that I
+can analyze it on another computer without setting up a Fricon data library or
+importing the data first.
+
+## Acceptance Notes
+
+- Export starts from a measurement by default.
+- Produced datasets and semantic metadata are included.
+- Common analysis files are included where practical, but the Fricon manifest
+  remains the source of meaning.
+- Sensitive provenance is previewed or opt-in.
+- Python can open the bundle directly.
+
+## Related
+
+CAP-010, CAP-011, SPEC-002.

--- a/docs-next/product/user-stories/US-009-export-measurement.md
+++ b/docs-next/product/user-stories/US-009-export-measurement.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft. Detailed requirements live in `../../specs/SPEC-002-measurement-export-offline-analysis/`.
+Accepted. Detailed requirements live in `../../specs/SPEC-002-measurement-export-offline-analysis/`.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-010-update-without-corrupting-work.md
+++ b/docs-next/product/user-stories/US-010-update-without-corrupting-work.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-010-update-without-corrupting-work.md
+++ b/docs-next/product/user-stories/US-010-update-without-corrupting-work.md
@@ -1,0 +1,34 @@
+# US-010: Update Without Corrupting Measurement Work
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-001: Local setup and data-library adoption.
+
+## Story
+
+As an experimentalist, I want Fricon updates and format changes to fail safely
+so that measurement work is not corrupted by mismatched Desktop, service, CLI,
+Python SDK, or library versions.
+
+## Success Criteria
+
+- Mutating clients negotiate compatibility with the service and library before
+  writes.
+- Incompatible versions fail before mutation and explain the required action.
+- Format migrations or repair operations create or require a checkpoint
+  strategy.
+- Users can tell whether a problem is service state, library state, client
+  version, or data-format compatibility.
+
+## Not In Scope
+
+- Stable third-party protocol commitments before v0.2 is proven.
+- Automatic migration of old v0.1 workspaces or legacy systems.
+
+## Related Capabilities / Specs
+
+CAP-012, CAP-013, SPEC-001.

--- a/docs-next/product/user-stories/US-010-update-without-corrupting-work.md
+++ b/docs-next/product/user-stories/US-010-update-without-corrupting-work.md
@@ -26,7 +26,7 @@ Python SDK, or library versions.
 
 ## Not In Scope
 
-- Stable third-party protocol commitments before v0.2 is proven.
+- Stable third-party protocol commitments before the MVP is proven.
 - Automatic migration of old v0.1 workspaces or legacy systems.
 
 ## Related Capabilities / Specs

--- a/docs-next/product/user-stories/US-011-record-code-provenance.md
+++ b/docs-next/product/user-stories/US-011-record-code-provenance.md
@@ -1,0 +1,34 @@
+# US-011: Record Code Provenance Honestly
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
+## Story
+
+As an experimentalist, I want Fricon to record what it can honestly know about
+the code that produced a measurement so that later analysis can judge
+trustworthiness without pretending Fricon managed execution.
+
+## Success Criteria
+
+- Unmanaged Python is labeled as unmanaged unless Fricon actually controls
+  execution.
+- Optional script path, Git revision, dirty-state signal, and user summary can
+  be recorded where available.
+- Provenance can be previewed or omitted during export when it contains
+  sensitive local details.
+- Corrections to provenance are visible as events.
+
+## Not In Scope
+
+- Automatic notebook state capture.
+- Managed code snapshots, deployment, or approved update flows.
+
+## Related Capabilities / Specs
+
+CAP-014, CAP-017, SPEC-001.

--- a/docs-next/product/user-stories/US-011-record-code-provenance.md
+++ b/docs-next/product/user-stories/US-011-record-code-provenance.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-012-register-sample-session.md
+++ b/docs-next/product/user-stories/US-012-register-sample-session.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-012-register-sample-session.md
+++ b/docs-next/product/user-stories/US-012-register-sample-session.md
@@ -1,0 +1,34 @@
+# US-012: Register A Sample And Sample Session When Useful
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
+## Story
+
+As an experimentalist, I want to attach optional sample or sample-session
+context to a measurement so that data is easier to interpret when sample
+identity matters, without blocking exploratory measurements.
+
+## Success Criteria
+
+- Measurement creation can use no sample context, an active sample, or an
+  active sample session.
+- The chosen context is visible when the measurement starts and can be corrected
+  later.
+- Dataset and export views carry enough context to answer which sample/session
+  was active.
+- Missing sample context remains an explicit absence, not a fake sample.
+
+## Not In Scope
+
+- Requiring a complete sample registry before recording data.
+- Rich sample maps, saved views, or spatial comparison workflows.
+
+## Related Capabilities / Specs
+
+CAP-004, SPEC-001.

--- a/docs-next/product/user-stories/US-013-find-open-dataset-artifact.md
+++ b/docs-next/product/user-stories/US-013-find-open-dataset-artifact.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-013-find-open-dataset-artifact.md
+++ b/docs-next/product/user-stories/US-013-find-open-dataset-artifact.md
@@ -1,0 +1,32 @@
+# US-013: Find And Open A Dataset Artifact Directly
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-003: Measurement console and inspection.
+
+## Story
+
+As an experimentalist, I want to find and open a produced dataset artifact
+directly so that measurement-first navigation does not hide the actual data I
+need to inspect or analyze.
+
+## Success Criteria
+
+- Dataset artifacts have stable IDs and searchable labels or context.
+- Direct-open routes show the artifact with its parent measurement context.
+- Table and plot views can start from the artifact, not only from the parent
+  measurement.
+- Reopen snippets can target a dataset artifact when that is the useful unit.
+
+## Not In Scope
+
+- Returning to a dataset-first Desktop home screen.
+- Treating internal artifact streams as first-class navigation targets.
+
+## Related Capabilities / Specs
+
+CAP-010, CAP-026, SPEC-001.

--- a/docs-next/product/user-stories/US-014-record-passive-setup-context.md
+++ b/docs-next/product/user-stories/US-014-record-passive-setup-context.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-014-record-passive-setup-context.md
+++ b/docs-next/product/user-stories/US-014-record-passive-setup-context.md
@@ -10,16 +10,16 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want to record setup, device, method, software, or
-environment summaries for a measurement so that future analysis has practical
-context without requiring Fricon to control instruments.
+As an experimentalist, I want to record light setup, device, method, software,
+or environment summaries for a measurement so that future analysis has
+practical context without requiring Fricon to control instruments.
 
 ## Success Criteria
 
 - Measurement context can include optional setup, device, method, software, or
   environment labels and summaries.
-- Context may be user-supplied, inferred, imported from an external reference,
-  or corrected after the run.
+- Context may be user-supplied, imported from an external reference, or
+  corrected after the run.
 - Export previews sensitive local paths, machine names, or environment details.
 - Passive setup context is clearly separate from device control.
 

--- a/docs-next/product/user-stories/US-014-record-passive-setup-context.md
+++ b/docs-next/product/user-stories/US-014-record-passive-setup-context.md
@@ -1,0 +1,33 @@
+# US-014: Record Passive Setup Context
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
+## Story
+
+As an experimentalist, I want to record setup, device, method, software, or
+environment summaries for a measurement so that future analysis has practical
+context without requiring Fricon to control instruments.
+
+## Success Criteria
+
+- Measurement context can include optional setup, device, method, software, or
+  environment labels and summaries.
+- Context may be user-supplied, inferred, imported from an external reference,
+  or corrected after the run.
+- Export previews sensitive local paths, machine names, or environment details.
+- Passive setup context is clearly separate from device control.
+
+## Not In Scope
+
+- Device communication, calibration registry, or managed hardware inventory.
+- Claiming setup context is complete when it is only a passive summary.
+
+## Related Capabilities / Specs
+
+CAP-027, SPEC-001.

--- a/docs-next/product/user-stories/US-015-declare-common-scan-shapes.md
+++ b/docs-next/product/user-stories/US-015-declare-common-scan-shapes.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-015-declare-common-scan-shapes.md
+++ b/docs-next/product/user-stories/US-015-declare-common-scan-shapes.md
@@ -1,0 +1,33 @@
+# US-015: Declare Common Scan Shapes Quickly
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-002: New measurement logging replacement.
+
+## Story
+
+As an experimentalist, I want concise helpers for common scan and trace shapes
+so that Fricon data has reliable plotting semantics without making every script
+write raw schema by hand.
+
+## Success Criteria
+
+- Helper APIs cover common 1D, 2D, N-D, fixed-trace, and variable-trace cases.
+- Schema can represent regular grids, partial grids, irregular/adaptive points,
+  repeated points, and missing expected points where meaningful.
+- Advanced users can use raw schema when helpers are too narrow.
+- Live and historical plots rely on schema semantics instead of column order
+  guesses.
+
+## Not In Scope
+
+- Visual sweep builder as the primary acquisition model.
+- Managed execution plans or device control.
+
+## Related Capabilities / Specs
+
+CAP-006, CAP-028, SPEC-001.

--- a/docs-next/product/user-stories/US-015-declare-common-scan-shapes.md
+++ b/docs-next/product/user-stories/US-015-declare-common-scan-shapes.md
@@ -10,16 +10,21 @@ EPIC-002: New measurement logging replacement.
 
 ## Story
 
-As an experimentalist, I want concise helpers for common scan and trace shapes
-so that Fricon data has reliable plotting semantics without making every script
-write raw schema by hand.
+As an experimentalist, I want concise Python-native scan plans or helpers for
+common scan and trace shapes so that Fricon data has reliable plotting
+semantics without making every script write raw schema by hand.
 
 ## Success Criteria
 
-- Helper APIs cover common 1D, 2D, N-D, fixed-trace, and variable-trace cases.
+- Scan-plan authoring covers common 1D, 2D, N-D, fixed-trace, and
+  variable-trace cases.
+- Dict/literal-friendly plans are acceptable if they keep axes, setters,
+  measured values, labels, and units readable in ordinary Python.
+- The accepted simplification shape is informed by real scripts/notebooks and
+  feedback, not only by borrowed framework API names.
 - Schema can represent regular grids, partial grids, irregular/adaptive points,
   repeated points, and missing expected points where meaningful.
-- Advanced users can use raw schema when helpers are too narrow.
+- Advanced users can use raw schema when scan-plan helpers are too narrow.
 - Live and historical plots rely on schema semantics instead of column order
   guesses.
 
@@ -27,6 +32,8 @@ write raw schema by hand.
 
 - Visual sweep builder as the primary acquisition model.
 - Managed execution plans or device control.
+- A fixed framework-specific helper name or QCoDeS-style parameter-object
+  model.
 
 ## Related Capabilities / Specs
 

--- a/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
+++ b/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
+++ b/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
@@ -18,8 +18,8 @@ even before Fricon manages execution.
 
 - A measurement can link an unmanaged script summary, external-runner
   reference, or declared plan summary.
-- Procedure context can mention planned shape, relevant parameters, and
-  external identifiers without becoming a managed plan.
+- Procedure context can mention planned shape and external identifiers without
+  becoming a managed plan.
 - Corrections to procedure context are visible after the run.
 - Procedure context remains distinct from code provenance and setup context.
 

--- a/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
+++ b/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
@@ -1,0 +1,33 @@
+# US-016: Record Passive Procedure Context
+
+## Status
+
+Draft.
+
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
+## Story
+
+As an experimentalist, I want to record an unmanaged script, external runner,
+or declared procedure summary so that the measurement has procedural context
+even before Fricon manages execution.
+
+## Success Criteria
+
+- A measurement can link an unmanaged script summary, external-runner
+  reference, or declared plan summary.
+- Procedure context can mention planned shape, relevant parameters, and
+  external identifiers without becoming a managed plan.
+- Corrections to procedure context are visible after the run.
+- Procedure context remains distinct from code provenance and setup context.
+
+## Not In Scope
+
+- Managed measurement plans, task queues, or scan-point checkpoints.
+- Claiming Fricon executed steps it only observed or recorded.
+
+## Related Capabilities / Specs
+
+CAP-029, SPEC-001.

--- a/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -22,7 +22,8 @@ logger for new measurements without rewriting the whole experiment stack.
   schema helpers or raw schema.
 - Labels, units, legends, source aliases, original paths, and old numbered
   titles can be recorded without becoming primary identity.
-- User-written import scripts can call generic Fricon APIs for old data later.
+- The writer model does not block later user-written import scripts, but old
+  data import is not part of the migration path for starting new work.
 - v0.2 does not ship a built-in Data Vault parser or legacy browser.
 
 ## Not In Scope

--- a/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -4,13 +4,17 @@
 
 Draft.
 
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
 ## Story
 
 As a lab user, I want to translate a new Data Vault-style measurement script
 into Fricon with minimal conceptual change so that I can stop using the old
 logger for new measurements without rewriting the whole experiment stack.
 
-## Acceptance Notes
+## Success Criteria
 
 - The migration path uses Fricon SDK writers, not a Data Vault compatibility
   server.
@@ -21,6 +25,11 @@ logger for new measurements without rewriting the whole experiment stack.
 - User-written import scripts can call generic Fricon APIs for old data later.
 - v0.2 does not ship a built-in Data Vault parser or legacy browser.
 
-## Related
+## Not In Scope
+
+- Built-in LabRAD Data Vault parser, compatibility server, or legacy browser.
+- Requiring old data to migrate before new Fricon measurements can start.
+
+## Related Capabilities / Specs
 
 CAP-003, CAP-006, CAP-028, CAP-030.

--- a/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -1,0 +1,26 @@
+# US-017: Migrate A Data Vault-Style Script
+
+## Status
+
+Draft.
+
+## Story
+
+As a lab user, I want to translate a new Data Vault-style measurement script
+into Fricon with minimal conceptual change so that I can stop using the old
+logger for new measurements without rewriting the whole experiment stack.
+
+## Acceptance Notes
+
+- The migration path uses Fricon SDK writers, not a Data Vault compatibility
+  server.
+- Independent/dependent variable declarations map naturally to Fricon scan
+  schema helpers or raw schema.
+- Labels, units, legends, source aliases, original paths, and old numbered
+  titles can be recorded without becoming primary identity.
+- User-written import scripts can call generic Fricon APIs for old data later.
+- v0.2 does not ship a built-in Data Vault parser or legacy browser.
+
+## Related
+
+CAP-003, CAP-006, CAP-028, CAP-030.

--- a/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -24,7 +24,7 @@ logger for new measurements without rewriting the whole experiment stack.
   titles can be recorded without becoming primary identity.
 - The writer model does not block later user-written import scripts, but old
   data import is not part of the migration path for starting new work.
-- v0.2 does not ship a built-in Data Vault parser or legacy browser.
+- The MVP does not ship a built-in Data Vault parser or legacy browser.
 
 ## Not In Scope
 

--- a/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Accepted.
 
 ## Primary Epic
 

--- a/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -1,0 +1,23 @@
+# US-018: Start New Work While Old History Stays Put
+
+## Status
+
+Draft.
+
+## Story
+
+As an experimentalist, I want to start recording new measurements in Fricon
+while old LabRAD, QCoDeS, Labber, or folder-based history remains where it is
+so that migration does not block new data collection.
+
+## Acceptance Notes
+
+- v0.2 communicates that old history can stay in the old system.
+- New Fricon measurements may record source aliases or legacy references.
+- Later user-written import scripts can use generic APIs when old data needs to
+  move forward.
+- Fricon does not require a full historical migration before adoption.
+
+## Related
+
+CAP-001, CAP-011, CAP-026, CAP-030.

--- a/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -16,7 +16,7 @@ so that migration does not block new data collection.
 
 ## Success Criteria
 
-- v0.2 communicates that old history can stay in the old system.
+- The MVP communicates that old history can stay in the old system.
 - New Fricon measurements may record source aliases or legacy references.
 - Later user-written import scripts can use generic APIs when old data needs to
   move forward.
@@ -24,7 +24,7 @@ so that migration does not block new data collection.
 
 ## Not In Scope
 
-- Built-in legacy import as a v0.2 adoption prerequisite.
+- Built-in legacy import as an MVP adoption prerequisite.
 - Making reopen/export own old-system history migration.
 
 ## Related Capabilities / Specs

--- a/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs-next/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -4,13 +4,17 @@
 
 Draft.
 
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
 ## Story
 
 As an experimentalist, I want to start recording new measurements in Fricon
 while old LabRAD, QCoDeS, Labber, or folder-based history remains where it is
 so that migration does not block new data collection.
 
-## Acceptance Notes
+## Success Criteria
 
 - v0.2 communicates that old history can stay in the old system.
 - New Fricon measurements may record source aliases or legacy references.
@@ -18,6 +22,11 @@ so that migration does not block new data collection.
   move forward.
 - Fricon does not require a full historical migration before adoption.
 
-## Related
+## Not In Scope
+
+- Built-in legacy import as a v0.2 adoption prerequisite.
+- Making reopen/export own old-system history migration.
+
+## Related Capabilities / Specs
 
 CAP-001, CAP-011, CAP-026, CAP-030.

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -2,12 +2,19 @@
 
 ## Status
 
-Accepted v0.2+ product baseline.
+Accepted clean-reset product baseline.
 
 ## Thesis
 
-Fricon v0.2+ is a local lab data library and automation foundation for
-scientific measurement work.
+Fricon is a local lab data library and automation foundation for scientific
+measurement work.
+
+## Planning Language
+
+This document uses MVP, post-MVP, and ADR-gated as product priority labels.
+They are not semantic-version labels. Compatible improvements can still ship on
+the same compatible release line when the storage, API, and compatibility
+policies allow it.
 
 ## Long-Term Motivation
 
@@ -28,14 +35,14 @@ scripts and notebooks remain first-class, local lab computers remain useful
 without a server account model, and higher-provenance workflows grow from the
 same core experience instead of becoming a separate system.
 
-## v0.2 MVP Goal
+## MVP Goal
 
-The v0.2 MVP goal is practical: replace the simple LabRAD Data Vault/Grapher
-loop for new measurements.
+The MVP goal is practical: replace the simple LabRAD Data Vault/Grapher loop
+for new measurements.
 
 Success means a user can start new measurement work in Fricon, write data from
 Python, watch it live, recover partial results, reopen it later, and export it
-without depending on old storage paths. v0.2 does not need to import old
+without depending on old storage paths. The MVP does not need to import old
 history or emulate LabRAD; old LabRAD, QCoDeS, Labber, or folder-based history
 can remain where it is while new work moves to Fricon.
 
@@ -74,9 +81,9 @@ Detailed SDK usage guidance lives in `product/python-sdk-ux.md`. Old planning
 snippets under `dev-docs/` should be read as non-binding UX sketches unless an
 ADR accepts exact API syntax.
 
-## v0.2 MVP Scope
+## MVP Scope
 
-To meet the MVP goal, v0.2 should include:
+To meet the MVP goal, the MVP should include:
 
 - one local data library per normal lab computer
 - explicit measurements
@@ -100,9 +107,9 @@ To meet the MVP goal, v0.2 should include:
 - backup/restore and migration checkpoints
 - coherent install/update compatibility and guided setup diagnostics
 
-## Future Direction
+## Post-MVP Direction
 
-These directions matter to the long-term product, but are not v0.2 MVP
+These directions matter to the long-term product, but are not MVP
 commitments:
 
 - parameter profiles, proposals, and calibration promotion
@@ -120,7 +127,7 @@ commitments:
 - resumable managed execution with scan-point checkpoints
 - AI-assisted reviewable automation
 
-## Non-Goals For v0.2
+## Non-Goals For MVP
 
 - hosted SaaS
 - account/team administration

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -13,6 +13,12 @@ The first product goal is practical: replace a simple LabRAD Grapher/Data Vault
 style logger for new measurements without building a compatibility layer for
 old storage.
 
+The adoption promise is incremental: users should be able to start new
+measurements in Fricon while old LabRAD, QCoDeS, Labber, or folder-based
+history stays where it is. Fricon may record source aliases and legacy
+references, but v0.2 should not require a historical migration before new data
+collection can move forward.
+
 ## User Promise
 
 Fricon should help a researcher answer:
@@ -61,7 +67,7 @@ The first shipped slice should include:
 - a near-term measurement export spec for portable bundles and common analysis
   formats
 - backup/restore and migration checkpoints
-- guided setup and compatibility diagnostics
+- coherent install/update compatibility and guided setup diagnostics
 
 ## Later Layers
 
@@ -87,6 +93,7 @@ These are important but not first-slice commitments:
 - direct shared-folder access to one editable data library
 - LabRAD Data Vault/Grapher compatibility server
 - built-in legacy Data Vault import or browser
+- requiring full old-history migration before adopting Fricon for new data
 - broad device-driver framework
 - generic workflow DAG engine
 - visual sweep builder as the primary acquisition model

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft v0.2+ product baseline.
+Accepted v0.2+ product baseline.
 
 ## Thesis
 

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -1,0 +1,80 @@
+# Product Vision
+
+## Status
+
+Draft v0.2+ product baseline.
+
+## Thesis
+
+Fricon v0.2+ is a local lab data library and automation foundation for
+scientific measurement work.
+
+The first product goal is practical: replace a simple LabRAD Grapher/Data Vault
+style logger for new measurements without building a compatibility layer for
+old storage.
+
+## User Promise
+
+Fricon should help a researcher answer:
+
+- What measurement did I run?
+- Which sample or session was active, if any?
+- What datasets and attachments did it produce?
+- Was the run finished, interrupted, failed, invalidated, or recovered?
+- What notes, parameters, code provenance, and setup labels explain it?
+- How do I inspect it live, reopen it from Python, export it, or recover it?
+
+## Primary Mental Model
+
+```text
+I selected an active sample/session when it mattered.
+I ran a measurement from Python.
+It produced datasets.
+Fricon helps me inspect, annotate, recover, reopen, and export them.
+```
+
+## First v0.2 Slice
+
+The first shipped slice should include:
+
+- one local data library per normal lab computer
+- explicit measurements
+- optional sample and sample-session context
+- table-shaped dataset artifacts with explicit scan schema for plotted data
+- nonblocking live table and chart inspection
+- measurement lifecycle, notes, events, favorites/pins, trash/recover
+- light attachments
+- optional flexible parameter snapshot
+- honest code provenance summary
+- Python reopen snippets through public APIs
+- measurement-centered portable export
+- backup/restore and migration checkpoints
+- guided setup and compatibility diagnostics
+
+## Later Layers
+
+These are important but not first-slice commitments:
+
+- read-only LAN monitoring
+- richer sample fields and 2D sample maps
+- parameter profiles, proposals, and calibration promotion
+- managed code snapshots and managed script execution
+- managed measurement plans
+- analysis and calibration activity records
+- device identity and communication
+- AI-assisted reviewable automation
+
+## Non-Goals For v0.2
+
+- hosted SaaS
+- account/team administration
+- multi-user permissions
+- distributed database semantics
+- direct shared-folder access to one editable data library
+- LabRAD Data Vault/Grapher compatibility server
+- built-in legacy Data Vault import or browser
+- broad device-driver framework
+- generic workflow DAG engine
+- visual sweep builder as the primary acquisition model
+- automatic notebook state capture
+- AI actions that mutate data-library state without explicit review and audit

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -109,23 +109,19 @@ To meet the MVP goal, the MVP should include:
 
 ## Post-MVP Direction
 
-These directions matter to the long-term product, but are not MVP
-commitments:
+These priorities matter most after the MVP because they change the experiment
+experience most directly:
 
-- parameter profiles, proposals, and calibration promotion
-- parameter history, diffs, and proposal review
-- managed measurement-code sources and approved-code update flows
-- managed code snapshots and managed script execution
-- SDK runner capture before scheduler/resource queues
-- generated run history, compare, and operator handoff views
-- read-only LAN monitoring
-- richer sample fields and 2D sample maps
-- managed measurement plans
-- user-facing stream concepts inside dataset artifacts
-- analysis and calibration activity records
-- device identity and communication
-- resumable managed execution with scan-point checkpoints
-- AI-assisted reviewable automation
+- Priority 1: parameter system for profiles, immutable run-bound snapshots,
+  diffs, and proposal review.
+- Priority 2: managed run for importable SDK runner entry points, code/source
+  capture, lifecycle capture, and generated run history.
+- Priority 3: reviewable automation workflow that previews, reviews, audits,
+  and applies changes only through explicit safety boundaries.
+
+Lower-priority or ADR-gated directions include read-only LAN monitoring, richer
+sample maps, analysis/calibration records, device communication, resumable
+execution, user-facing stream concepts, and AI-assisted automation.
 
 ## Non-Goals For MVP
 

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -113,15 +113,25 @@ These priorities matter most after the MVP because they change the experiment
 experience most directly:
 
 - Priority 1: parameter system for profiles, immutable run-bound snapshots,
-  diffs, and proposal review.
+  diffs, proposal review, and user-defined table row keys that can later
+  support visualization lookup.
 - Priority 2: managed run for importable SDK runner entry points, code/source
-  capture, lifecycle capture, and generated run history.
-- Priority 3: reviewable automation workflow that previews, reviews, audits,
-  and applies changes only through explicit safety boundaries.
+  capture, lifecycle capture, compact run manifests, failure investigation,
+  and generated run history.
+- Priority 3: reviewable routine replay and automation workflow that previews,
+  reviews, audits, and applies changes only through explicit safety
+  boundaries.
+
+Sample visualization should stay lightweight until product evidence says
+otherwise. Treat a sample visualizer as a view over parameter snapshots and
+snapshot query results, not as proof that Fricon understands the sample's
+physical shape. User-authored 2D sample-map configs/DSLs may live near sample
+records for discoverability, but schema evolution, invalid visualizers, and
+visualizer migration policy are later design questions.
 
 Lower-priority or ADR-gated directions include read-only LAN monitoring, richer
-sample maps, analysis/calibration records, device communication, resumable
-execution, user-facing stream concepts, and AI-assisted automation.
+sample-map authoring, analysis/calibration records, device communication,
+resumable execution, user-facing stream concepts, and AI-assisted automation.
 
 ## Non-Goals For MVP
 

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -74,8 +74,13 @@ or notebooks, so SDK ergonomics are product requirements.
 
 At the vision level, the SDK should feel like ordinary Python with low
 ceremony: a visible notebook context, natural interactive unmanaged runs,
-importable managed-run entry points for higher provenance, concise doNd-style
-helpers for routine scans, and public reopen/export APIs for later analysis.
+importable managed-run entry points for higher provenance, Python-native
+scan-plan authoring for routine scans, and public reopen/export APIs for later
+analysis.
+
+Common workflows should have appropriate simplifications, but exact helper
+shapes are not part of the product vision until real usage feedback supports
+them.
 
 Detailed SDK usage guidance lives in `product/python-sdk-ux.md`. Old planning
 snippets under `dev-docs/` should be read as non-binding UX sketches unless an
@@ -93,8 +98,8 @@ To meet the MVP goal, the MVP should include:
 - table-shaped scan and trace data with explicit scan schema for plotted data
 - scan modes for regular grids, partial grids, irregular or adaptive points,
   repeated points, and fixed-shape or variable-length traces
-- short scan-schema helpers for common 1D/2D/N-D scans and traces, plus a raw
-  schema escape hatch for advanced cases
+- low-ceremony scan-plan/schema authoring for common 1D/2D/N-D scans and
+  traces, plus a raw schema escape hatch for advanced cases
 - nonblocking live table and chart inspection
 - measurement lifecycle, notes, events, favorites/pins, trash/recover, and
   readable partial data semantics

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -40,14 +40,26 @@ The first shipped slice should include:
 - one local data library per normal lab computer
 - explicit measurements
 - optional sample and sample-session context
-- table-shaped dataset artifacts with explicit scan schema for plotted data
+- dataset artifacts that remain directly searchable and openable, even though
+  the Desktop home is measurement-first
+- table-shaped scan and trace data with explicit scan schema for plotted data
+- scan modes for regular grids, partial grids, irregular or adaptive points,
+  repeated points, and fixed-shape or variable-length traces
+- short scan-schema helpers for common 1D/2D/N-D scans and traces, plus a raw
+  schema escape hatch for advanced cases
 - nonblocking live table and chart inspection
-- measurement lifecycle, notes, events, favorites/pins, trash/recover
+- measurement lifecycle, notes, events, favorites/pins, trash/recover, and
+  readable partial data semantics
 - light attachments
 - optional flexible parameter snapshot
 - honest code provenance summary
+- optional passive setup, device, and environment summary that describes
+  context without controlling devices
+- optional passive procedure summary that records unmanaged script, external
+  runner, or declared plan context without implementing a runner
 - Python reopen snippets through public APIs
-- measurement-centered portable export
+- a near-term measurement export spec for portable bundles and common analysis
+  formats
 - backup/restore and migration checkpoints
 - guided setup and compatibility diagnostics
 
@@ -60,8 +72,10 @@ These are important but not first-slice commitments:
 - parameter profiles, proposals, and calibration promotion
 - managed code snapshots and managed script execution
 - managed measurement plans
+- user-facing stream concepts inside dataset artifacts
 - analysis and calibration activity records
 - device identity and communication
+- resumable managed execution with scan-point checkpoints
 - AI-assisted reviewable automation
 
 ## Non-Goals For v0.2

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -11,35 +11,33 @@ scientific measurement work.
 
 ## Long-Term Motivation
 
-Fricon is motivated by a gap in existing physical measurement workflows:
-dataset logging can be usable, but parameter management, measurement-code
-management, environment setup, run provenance, calibration history, and later
-automation often remain fragmented.
+Physical measurement work is hard to make reliable when data, parameters,
+measurement code, setup state, notes, and later analysis live in separate tools
+or informal files. Existing frameworks can help users collect data, but they
+often leave the broader experiment record to conventions that are difficult to
+inspect, compare, migrate, or automate.
 
-Building separate systems on top of existing measurement frameworks tends to
-produce inconsistent user experience and brittle conventions: parameters hide
-in JSON files, code history depends on copied folders or dirty Git checkouts,
-runner facts hide in logs, and provenance is reconstructed after the fact.
+Fricon should give experimenters one local-first product model for defining,
+running, inspecting, explaining, and reusing measurement work. The long-term
+aim is not only to store results, but to make the relationship between a
+measurement, its datasets, its Python code, its context, and its later
+interpretation explicit enough for humans and future automation to trust.
 
-Fricon's long-term goal is a unified local-first experience where measurement
-recording, parameter snapshots, managed code sources, SDK runner capture,
-dataset artifacts, setup state, analysis/calibration records, and reviewed
-automation share one coherent product model.
+The product should stay close to how experimentalists already work: Python
+scripts and notebooks remain first-class, local lab computers remain useful
+without a server account model, and higher-provenance workflows grow from the
+same core experience instead of becoming a separate system.
 
-Dataset artifacts and scan semantics are foundational, but they are not the
-product endpoint. The v0.2 measurement/data-library slice exists to create a
-stable base for the parameter system, measurement-code management, managed
-runner, and calibration/automation layers.
+## v0.2 MVP Goal
 
-The first product goal is practical: replace a simple LabRAD Grapher/Data Vault
-style logger for new measurements without building a compatibility layer for
-old storage.
+The v0.2 MVP goal is practical: replace the simple LabRAD Data Vault/Grapher
+loop for new measurements.
 
-The adoption promise is incremental: users should be able to start new
-measurements in Fricon while old LabRAD, QCoDeS, Labber, or folder-based
-history stays where it is. Fricon may record source aliases and legacy
-references, but v0.2 should not require a historical migration before new data
-collection can move forward.
+Success means a user can start new measurement work in Fricon, write data from
+Python, watch it live, recover partial results, reopen it later, and export it
+without depending on old storage paths. v0.2 does not need to import old
+history or emulate LabRAD; old LabRAD, QCoDeS, Labber, or folder-based history
+can remain where it is while new work moves to Fricon.
 
 ## User Promise
 
@@ -67,30 +65,18 @@ The Python SDK is a primary user experience, not only an implementation API.
 Most experimentalists will define and run measurements through Python scripts
 or notebooks, so SDK ergonomics are product requirements.
 
-The SDK should:
+At the vision level, the SDK should feel like ordinary Python with low
+ceremony: a visible notebook context, natural interactive unmanaged runs,
+importable managed-run entry points for higher provenance, concise doAnd-style
+helpers for routine scans, and public reopen/export APIs for later analysis.
 
-- let users create explicit measurements with low ceremony
-- support a visible notebook context for current library and optional lab
-  context
-- keep interactive unmanaged runs natural for exploratory Python
-- make importable decorated managed runs possible later for higher-provenance
-  work
-- make doAnd-style scan helpers concise enough for routine scripts
-- keep advanced raw schema available when helper APIs are too narrow
-- return users to public Python read/reopen/export APIs instead of storage
-  paths
-- fail before mutation when Desktop, service, data library, CLI, or SDK versions
-  are incompatible
+Detailed SDK usage guidance lives in `product/python-sdk-ux.md`. Old planning
+snippets under `dev-docs/` should be read as non-binding UX sketches unless an
+ADR accepts exact API syntax.
 
-Old planning snippets under `dev-docs/` should be read as UX sketches unless an
-ADR accepts exact syntax. They express user requirements such as explicit
-measurement creation, visible notebook context, interactive unmanaged runs,
-importable decorated managed runs, doAnd-style helper ergonomics, and direct
-Python reopen/export, not final API design.
+## v0.2 MVP Scope
 
-## First v0.2 Slice
-
-The first shipped slice should include:
+To meet the MVP goal, the first shipped slice should include:
 
 - one local data library per normal lab computer
 - explicit measurements
@@ -106,21 +92,18 @@ The first shipped slice should include:
 - measurement lifecycle, notes, events, favorites/pins, trash/recover, and
   readable partial data semantics
 - light attachments
-- optional flexible parameter snapshot
-- honest code provenance summary
-- optional passive setup, device, and environment summary that describes
-  context without controlling devices
-- optional passive procedure summary that records unmanaged script, external
-  runner, or declared plan context without implementing a runner
+- light contextual summaries for parameters, code provenance, setup,
+  environment, and unmanaged procedure context
 - Python reopen snippets through public APIs
 - a near-term measurement export spec for portable bundles and common analysis
   formats
 - backup/restore and migration checkpoints
 - coherent install/update compatibility and guided setup diagnostics
 
-## Later Layers
+## Future Direction
 
-These are important but not first-slice commitments:
+These directions matter to the long-term product, but are not v0.2 MVP
+commitments:
 
 - parameter profiles, proposals, and calibration promotion
 - parameter history, diffs, and proposal review

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -74,7 +74,7 @@ or notebooks, so SDK ergonomics are product requirements.
 
 At the vision level, the SDK should feel like ordinary Python with low
 ceremony: a visible notebook context, natural interactive unmanaged runs,
-importable managed-run entry points for higher provenance, concise doAnd-style
+importable managed-run entry points for higher provenance, concise doNd-style
 helpers for routine scans, and public reopen/export APIs for later analysis.
 
 Detailed SDK usage guidance lives in `product/python-sdk-ux.md`. Old planning

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -9,6 +9,28 @@ Accepted v0.2+ product baseline.
 Fricon v0.2+ is a local lab data library and automation foundation for
 scientific measurement work.
 
+## Long-Term Motivation
+
+Fricon is motivated by a gap in existing physical measurement workflows:
+dataset logging can be usable, but parameter management, measurement-code
+management, environment setup, run provenance, calibration history, and later
+automation often remain fragmented.
+
+Building separate systems on top of existing measurement frameworks tends to
+produce inconsistent user experience and brittle conventions: parameters hide
+in JSON files, code history depends on copied folders or dirty Git checkouts,
+runner facts hide in logs, and provenance is reconstructed after the fact.
+
+Fricon's long-term goal is a unified local-first experience where measurement
+recording, parameter snapshots, managed code sources, SDK runner capture,
+dataset artifacts, setup state, analysis/calibration records, and reviewed
+automation share one coherent product model.
+
+Dataset artifacts and scan semantics are foundational, but they are not the
+product endpoint. The v0.2 measurement/data-library slice exists to create a
+stable base for the parameter system, measurement-code management, managed
+runner, and calibration/automation layers.
+
 The first product goal is practical: replace a simple LabRAD Grapher/Data Vault
 style logger for new measurements without building a compatibility layer for
 old storage.
@@ -38,6 +60,33 @@ I ran a measurement from Python.
 It produced datasets.
 Fricon helps me inspect, annotate, recover, reopen, and export them.
 ```
+
+## Python SDK Experience
+
+The Python SDK is a primary user experience, not only an implementation API.
+Most experimentalists will define and run measurements through Python scripts
+or notebooks, so SDK ergonomics are product requirements.
+
+The SDK should:
+
+- let users create explicit measurements with low ceremony
+- support a visible notebook context for current library and optional lab
+  context
+- keep interactive unmanaged runs natural for exploratory Python
+- make importable decorated managed runs possible later for higher-provenance
+  work
+- make doAnd-style scan helpers concise enough for routine scripts
+- keep advanced raw schema available when helper APIs are too narrow
+- return users to public Python read/reopen/export APIs instead of storage
+  paths
+- fail before mutation when Desktop, service, data library, CLI, or SDK versions
+  are incompatible
+
+Old planning snippets under `dev-docs/` should be read as UX sketches unless an
+ADR accepts exact syntax. They express user requirements such as explicit
+measurement creation, visible notebook context, interactive unmanaged runs,
+importable decorated managed runs, doAnd-style helper ergonomics, and direct
+Python reopen/export, not final API design.
 
 ## First v0.2 Slice
 
@@ -73,10 +122,14 @@ The first shipped slice should include:
 
 These are important but not first-slice commitments:
 
+- parameter profiles, proposals, and calibration promotion
+- parameter history, diffs, and proposal review
+- managed measurement-code sources and approved-code update flows
+- managed code snapshots and managed script execution
+- SDK runner capture before scheduler/resource queues
+- generated run history, compare, and operator handoff views
 - read-only LAN monitoring
 - richer sample fields and 2D sample maps
-- parameter profiles, proposals, and calibration promotion
-- managed code snapshots and managed script execution
 - managed measurement plans
 - user-facing stream concepts inside dataset artifacts
 - analysis and calibration activity records

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -76,7 +76,7 @@ ADR accepts exact API syntax.
 
 ## v0.2 MVP Scope
 
-To meet the MVP goal, the first shipped slice should include:
+To meet the MVP goal, v0.2 should include:
 
 - one local data library per normal lab computer
 - explicit measurements

--- a/docs-next/redesign-from-prototype.md
+++ b/docs-next/redesign-from-prototype.md
@@ -17,7 +17,7 @@ Track the reset from the v0.1 prototype to the v0.2+ design baseline.
 | Phase 2: Domain baseline | Draft complete | `domain/conceptual-model.md`, `domain/context-map.md`, `domain/lifecycle-model.md`, `domain/invariants.md` |
 | Phase 3: Architecture baseline | Draft complete | `architecture/system-overview.md`, `architecture/module-boundaries.md`, `architecture/data-flow.md`, `architecture/api-boundaries.md`, `architecture/storage-model.md`, `architecture/compatibility-policy.md`, `architecture/risks.md` |
 | Phase 4: Traceability baseline | Draft complete | `product/story-module-matrix.md`, `specs/SPEC-001-data-library-measurement-foundation/traceability.md` |
-| Phase 5: System-slice specs | Draft started | `specs/SPEC-001-data-library-measurement-foundation/` |
+| Phase 5: System-slice specs | Draft started | `specs/SPEC-001-data-library-measurement-foundation/`, `specs/SPEC-002-measurement-export-offline-analysis/` |
 | Phase 6: Implementation and doc sync | Not started | Requires accepted SPEC-001 and storage/API ADRs |
 
 ## Baseline Readiness Gate
@@ -41,5 +41,9 @@ Create focused ADRs before durable v0.2 implementation:
 1. Data-library storage layout and pre-v0.2 migration/import stance.
 2. Local service API contract and compatibility negotiation.
 3. Dataset artifact storage and scan schema representation.
-4. Measurement lifecycle and event/audit record model.
-5. Export bundle format and privacy preview.
+4. Scan shape and readable-partial semantics.
+5. Measurement lifecycle and event/audit record model.
+6. Scan schema helper API shape.
+7. Passive setup and procedure summary shape.
+8. Internal stream/subpayload representation policy.
+9. Export bundle format and privacy preview.

--- a/docs-next/redesign-from-prototype.md
+++ b/docs-next/redesign-from-prototype.md
@@ -43,7 +43,7 @@ Create focused ADRs before durable v0.2 implementation:
 3. Dataset artifact storage and scan schema representation.
 4. Scan shape and readable-partial semantics.
 5. Measurement lifecycle and event/audit record model.
-6. Scan schema helper API shape.
+6. Python-native scan-plan/helper API shape.
 7. Passive setup and procedure summary shape.
 8. Internal stream/subpayload representation policy.
 9. Export bundle format and privacy preview.

--- a/docs-next/redesign-from-prototype.md
+++ b/docs-next/redesign-from-prototype.md
@@ -1,0 +1,45 @@
+# Redesign From Prototype Workflow
+
+## Status
+
+Draft workflow tracker.
+
+## Purpose
+
+Track the reset from the v0.1 prototype to the v0.2+ design baseline.
+
+## Workflow State
+
+| Phase | Status | Output |
+| --- | --- | --- |
+| Phase 0: Inventory and postmortem | Draft complete | `postmortems/v0-lessons.md`, `architecture/compatibility-policy.md`, ADR-001 |
+| Phase 1: Product and capability baseline | Draft complete | `product/vision.md`, `product/personas.md`, `product/capability-map.md`, `product/story-map.md`, `product/glossary.md` |
+| Phase 2: Domain baseline | Draft complete | `domain/conceptual-model.md`, `domain/context-map.md`, `domain/lifecycle-model.md`, `domain/invariants.md` |
+| Phase 3: Architecture baseline | Draft complete | `architecture/system-overview.md`, `architecture/module-boundaries.md`, `architecture/data-flow.md`, `architecture/api-boundaries.md`, `architecture/storage-model.md`, `architecture/compatibility-policy.md`, `architecture/risks.md` |
+| Phase 4: Traceability baseline | Draft complete | `product/story-module-matrix.md`, `specs/SPEC-001-data-library-measurement-foundation/traceability.md` |
+| Phase 5: System-slice specs | Draft started | `specs/SPEC-001-data-library-measurement-foundation/` |
+| Phase 6: Implementation and doc sync | Not started | Requires accepted SPEC-001 and storage/API ADRs |
+
+## Baseline Readiness Gate
+
+Gate A currently passes as a draft baseline:
+
+- Vision and capability map exist.
+- Core domain concepts are named.
+- Module boundaries are explicit.
+- Compatibility policy exists.
+- ADRs record the reset boundary and documentation governance.
+- Agent steering exists.
+
+Before implementation, move the relevant docs or spec from Draft to Accepted,
+or record explicit user authorization to implement from Draft.
+
+## Immediate Next Decisions
+
+Create focused ADRs before durable v0.2 implementation:
+
+1. Data-library storage layout and pre-v0.2 migration/import stance.
+2. Local service API contract and compatibility negotiation.
+3. Dataset artifact storage and scan schema representation.
+4. Measurement lifecycle and event/audit record model.
+5. Export bundle format and privacy preview.

--- a/docs-next/research/README.md
+++ b/docs-next/research/README.md
@@ -1,0 +1,35 @@
+# Research Notes
+
+## Status
+
+Draft process note.
+
+## Purpose
+
+`docs-next/research/` stores lightweight background research and accepted
+lessons. It should not become an encyclopedia of external measurement
+frameworks.
+
+Use focused research only when a concrete ADR, spec, or design question needs
+pressure from existing systems.
+
+## Research Rules
+
+- Prefer official docs, official repos, and project-maintained docs.
+- Record source links and review date.
+- Distinguish factual observations from Fricon design conclusions.
+- Move only durable synthesized lessons into product, domain, architecture, or
+  ADR documents.
+- Do not let reference-system notes override accepted Fricon ADRs.
+
+## Current Reference-System Passes
+
+Initial review date: 2026-05-06.
+
+Covered:
+
+- QCoDeS and LabRAD Data Vault/Grapher
+- Bluesky, Ophyd, Tiled, Databroker, Suitcase
+- Labber and ARTIQ/NIST ARTIQ scan framework
+
+Synthesis lives in `lessons-for-fricon.md`.

--- a/docs-next/research/README.md
+++ b/docs-next/research/README.md
@@ -34,4 +34,5 @@ Covered:
 - Sacred, MLflow, W&B, DVC, Sumatra, ReproZip, Nextflow, and Snakemake
 - EPICS Archiver, Olog, eLabFTW, LabKey, openBIS, and calibration-ledger tools
 
-Synthesis lives in `lessons-for-fricon.md`.
+Accepted synthesis lives in `lessons-for-fricon.md`. The broader source list
+and post-MVP planning synthesis live in `post-mvp-future-systems.md`.

--- a/docs-next/research/README.md
+++ b/docs-next/research/README.md
@@ -31,5 +31,7 @@ Covered:
 - QCoDeS and LabRAD Data Vault/Grapher
 - Bluesky, Ophyd, Tiled, Databroker, Suitcase
 - Labber and ARTIQ/NIST ARTIQ scan framework
+- Sacred, MLflow, W&B, DVC, Sumatra, ReproZip, Nextflow, and Snakemake
+- EPICS Archiver, Olog, eLabFTW, LabKey, openBIS, and calibration-ledger tools
 
 Synthesis lives in `lessons-for-fricon.md`.

--- a/docs-next/research/lessons-for-fricon.md
+++ b/docs-next/research/lessons-for-fricon.md
@@ -74,9 +74,10 @@ Fricon v0.2 should model:
 
 Display hints should stay separate from durable semantic facts.
 
-The public API also needs ergonomic helpers for common scan/trace shapes.
-Raw schema should remain available for advanced cases, but raw schema alone is
-too much ceremony for routine 1D/2D/N-D measurements.
+The public API also needs ergonomic Python-native scan plans or helpers for
+common scan/trace shapes. Raw schema should remain available for advanced
+cases, but raw schema alone is too much ceremony for routine 1D/2D/N-D
+measurements.
 
 ### Internal streams should not become the normal user concept
 

--- a/docs-next/research/lessons-for-fricon.md
+++ b/docs-next/research/lessons-for-fricon.md
@@ -1,0 +1,120 @@
+# Lessons For Fricon
+
+## Status
+
+Draft research synthesis.
+
+## Review Date
+
+2026-05-06.
+
+## Sources
+
+Primary/project-maintained sources reviewed:
+
+- QCoDeS measurement/dataset docs:
+  https://microsoft.github.io/Qcodes/examples/DataSet/Performing-measurements-using-qcodes-parameters-and-dataset.html
+- QCoDeS datasaver builder:
+  https://microsoft.github.io/Qcodes/examples/DataSet/Datasaver_Builder.html
+- QCoDeS export docs:
+  https://microsoft.github.io/Qcodes/examples/DataSet/Exporting-data-to-other-file-formats.html
+- QCoDeS Pandas/XArray docs:
+  https://microsoft.github.io/Qcodes/examples/DataSet/Working-With-Pandas-and-XArray.html
+- LabRAD Data Vault/Grapher quick start:
+  https://sourceforge.net/p/labrad/wiki/QuickStartDataVaultAndGrapher/
+- Bluesky Event Model:
+  https://blueskyproject.io/event-model/main/explanations/data-model.html
+- Ophyd device/hints docs:
+  https://blueskyproject.io/ophyd/device-overview.html
+- Bluesky callbacks and interruption/state-machine docs:
+  https://blueskyproject.io/bluesky/v1.13/callbacks.html
+  https://blueskyproject.io/bluesky/v1.14.0/state-machine.html
+- Databroker and Tiled docs:
+  https://blueskyproject.io/databroker/
+  https://blueskyproject.io/tiled/getting-started/what-is-tiled.html
+- Bluesky Tiled Plugins layout:
+  https://blueskyproject.io/bluesky-tiled-plugins/explanations/layout.html
+- Suitcase usage:
+  https://blueskyproject.io/suitcase/usage.html
+- Keysight Labber product docs:
+  https://www.keysight.com/us/en/products/all-instrument-software/labber-software.html
+- ARTIQ data interfaces and core language docs:
+  https://m-labs.hk/artiq/manual/using_data_interfaces.html
+  https://m-labs.hk/artiq/manual/core_language_reference.html
+- ARTIQ environment and management docs:
+  https://m-labs.hk/artiq/manual/environment.html
+  https://m-labs.hk/artiq/manual/management_system.html
+- NIST ARTIQ scan framework:
+  https://pages.nist.gov/artiq_scan_framework/scans/core_features.html
+
+## Synthesis
+
+### Measurement-first is supported, but datasets stay first-class
+
+Existing systems support a run or measurement record with metadata and
+lifecycle, but QCoDeS and LabRAD also make datasets easy to find and reopen.
+
+Fricon should make Desktop measurement-first while keeping `DatasetArtifact` a
+stable, searchable, directly openable artifact. This is especially important
+for future analysis, import, simulation, calibration, and export workflows.
+
+### Scan schema needs shape modes
+
+Explicit scan semantics are strongly supported, but a simple
+independent/dependent pair is not enough.
+
+Fricon v0.2 should model:
+
+- regular grids
+- partial grids with missing expected points
+- irregular or adaptive points
+- repeated points
+- fixed-shape arrays/traces
+- variable-length traces with per-trace coordinates and settings
+
+Display hints should stay separate from durable semantic facts.
+
+The public API also needs ergonomic helpers for common scan/trace shapes.
+Raw schema should remain available for advanced cases, but raw schema alone is
+too much ceremony for routine 1D/2D/N-D measurements.
+
+### Internal streams should not become the normal user concept
+
+Bluesky/Tiled style systems show that stream-like grouping is useful for
+primary, baseline, external arrays, and export/read layout. Fricon should allow
+internal stream or subpayload representation where storage/export/read APIs
+need it, while keeping `DatasetArtifact` as the normal user-facing concept in
+v0.2.
+
+### Readable partials come before resumable execution
+
+All reviewed systems care about partial/interrupted data. Some also support
+pause/resume, but resumability requires scan-point checkpoint semantics and
+runner cooperation.
+
+Fricon v0.2 should guarantee readable partial data and explicit missing/partial
+shape semantics. Resumable execution should wait for a managed-runner design.
+
+### Live views must be disposable consumers
+
+Live plotting and dashboards should not be on the acquisition write path.
+Durable writes come first; live events, previews, and charts are bounded,
+coalesced, throttled, or opt-in consumers.
+
+### Passive setup provenance is useful before device control
+
+Labber and ARTIQ show that device/setup information matters. Fricon should not
+build a broad device framework in v0.2, but measurements should have room for a
+passive setup/device/environment summary that describes context without
+claiming control or full reproducibility.
+
+Measurements should also allow passive procedure summaries: unmanaged script,
+external runner, or declared plan context. This records what was intended or
+invoked without claiming managed execution or resume semantics.
+
+### Export must support bundles and common analysis workflows
+
+Portable export should preserve measurement metadata, dataset semantics,
+checksums, and source identity. Common analysis formats such as CSV, Parquet,
+NetCDF, XArray-oriented views, or similar paths should be considered in a
+focused export spec rather than deferred indefinitely.

--- a/docs-next/research/post-mvp-future-systems.md
+++ b/docs-next/research/post-mvp-future-systems.md
@@ -1,4 +1,4 @@
-# v0.3+ Future-System Research
+# Post-MVP Future Systems Research
 
 ## Status
 
@@ -10,11 +10,12 @@ Draft research synthesis.
 
 ## Purpose
 
-Capture background lessons for v0.3+ parameter systems, managed code snapshots,
-runner capture, setup state, calibration history, and generated run history.
+Capture background lessons for post-MVP parameter systems, managed code
+snapshots, runner capture, setup state, calibration history, and generated run
+history.
 
 This research informs `product/future-stories-and-requirements.md`; it does
-not change accepted v0.2 scope.
+not change accepted MVP scope.
 
 ## Sources
 
@@ -79,9 +80,12 @@ Lab state, audit, and calibration references:
 
 ## Product Lessons
 
-- Parameter drift is a standalone product problem. v0.3+ should treat named
-  parameter profiles, immutable snapshots, proposals, overrides, and diffs as
-  first-class concepts.
+- Parameter drift is a standalone product problem. Post-MVP parameter work
+  should treat named parameter profiles, immutable snapshots, proposals,
+  overrides, and diffs as first-class concepts.
+- Sample visualization can stay convention-friendly: parameter table row keys
+  and user-authored 2D map configs can provide useful target binding without
+  forcing a full sample-component ontology early.
 - Useful run history should be generated from captured facts. Users will not
   reliably hand-enter code, parameter, setup, calibration, and environment
   context after every run.

--- a/docs-next/research/v03-future-systems.md
+++ b/docs-next/research/v03-future-systems.md
@@ -1,0 +1,102 @@
+# v0.3+ Future-System Research
+
+## Status
+
+Draft research synthesis.
+
+## Review Date
+
+2026-05-06.
+
+## Purpose
+
+Capture background lessons for v0.3+ parameter systems, managed code snapshots,
+runner capture, setup state, calibration history, and generated run history.
+
+This research informs `product/future-stories-and-requirements.md`; it does
+not change accepted v0.2 scope.
+
+## Sources
+
+Traditional measurement and control systems:
+
+- LabRAD Data Vault/Grapher:
+  https://sourceforge.net/p/labrad/wiki/QuickStartDataVaultAndGrapher/
+- QCoDeS measurement and station snapshots:
+  https://microsoft.github.io/Qcodes/examples/DataSet/Performing-measurements-using-qcodes-parameters-and-dataset.html
+  https://microsoft.github.io/Qcodes/examples/basic_examples/Station.html
+  https://microsoft.github.io/Qcodes/examples/DataSet/Working%20with%20snapshots.html
+- Bluesky documents and event model:
+  https://blueskyproject.io/bluesky/main/documents.html
+  https://blueskyproject.io/event-model/main/explanations/data-model.html
+- Tiled and Bluesky Tiled Plugins:
+  https://blueskyproject.io/tiled/getting-started/what-is-tiled.html
+  https://blueskyproject.io/bluesky-tiled-plugins/
+- Labber:
+  https://www.keysight.com/content/keysight/zz/en/products/all-instrument-software/labber-software.html
+- Labbench and PyMeasure:
+  https://pages.nist.gov/labbench/guide/02_getting_started/03%20data%20logging.html
+  https://pymeasure.readthedocs.io/en/stable/tutorial/procedure.html
+
+Code provenance, runner, and experiment-history systems:
+
+- Sacred:
+  https://sacred.readthedocs.io/en/latest/experiment.html
+  https://sacred.readthedocs.io/en/stable/optional.html
+- MLflow:
+  https://mlflow.org/docs/latest/ml/tracking/
+  https://mlflow.org/docs/latest/ml/projects/
+- W&B:
+  https://docs.wandb.ai/models/track
+  https://docs.wandb.ai/guides/app/features/panels/code
+- DVC:
+  https://dvc.org/doc/use-cases/experiment-tracking
+  https://dvc.org/doc/start/data-pipelines/data-pipelines
+- Sumatra:
+  https://sumatra.readthedocs.io/en/master/introduction.html
+  https://sumatra.readthedocs.io/en/latest/reference/records.html
+- ReproZip:
+  https://docs.reprozip.org/en/0.6.x/packing.html
+- Nextflow and Snakemake:
+  https://www.nextflow.io/docs/latest/reports.html
+  https://nextflow.io/docs/latest/tutorials/data-lineage.html
+  https://snakemake.readthedocs.io/en/v9.17.0/snakefiles/reporting.html
+  https://snakemake.readthedocs.io/en/latest/executing/provenance.html
+
+Lab state, audit, and calibration references:
+
+- EPICS Archiver Appliance:
+  https://epicsarchiver.readthedocs.io/en/latest/developer/details.html
+- Phoebus Olog:
+  https://control-system-studio.readthedocs.io/en/latest/app/logbook/olog/ui/doc/index.html
+- eLabFTW:
+  https://www.elabftw.net/
+  https://doc.elabftw.net/
+- LabKey LIMS:
+  https://www.labkey.com/products-services/lims-software/
+- openBIS data model:
+  https://openbis.readthedocs.io/en/20.10.12-plus/user-documentation/advance-features/openbis-data-modelling.html
+
+## Product Lessons
+
+- Parameter drift is a standalone product problem. v0.3+ should treat named
+  parameter profiles, immutable snapshots, proposals, overrides, and diffs as
+  first-class concepts.
+- Useful run history should be generated from captured facts. Users will not
+  reliably hand-enter code, parameter, setup, calibration, and environment
+  context after every run.
+- Managed code snapshot and runner capture matter early because they create
+  trustworthy history. They should be opt-in at first, not a forced replacement
+  for Python scripts.
+- Provenance confidence must be honest: unmanaged, observed, and managed
+  snapshots are different product states.
+- Setup/device/calibration state should start with store, bind, search, and
+  diff. Applying settings to devices comes later and needs safety ADRs.
+- Local-first experiment history aligns better with Fricon than cloud-first ML
+  tracking, model registries, or hyperparameter leaderboards.
+- Borrow lifecycle, event, and schema rigor from Bluesky, but avoid exposing
+  facility-scale document-stream complexity as the normal Fricon API.
+- Borrow QCoDeS station snapshot ideas, but avoid opaque giant snapshot dumps
+  as the main user experience. Diffs and named groups matter.
+- Borrow ELN/logbook links and audit primitives, but avoid becoming a full
+  ELN, LIMS, or compliance platform.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
@@ -1,0 +1,98 @@
+# SPEC-001: Data Library Measurement Foundation Design
+
+## Status
+
+Draft.
+
+## Design Summary
+
+Build a thin but coherent v0.2 backbone:
+
+```text
+Python SDK / Desktop / CLI
+  -> local service API
+  -> data library
+  -> measurement
+  -> dataset artifacts
+  -> live events and semantic reads
+```
+
+## Domain Records
+
+First implementation records:
+
+- DataLibrary
+- Measurement
+- DatasetArtifact
+- Event/AuditRecord
+- optional Sample and SampleSession links
+- optional ParameterSnapshot
+- optional CodeProvenanceSummary
+
+## Service Operations
+
+Candidate operation groups:
+
+- `library.open_or_create`
+- `compatibility.negotiate`
+- `measurements.create`
+- `measurements.finish`
+- `measurements.abort`
+- `measurements.record_event`
+- `datasets.create_writer`
+- `datasets.append`
+- `datasets.finish`
+- `datasets.abort`
+- `measurements.list_recent`
+- `measurements.get`
+- `datasets.read_semantic`
+- `events.subscribe`
+
+Exact route/transport shape requires an ADR.
+
+## Python Shape
+
+Draft user-facing shape:
+
+```python
+lib = fricon.library()
+lib.use_context(sample="sample-a", session="cooldown-2026-05")
+
+with lib.measurement("rabi q3") as meas:
+    ds = meas.dataset(
+        "rabi",
+        scan={"independent": "amp", "dependent": "signal"},
+    )
+    ds.write(amp=0.1, signal=0.25)
+```
+
+## Desktop Shape
+
+First screen becomes a measurement console:
+
+- active sample/session context
+- active measurements
+- recent measurements
+- produced datasets
+- table/plot actions
+- partial/failed/trash shortcuts
+- diagnostics when service or compatibility checks fail
+
+## Storage Shape
+
+Storage ADR must decide physical layout. The design requires only:
+
+- stable data-library and record identities
+- measurement catalog records
+- dataset payload chunks and semantic schema
+- event timeline records
+- compatibility version and migration state
+- active writer state sufficient for recovery
+
+## Open Design Questions
+
+1. Minimal lifecycle state enum and legal transitions.
+2. Data-library storage layout and pre-v0.2 import stance.
+3. Dataset artifact representation for fixed arrays and variable-length traces.
+4. HTTP/WebSocket/binary API shape and local service discovery.
+5. Actor/token storage and local operator profile scope.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
@@ -77,17 +77,24 @@ with lib.measurement("rabi q3") as meas:
     ds.write(amp=0.1, signal=0.25)
 ```
 
-Common scan and trace schema should also have helper APIs. Exact names are
-unsettled, but the public direction is:
+Common scan and trace schema should also have Python-native scan-plan authoring.
+Exact names and whether the accepted API is dict/literal data, a helper
+function, small builder objects, or multiple entry points are unsettled. The
+public direction is low ceremony for common workflows, then refinement from
+real script and notebook feedback:
 
 ```python
 with lib.measurement("rabi q3") as meas:
-    rabi = meas.scan_1d("rabi", x="amp", y="signal")
+    rabi = meas.scan(
+        "rabi",
+        plan={"axes": [{"name": "amp"}], "measure": ["signal"]},
+    )
     rabi.write(amp=0.1, signal=0.25)
 ```
 
-The helper path should not replace raw schema for irregular/adaptive,
-multi-output, repeated-point, or trace-heavy cases.
+The scan-plan path should not replace raw schema for irregular/adaptive,
+multi-output, repeated-point, or trace-heavy cases. It also should not imply a
+QCoDeS-compatible helper API or parameter-object model.
 
 ## Desktop Shape
 

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
@@ -28,6 +28,15 @@ First implementation records:
 - optional Sample and SampleSession links
 - optional ParameterSnapshot
 - optional CodeProvenanceSummary
+- optional SetupProvenanceSummary
+- optional ProcedureSummary
+
+DatasetArtifact remains a first-class searchable/openable record. Measurement
+is the primary navigation context, but datasets are not hidden children because
+future analysis, import, and export workflows need direct artifact handles.
+DatasetArtifact may have internal stream-like payload groups in storage/export
+or advanced read APIs, but v0.2 should keep streams out of the normal user
+concept budget.
 
 ## Service Operations
 
@@ -46,6 +55,8 @@ Candidate operation groups:
 - `measurements.list_recent`
 - `measurements.get`
 - `datasets.read_semantic`
+- `datasets.search`
+- `datasets.get`
 - `events.subscribe`
 
 Exact route/transport shape requires an ADR.
@@ -66,6 +77,18 @@ with lib.measurement("rabi q3") as meas:
     ds.write(amp=0.1, signal=0.25)
 ```
 
+Common scan and trace schema should also have helper APIs. Exact names are
+unsettled, but the public direction is:
+
+```python
+with lib.measurement("rabi q3") as meas:
+    rabi = meas.scan_1d("rabi", x="amp", y="signal")
+    rabi.write(amp=0.1, signal=0.25)
+```
+
+The helper path should not replace raw schema for irregular/adaptive,
+multi-output, repeated-point, or trace-heavy cases.
+
 ## Desktop Shape
 
 First screen becomes a measurement console:
@@ -74,6 +97,7 @@ First screen becomes a measurement console:
 - active measurements
 - recent measurements
 - produced datasets
+- dataset search/direct open entry points
 - table/plot actions
 - partial/failed/trash shortcuts
 - diagnostics when service or compatibility checks fail
@@ -85,6 +109,10 @@ Storage ADR must decide physical layout. The design requires only:
 - stable data-library and record identities
 - measurement catalog records
 - dataset payload chunks and semantic schema
+- scan shape modes for regular grids, partial grids, irregular/adaptive
+  points, repeated points, fixed-shape traces, and variable-length traces
+- partial-read semantics for interrupted or incomplete data
+- optional internal stream-like groups for advanced storage/export/read needs
 - event timeline records
 - compatibility version and migration state
 - active writer state sufficient for recovery
@@ -94,5 +122,11 @@ Storage ADR must decide physical layout. The design requires only:
 1. Minimal lifecycle state enum and legal transitions.
 2. Data-library storage layout and pre-v0.2 import stance.
 3. Dataset artifact representation for fixed arrays and variable-length traces.
-4. HTTP/WebSocket/binary API shape and local service discovery.
-5. Actor/token storage and local operator profile scope.
+4. Partial grid, irregular/adaptive, repeated-point, and trace read APIs.
+5. HTTP/WebSocket/binary API shape and local service discovery.
+6. Actor/token storage and local operator profile scope.
+7. Passive setup summary shape and whether future device snapshots need a
+   reserved artifact/reference hook.
+8. Passive procedure summary shape.
+9. Whether internal stream groups are required for first implementation or only
+   reserved in the storage/export ADRs.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
@@ -38,7 +38,7 @@ CAP-027, CAP-028, CAP-029.
 | REQ-016 | Support scan and trace shape modes. | Scan schema distinguishes regular grids, partial grids, irregular/adaptive points, repeated points, fixed-shape traces, and variable-length traces. |
 | REQ-017 | Expose readable partial semantics. | Interrupted data reads show partial/missing expected points when schema supports them; v0.2 does not promise execution resume. |
 | REQ-018 | Record passive setup summaries. | Measurements can link optional setup/device/environment/method summaries without device control. |
-| REQ-019 | Provide scan schema authoring helpers. | Common 1D/2D/N-D scan and trace cases have helper APIs; advanced cases can use raw schema. |
+| REQ-019 | Provide scan schema authoring helpers. | Common 1D/2D/N-D scan and trace cases have Python-native scan plans or helpers; advanced cases can use raw schema. Exact helper shape should be refined from usage feedback. |
 | REQ-020 | Record passive procedure summaries. | Measurements can link unmanaged script, external runner, or declared plan summaries without managed execution. |
 | REQ-021 | Allow internal artifact streams below the user concept. | Storage/export/read APIs may model internal streams, but v0.2 UI and public examples keep one dataset artifact as the normal concept. |
 

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
@@ -13,7 +13,8 @@ inspection, partial recovery, and Python reopen.
 ## Related Capabilities
 
 CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
-CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017.
+CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017, CAP-026,
+CAP-027, CAP-028, CAP-029.
 
 ## Requirements
 
@@ -33,14 +34,25 @@ CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017.
 | REQ-012 | Support trash/recover and backup checkpoint hooks. | Ordinary cleanup is recoverable; migration/repair has checkpoint strategy. |
 | REQ-013 | Record honest code provenance level. | Unmanaged code is labeled unmanaged unless user supplies summary. |
 | REQ-014 | Allow optional flexible parameter snapshot. | Measurement can link a snapshot without global profile registry. |
+| REQ-015 | Keep dataset artifacts first-class. | Dataset artifacts are searchable/openable by stable ID and context even in a measurement-first UI. |
+| REQ-016 | Support scan and trace shape modes. | Scan schema distinguishes regular grids, partial grids, irregular/adaptive points, repeated points, fixed-shape traces, and variable-length traces. |
+| REQ-017 | Expose readable partial semantics. | Interrupted data reads show partial/missing expected points when schema supports them; v0.2 does not promise execution resume. |
+| REQ-018 | Record passive setup summaries. | Measurements can link optional setup/device/environment/method summaries without device control. |
+| REQ-019 | Provide scan schema authoring helpers. | Common 1D/2D/N-D scan and trace cases have helper APIs; advanced cases can use raw schema. |
+| REQ-020 | Record passive procedure summaries. | Measurements can link unmanaged script, external runner, or declared plan summaries without managed execution. |
+| REQ-021 | Allow internal artifact streams below the user concept. | Storage/export/read APIs may model internal streams, but v0.2 UI and public examples keep one dataset artifact as the normal concept. |
 
 ## Non-Goals
 
 - Opening or migrating old v0.1 workspaces by default.
 - Data Vault/Grapher compatibility server or direct legacy importer.
 - Full export bundle format.
+- Resumable managed execution or scan-point checkpoints.
 - Remote access.
 - Managed runner or task queue.
+- User-facing dataset streams as a normal v0.2 concept.
 - Full parameter registry or calibration workflow.
 - Device communication.
+- Large detector-file/image asset management unless a focused ADR pulls a
+  narrow hook into scope.
 - AI mutating automation.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
@@ -1,0 +1,46 @@
+# SPEC-001: Data Library Measurement Foundation Requirements
+
+## Status
+
+Draft.
+
+## Purpose
+
+Define the first system slice for the v0.2 reset: one local data library,
+explicit measurement records, measurement-scoped dataset artifacts, live
+inspection, partial recovery, and Python reopen.
+
+## Related Capabilities
+
+CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
+CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017.
+
+## Requirements
+
+| ID | Requirement | Acceptance Criteria |
+| --- | --- | --- |
+| REQ-001 | Create/open a local data library with durable identity. | Library has UUID, display name, format version, and remembered location. |
+| REQ-002 | Route mutating operations through the local service. | Python, Desktop, and CLI cannot write without compatibility negotiation. |
+| REQ-003 | Create explicit measurements from Python. | API is short, reusable in notebooks, and records title/start time/lifecycle. |
+| REQ-004 | Support optional sample/session context. | Context is resolved on measurement creation, may be absent, and is correctable later. |
+| REQ-005 | Create dataset artifacts under a measurement. | A measurement can produce multiple datasets; writers share lifecycle by default. |
+| REQ-006 | Require explicit scan schema for plotted datasets. | Variables include roles, labels/units where supplied, dependencies, and axis structure. |
+| REQ-007 | Preserve append-only facts and partial data. | Crashes leave readable partial facts and visible interrupted/failed state. |
+| REQ-008 | Provide nonblocking live inspection events. | Live table/chart consumers never block, slow, or fail acquisition writes. |
+| REQ-009 | Record measurement events and notes. | Lifecycle events, notes, markers, corrections, and actor labels form a timeline. |
+| REQ-010 | Reopen measurement outputs from Python. | Reads use stable IDs and public APIs, not storage paths. |
+| REQ-011 | Fail before writes on incompatibility. | Client/service/library mismatch produces clear diagnostics before mutation. |
+| REQ-012 | Support trash/recover and backup checkpoint hooks. | Ordinary cleanup is recoverable; migration/repair has checkpoint strategy. |
+| REQ-013 | Record honest code provenance level. | Unmanaged code is labeled unmanaged unless user supplies summary. |
+| REQ-014 | Allow optional flexible parameter snapshot. | Measurement can link a snapshot without global profile registry. |
+
+## Non-Goals
+
+- Opening or migrating old v0.1 workspaces by default.
+- Data Vault/Grapher compatibility server or direct legacy importer.
+- Full export bundle format.
+- Remote access.
+- Managed runner or task queue.
+- Full parameter registry or calibration workflow.
+- Device communication.
+- AI mutating automation.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
@@ -1,0 +1,23 @@
+# SPEC-001: Data Library Measurement Foundation Tasks
+
+## Status
+
+Draft. Not implementation-ready until required ADRs are accepted.
+
+## Tasks
+
+| ID | Task | Status |
+| --- | --- | --- |
+| T-001 | Accept/reset ADRs and confirm lifecycle vocabulary. | Pending |
+| T-002 | Design data-library storage layout ADR. | Pending |
+| T-003 | Design service API and compatibility negotiation ADR. | Pending |
+| T-004 | Design dataset artifact storage/API ADR, including variable-length traces. | Pending |
+| T-005 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, and Event. | Pending |
+| T-006 | Add persistence adapters and migrations for first-slice records. | Pending |
+| T-007 | Add local service operations for compatibility, measurement, dataset writer, and events. | Pending |
+| T-008 | Redesign Python SDK measurement-scoped writer API. | Pending |
+| T-009 | Add semantic read/reopen path from Python. | Pending |
+| T-010 | Build Desktop measurement console skeleton. | Pending |
+| T-011 | Wire live event subscription and nonblocking table/chart preview. | Pending |
+| T-012 | Add partial/interrupted recovery and trash/recover basics. | Pending |
+| T-013 | Add focused tests and docs updates. | Pending |

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
@@ -12,12 +12,15 @@ Draft. Not implementation-ready until required ADRs are accepted.
 | T-002 | Design data-library storage layout ADR. | Pending |
 | T-003 | Design service API and compatibility negotiation ADR. | Pending |
 | T-004 | Design dataset artifact storage/API ADR, including variable-length traces. | Pending |
-| T-005 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, and Event. | Pending |
-| T-006 | Add persistence adapters and migrations for first-slice records. | Pending |
-| T-007 | Add local service operations for compatibility, measurement, dataset writer, and events. | Pending |
-| T-008 | Redesign Python SDK measurement-scoped writer API. | Pending |
-| T-009 | Add semantic read/reopen path from Python. | Pending |
-| T-010 | Build Desktop measurement console skeleton. | Pending |
-| T-011 | Wire live event subscription and nonblocking table/chart preview. | Pending |
-| T-012 | Add partial/interrupted recovery and trash/recover basics. | Pending |
-| T-013 | Add focused tests and docs updates. | Pending |
+| T-005 | Design scan shape and readable-partial semantics for regular, partial, irregular, repeated, and trace data. | Pending |
+| T-006 | Design scan schema helper API shape for common 1D/2D/N-D scans and traces. | Pending |
+| T-007 | Decide whether internal stream groups are implementation scope or ADR-reserved only. | Pending |
+| T-008 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, SetupProvenanceSummary, ProcedureSummary, and Event. | Pending |
+| T-009 | Add persistence adapters and migrations for first-slice records. | Pending |
+| T-010 | Add local service operations for compatibility, measurement, dataset writer/search/read, and events. | Pending |
+| T-011 | Redesign Python SDK measurement-scoped writer API. | Pending |
+| T-012 | Add semantic read/reopen path from Python. | Pending |
+| T-013 | Build Desktop measurement console skeleton with dataset direct-open entry points. | Pending |
+| T-014 | Wire live event subscription and nonblocking table/chart preview. | Pending |
+| T-015 | Add readable partial data and trash/recover basics. | Pending |
+| T-016 | Add focused tests and docs updates. | Pending |

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
@@ -13,7 +13,7 @@ Draft. Not implementation-ready until required ADRs are accepted.
 | T-003 | Design service API and compatibility negotiation ADR. | Pending |
 | T-004 | Design dataset artifact storage/API ADR, including variable-length traces. | Pending |
 | T-005 | Design scan shape and readable-partial semantics for regular, partial, irregular, repeated, and trace data. | Pending |
-| T-006 | Design scan schema helper API shape for common 1D/2D/N-D scans and traces. | Pending |
+| T-006 | Design Python-native scan-plan/helper API shape for common 1D/2D/N-D scans and traces. | Pending |
 | T-007 | Decide whether internal stream groups are implementation scope or ADR-reserved only. | Pending |
 | T-008 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, SetupProvenanceSummary, ProcedureSummary, and Event. | Pending |
 | T-009 | Add persistence adapters and migrations for first-slice records. | Pending |

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
@@ -1,0 +1,60 @@
+# SPEC-001: Traceability
+
+## Status
+
+Draft.
+
+## Related Capabilities
+
+CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
+CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017.
+
+## Related User Stories
+
+US-001, US-002, US-003, US-004, US-005, US-006, US-007, US-008, US-010,
+US-011, US-012.
+
+## Related Domain Concepts
+
+DataLibrary, Measurement, DatasetArtifact, Sample, SampleSession,
+ParameterSnapshot, CodeProvenanceSummary, Event/AuditRecord, OperatorProfile.
+
+## Related Architecture Docs
+
+- `architecture/system-overview.md`
+- `architecture/module-boundaries.md`
+- `architecture/data-flow.md`
+- `architecture/api-boundaries.md`
+- `architecture/storage-model.md`
+- `architecture/compatibility-policy.md`
+
+## Related ADRs
+
+- ADR-001: v0.2 Clean Reset Boundary
+- ADR-002: Documentation Governance For v0.2+
+- Pending: data-library storage layout
+- Pending: service API contract
+- Pending: dataset artifact storage and scan schema
+- Pending: lifecycle and event model
+
+## Affected Modules
+
+Expected high-impact areas:
+
+- `crates/fricon/src/**`
+- `crates/fricon-py/**`
+- `crates/fricon-ui/src/**`
+- `crates/fricon-ui/frontend/src/**`
+- `docs-next/**`
+- later public `docs/**` after behavior lands
+
+## Compatibility Impact
+
+This spec intentionally breaks pre-v0.2 workspace/dataset-first assumptions.
+
+Before implementation, confirm whether any pre-v0.2 data migration/import path
+is required. Default policy is no automatic compatibility.
+
+## Validation Links
+
+See `validation.md`.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
@@ -41,7 +41,7 @@ ProcedureSummary, Event/AuditRecord, OperatorProfile.
 - Pending: scan shape and readable-partial semantics
 - Pending: passive setup summary shape
 - Pending: passive procedure summary shape
-- Pending: scan schema helper API shape
+- Pending: Python-native scan-plan/helper API shape
 - Pending: internal stream/subpayload representation, if needed
 
 ## Affected Modules

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
@@ -7,17 +7,19 @@ Draft.
 ## Related Capabilities
 
 CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
-CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017.
+CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017, CAP-026,
+CAP-027, CAP-028, CAP-029.
 
 ## Related User Stories
 
 US-001, US-002, US-003, US-004, US-005, US-006, US-007, US-008, US-010,
-US-011, US-012.
+US-011, US-012, US-013, US-014, US-015, US-016.
 
 ## Related Domain Concepts
 
 DataLibrary, Measurement, DatasetArtifact, Sample, SampleSession,
-ParameterSnapshot, CodeProvenanceSummary, Event/AuditRecord, OperatorProfile.
+ParameterSnapshot, CodeProvenanceSummary, SetupProvenanceSummary,
+ProcedureSummary, Event/AuditRecord, OperatorProfile.
 
 ## Related Architecture Docs
 
@@ -36,6 +38,11 @@ ParameterSnapshot, CodeProvenanceSummary, Event/AuditRecord, OperatorProfile.
 - Pending: service API contract
 - Pending: dataset artifact storage and scan schema
 - Pending: lifecycle and event model
+- Pending: scan shape and readable-partial semantics
+- Pending: passive setup summary shape
+- Pending: passive procedure summary shape
+- Pending: scan schema helper API shape
+- Pending: internal stream/subpayload representation, if needed
 
 ## Affected Modules
 

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
@@ -16,7 +16,7 @@ Python SDK, and Desktop.
 | Rust domain/storage | Unit and integration tests for lifecycle transitions, record links, compatibility gates, and recovery state. |
 | Dataset artifact | Tests for append, finish, abort, scan schema validation, semantic reads, regular grids, partial grids, irregular/adaptive points, repeated points, fixed arrays, and variable-length traces once designed. |
 | Service API | Tests for negotiate-before-write, active writer isolation, live event ordering, and mismatch diagnostics. |
-| Python SDK | Integration tests for `fricon.library()`, measurement-scoped dataset writes, scan helper APIs, raw schema escape hatch, crash/abort behavior, and reopen snippets. |
+| Python SDK | Integration tests for `fricon.library()`, measurement-scoped dataset writes, scan-plan/helper APIs, raw schema escape hatch, crash/abort behavior, and reopen snippets. |
 | Desktop | Browser/unit tests for measurement console state, active/recent lists, live update rendering, and compatibility diagnostics. |
 | Export | Deferred until export format ADR, but keep measurement-centered export acceptance in scope. |
 | Docs | Docs-next traceability and public docs updated only after behavior lands. |
@@ -33,7 +33,8 @@ Python SDK, and Desktop.
    reopen preserves trace facts.
 7. Reopen produced datasets from Python using stable IDs and direct dataset
    handles.
-8. Create a common scan through a helper and an advanced scan through raw
-   schema, then verify both produce equivalent semantic reads where expected.
+8. Create a common scan through a scan plan/helper and an advanced scan through
+   raw schema, then verify both produce equivalent semantic reads where
+   expected.
 9. Attempt to write with an incompatible client and verify failure before
    mutation.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
@@ -14,9 +14,9 @@ Python SDK, and Desktop.
 | Area | Validation |
 | --- | --- |
 | Rust domain/storage | Unit and integration tests for lifecycle transitions, record links, compatibility gates, and recovery state. |
-| Dataset artifact | Tests for append, finish, abort, scan schema validation, semantic reads, fixed arrays, and variable-length traces once designed. |
+| Dataset artifact | Tests for append, finish, abort, scan schema validation, semantic reads, regular grids, partial grids, irregular/adaptive points, repeated points, fixed arrays, and variable-length traces once designed. |
 | Service API | Tests for negotiate-before-write, active writer isolation, live event ordering, and mismatch diagnostics. |
-| Python SDK | Integration tests for `fricon.library()`, measurement-scoped dataset writes, crash/abort behavior, and reopen snippets. |
+| Python SDK | Integration tests for `fricon.library()`, measurement-scoped dataset writes, scan helper APIs, raw schema escape hatch, crash/abort behavior, and reopen snippets. |
 | Desktop | Browser/unit tests for measurement console state, active/recent lists, live update rendering, and compatibility diagnostics. |
 | Export | Deferred until export format ADR, but keep measurement-centered export acceptance in scope. |
 | Docs | Docs-next traceability and public docs updated only after behavior lands. |
@@ -26,7 +26,14 @@ Python SDK, and Desktop.
 1. Run a 1D measurement and watch a live line/scatter view.
 2. Run a 2D measurement and watch a live heatmap with explicit axes.
 3. Record a measurement without sample context, then attach/correct context.
-4. Crash or interrupt a measurement and verify partial data remains readable.
-5. Reopen produced datasets from Python using stable IDs.
-6. Attempt to write with an incompatible client and verify failure before
+4. Crash or interrupt a measurement and verify partial data remains readable
+   with missing/partial shape semantics where expected points were declared.
+5. Write an irregular/adaptive scan and verify reads do not force a fake grid.
+6. Write variable-length traces with per-trace coordinates and verify Python
+   reopen preserves trace facts.
+7. Reopen produced datasets from Python using stable IDs and direct dataset
+   handles.
+8. Create a common scan through a helper and an advanced scan through raw
+   schema, then verify both produce equivalent semantic reads where expected.
+9. Attempt to write with an incompatible client and verify failure before
    mutation.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
@@ -1,0 +1,32 @@
+# SPEC-001: Validation
+
+## Status
+
+Draft.
+
+## Validation Strategy
+
+Use focused cross-surface tests because the slice crosses Rust core/service,
+Python SDK, and Desktop.
+
+## Required Checks
+
+| Area | Validation |
+| --- | --- |
+| Rust domain/storage | Unit and integration tests for lifecycle transitions, record links, compatibility gates, and recovery state. |
+| Dataset artifact | Tests for append, finish, abort, scan schema validation, semantic reads, fixed arrays, and variable-length traces once designed. |
+| Service API | Tests for negotiate-before-write, active writer isolation, live event ordering, and mismatch diagnostics. |
+| Python SDK | Integration tests for `fricon.library()`, measurement-scoped dataset writes, crash/abort behavior, and reopen snippets. |
+| Desktop | Browser/unit tests for measurement console state, active/recent lists, live update rendering, and compatibility diagnostics. |
+| Export | Deferred until export format ADR, but keep measurement-centered export acceptance in scope. |
+| Docs | Docs-next traceability and public docs updated only after behavior lands. |
+
+## Scenario Checks
+
+1. Run a 1D measurement and watch a live line/scatter view.
+2. Run a 2D measurement and watch a live heatmap with explicit axes.
+3. Record a measurement without sample context, then attach/correct context.
+4. Crash or interrupt a measurement and verify partial data remains readable.
+5. Reopen produced datasets from Python using stable IDs.
+6. Attempt to write with an incompatible client and verify failure before
+   mutation.

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/design.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/design.md
@@ -1,0 +1,34 @@
+# SPEC-002: Measurement Export And Offline Analysis Design
+
+## Status
+
+Draft placeholder.
+
+## Direction
+
+Treat export bundles as read-only analysis packages:
+
+```text
+Measurement
+  -> manifest and source identity
+  -> produced dataset artifacts
+  -> selected sample/session context
+  -> notes/events and lifecycle state
+  -> parameter/code/setup summaries selected for export
+  -> checksums
+  -> common tabular files where practical
+  -> Python loader snippets
+```
+
+The Fricon manifest remains the source of meaning. CSV or similar common files
+are convenience outputs and may be lossy.
+
+## Open Questions
+
+1. Bundle extension and physical layout.
+2. Which common formats are required in v0.2.
+3. How to represent variable-length traces and partial grids in common formats.
+4. Direct Python reader API.
+5. Privacy preview UX and defaults.
+6. Whether Desktop opens bundles without a running local service in v0.2 or a
+   later polish slice.

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/requirements.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/requirements.md
@@ -1,0 +1,33 @@
+# SPEC-002: Measurement Export And Offline Analysis Requirements
+
+## Status
+
+Draft placeholder.
+
+## Purpose
+
+Define the near-term export slice that follows SPEC-001. Export is part of the
+v0.2 product promise, but it should not be hidden inside the foundation spec.
+
+## Related Capabilities
+
+CAP-010, CAP-011, CAP-026.
+
+## Requirements To Refine
+
+| ID | Requirement | Acceptance Criteria |
+| --- | --- | --- |
+| REQ-001 | Export starts from a measurement by default. | Produced dataset artifacts and selected metadata are included. |
+| REQ-002 | Exported datasets remain directly readable. | Python can open the export without importing into a data library. |
+| REQ-003 | Preserve semantic metadata. | Variable roles, units, scan shape modes, partial semantics, and trace facts travel with the export. |
+| REQ-004 | Include source and integrity metadata. | Source data-library identity, export identity, format version, record IDs, and checksums are recorded. |
+| REQ-005 | Support common analysis formats where practical. | CSV/Parquet/NetCDF/XArray-oriented paths are evaluated without making lossy formats the source of meaning. |
+| REQ-006 | Preview sensitive provenance. | Local paths, source computer labels, detailed environment summaries, and dirty code state are opt-in or previewed. |
+| REQ-007 | Preserve passive summaries when selected. | Code provenance, setup summaries, and procedure summaries can travel in the export with privacy preview. |
+| REQ-008 | Preserve internal artifact grouping when needed. | Internal streams/subpayloads remain readable without making stream names the primary user-facing concept. |
+
+## Non-Goals
+
+- Importing the export into another editable data library as the default path.
+- Full offline Desktop viewer polish before the write/reopen loop is proven.
+- Legacy Data Vault/Labber/HDF5 compatibility layers.

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/tasks.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/tasks.md
@@ -1,0 +1,16 @@
+# SPEC-002: Measurement Export And Offline Analysis Tasks
+
+## Status
+
+Draft placeholder.
+
+## Tasks
+
+| ID | Task | Status |
+| --- | --- | --- |
+| T-001 | Write export bundle format ADR. | Pending |
+| T-002 | Define semantic manifest subset for exports. | Pending |
+| T-003 | Decide common analysis formats for v0.2. | Pending |
+| T-004 | Design direct Python export reader API. | Pending |
+| T-005 | Design privacy preview defaults. | Pending |
+| T-006 | Add validation scenarios for regular grids, partial grids, irregular scans, and variable-length traces. | Pending |

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/traceability.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/traceability.md
@@ -1,0 +1,33 @@
+# SPEC-002: Traceability
+
+## Status
+
+Draft placeholder.
+
+## Related Capabilities
+
+CAP-010, CAP-011, CAP-026.
+
+## Related User Stories
+
+US-008, US-009, US-013.
+
+## Related Domain Concepts
+
+Measurement, DatasetArtifact, ExportBundle, DataLibrary,
+ParameterSnapshot, CodeProvenanceSummary, SetupProvenanceSummary,
+Event/AuditRecord.
+
+## Related Docs
+
+- `product/story-map.md`
+- `domain/conceptual-model.md`
+- `architecture/storage-model.md`
+- `architecture/compatibility-policy.md`
+- `research/lessons-for-fricon.md`
+
+## ADRs Needed
+
+- export bundle format
+- common analysis format policy
+- export privacy defaults

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/validation.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/validation.md
@@ -1,0 +1,15 @@
+# SPEC-002: Validation
+
+## Status
+
+Draft placeholder.
+
+## Scenario Checks
+
+1. Export a measurement with one regular-grid dataset.
+2. Export a partial-grid measurement and verify missing expected points remain
+   visible.
+3. Export an irregular/adaptive scan without forcing a fake dense grid.
+4. Export variable-length traces with per-trace coordinates.
+5. Open the export from Python without importing into a data library.
+6. Verify sensitive provenance is omitted unless selected.

--- a/docs-next/user/documentation-plan.md
+++ b/docs-next/user/documentation-plan.md
@@ -1,0 +1,24 @@
+# Public Documentation Plan
+
+## Status
+
+Draft. Do not publish as current behavior.
+
+## Purpose
+
+Plan future user-facing documentation after v0.2 behavior lands. Current public
+docs in `docs/` still describe implemented v0.1 behavior.
+
+## Future Diataxis Split
+
+| Doc Type | v0.2 Topics |
+| --- | --- |
+| Tutorials | Install Fricon, create a data library, run first measurement, inspect live data. |
+| How-to guides | Add sample/session context, recover partial run, reopen data from Python, export measurement. |
+| Reference | Python SDK, CLI diagnostics, service compatibility messages, export bundle format. |
+| Explanation | Data library model, measurement vs dataset artifact, scan schema, compatibility policy. |
+
+## Publication Rule
+
+Do not update public docs to claim v0.2 behavior until the relevant code and
+tests are implemented.


### PR DESCRIPTION
## Summary
- Reworked the `docs-next` baseline around MVP, post-MVP priority horizons, and ADR-gated decisions instead of v0.3-style labeling.
- Rebuilt product guidance for vision, capability map, future concepts, stories, glossary, and Python SDK ergonomics around the reset model.
- Added/updated the supporting domain, architecture, research, and implementation-planning docs so the new docs chain stays coherent for agents.
- Kept scan ergonomics as a Python-native, low-ceremony requirement and deferred exact helper shape to later feedback.
- Ignored `docs-next/` in Prettier and preserved compact Markdown tables in `dev-docs/README.md` for AI readability.

## Testing
- `pnpm run format:check` passed.
- `prek run typos` passed on the changed docs.
- `git diff --check` passed.