### PR TITLE
docs: capture the future-state measurement model

### DIFF
--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -71,7 +71,13 @@ sidecars, and notebook-local analysis make calibration hard to trust and harder
 to automate safely. Fricon should first make code provenance, effective
 parameter snapshots, diffs, calibration evidence, and reviewed parameter
 changes durable enough that experimenters can trust the next run. Detailed
-confidence-label schemes can wait until a concrete workflow needs them.
+field-level confidence-label schemes can wait, but calibration task
+health/confidence gates are part of the post-MVP automation motivation.
+
+Use Calibration as the normal domain term for quantum-experiment parameter
+calibration. Qualify other meanings explicitly: instrument calibration for
+hardware/setup calibration, and setup/device reconciliation for desired-state
+apply/readback workflows.
 
 ## Product Route
 
@@ -141,8 +147,9 @@ It can eventually coordinate scheduled calibration, optimization, benchmark,
 and repeated measurement tasks, but should rely on clear measurement records,
 parameter snapshots, code provenance, generated artifacts, calibration
 evidence, visible before/after diffs, and human approval boundaries.
-Calibration-derived settings should be staged as reviewed proposals before
-they update active parameter refs, setup refs, generated config, or devices.
+Small calibration tasks may update chain-scoped working parameter refs for
+later steps. Publishing selected calibration results to durable named refs,
+setup refs, generated config, or devices should remain explicit and auditable.
 
 Fricon should also learn from modern desired-state systems without pretending
 lab hardware is a browser DOM or cloud resource graph. Many current scripts use

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -65,6 +65,14 @@ system that records enough facts to explain what happened, compare against
 previous-good runs, hand off state between operators, repeat work with visible
 differences, and automate only through reviewed plans and durable audit records.
 
+The highest-value post-MVP motivation is the code-and-parameter management
+loop. Copied measurement code, mutable parameter/config files, generated
+sidecars, and notebook-local analysis make calibration hard to trust and harder
+to automate safely. Fricon should first make code provenance, effective
+parameter snapshots, diffs, calibration evidence, and reviewed parameter
+changes durable enough that experimenters can trust the next run. Detailed
+confidence-label schemes can wait until a concrete workflow needs them.
+
 ## Product Route
 
 The product route is now the v0.2 measurement-library reset: Python-led,
@@ -131,7 +139,10 @@ one.
 Workflow automation should be treated as a layer above individual measurements.
 It can eventually coordinate scheduled calibration, optimization, benchmark,
 and repeated measurement tasks, but should rely on clear measurement records,
-parameter snapshots, provenance, and human approval boundaries.
+parameter snapshots, code provenance, generated artifacts, calibration
+evidence, visible before/after diffs, and human approval boundaries.
+Calibration-derived settings should be staged as reviewed proposals before
+they update active parameter refs, setup refs, generated config, or devices.
 
 AI-assisted workflows should be designed as assistive automation rather than
 silent authority. AI may help draft snippets, summaries, reports, metadata

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -144,6 +144,17 @@ evidence, visible before/after diffs, and human approval boundaries.
 Calibration-derived settings should be staged as reviewed proposals before
 they update active parameter refs, setup refs, generated config, or devices.
 
+Fricon should also learn from modern desired-state systems without pretending
+lab hardware is a browser DOM or cloud resource graph. Many current scripts use
+imperative nested loops that calculate and send every device setting inside the
+loop body. For routines that can be modeled safely, a better post-MVP direction
+is declarative: users define how parameters produce expected setup/device
+state, Fricon diffs that desired state against observed/readback state,
+previews an apply plan, skips no-op writes, groups safe independent writes, and
+records intended values, write attempts, readbacks, failures, and overrides.
+This needs explicit dependency, settling, timeout, readback, and abort behavior
+before it can control hardware.
+
 AI-assisted workflows should be designed as assistive automation rather than
 silent authority. AI may help draft snippets, summaries, reports, metadata
 cleanup, parameter comparisons, and workflow proposals, but mutating
@@ -344,6 +355,12 @@ Workflow definitions may eventually orchestrate repeated measurement execution,
 scheduled calibration, parameter optimization, and benchmark runs. These
 capabilities should record workflow versions, triggers, inputs, outputs,
 approval checkpoints, failures, and manual overrides.
+
+When workflow definitions touch setup or devices, prefer a desired-state plus
+reconciliation model over hand-coded command sequences where possible. Desired
+state, observed state, reconciliation plan, and apply execution should be
+separate records. This makes no-op changes, hidden drift, safe parallelism,
+partial failure, and rollback easier to reason about.
 
 AI model integration may eventually automate boring or repetitive work, but
 should not bypass product boundaries. AI-generated changes to data,

--- a/dev-docs/project-intent.md
+++ b/dev-docs/project-intent.md
@@ -59,6 +59,12 @@ Fricon is expected to provide:
 The product should make common scientific measurement workflows easier while
 remaining scriptable for users who already use Python in their research.
 
+The long-term product should go beyond replacing a logger. After the local
+measurement loop is reliable, Fricon should become local experiment memory: a
+system that records enough facts to explain what happened, compare against
+previous-good runs, hand off state between operators, repeat work with visible
+differences, and automate only through reviewed plans and durable audit records.
+
 ## Product Route
 
 The product route is now the v0.2 measurement-library reset: Python-led,

--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -89,6 +89,27 @@ docs-next/
   user/                 Future public documentation plan, not current docs
 ```
 
+## Source-Of-Truth Ownership
+
+Keep each idea in the narrowest durable owner:
+
+- `product/vision.md` owns the accepted product thesis, MVP goal, user promise,
+  and high-level product horizons.
+- `product/future-concepts.md` owns the accepted post-MVP priority ledger and
+  promotion rule.
+- `product/future-stories-and-requirements.md` owns proposed future user stories
+  and requirements. It should reference the priority ledger instead of restating
+  its rationale.
+- `product/capability-map.md` owns stable capability IDs and compact scope
+  boundaries. Detailed acceptance notes belong in stories, specs, or ADRs.
+- `product/glossary.md` owns public and future terminology.
+- `domain/conceptual-model.md`, `domain/context-map.md`, and
+  `domain/invariants.md` own concept relationships, bounded-context routing,
+  and hard anti-corruption rules.
+- `specs/` own implementation-slice requirements, design, tasks,
+  traceability, and validation.
+- `ai/` owns agent routing and update policy, not product or domain rationale.
+
 ## Source Inputs
 
 This baseline was bootstrapped from:

--- a/docs-next/ai/agent-steering.md
+++ b/docs-next/ai/agent-steering.md
@@ -26,6 +26,8 @@ Pause local implementation and update docs when:
 - an AI/calibration/automation feature would mutate data-library state
 - a calibration or analysis workflow would update active parameters, setup
   refs, generated config, or devices without a reviewed proposal/audit path
+- a managed routine introduces desired-state setup/device reconciliation,
+  parallel device apply, readback semantics, or partial-failure handling
 - a spec contradicts an accepted ADR
 
 ## Review Questions Before Implementation

--- a/docs-next/ai/agent-steering.md
+++ b/docs-next/ai/agent-steering.md
@@ -24,8 +24,11 @@ Pause local implementation and update docs when:
 - storage/API compatibility behavior changes
 - a lifecycle or recovery state is added
 - an AI/calibration/automation feature would mutate data-library state
-- a calibration or analysis workflow would update active parameters, setup
-  refs, generated config, or devices without a reviewed proposal/audit path
+- a calibration or analysis workflow would update durable named parameter refs,
+  setup refs, generated config, or devices without a reviewed proposal/audit
+  path
+- a calibration chain introduces working refs, health gates, retry semantics,
+  or pause/review behavior
 - a managed routine introduces desired-state setup/device reconciliation,
   parallel device apply, readback semantics, or partial-failure handling
 - a spec contradicts an accepted ADR

--- a/docs-next/ai/agent-steering.md
+++ b/docs-next/ai/agent-steering.md
@@ -24,6 +24,8 @@ Pause local implementation and update docs when:
 - storage/API compatibility behavior changes
 - a lifecycle or recovery state is added
 - an AI/calibration/automation feature would mutate data-library state
+- a calibration or analysis workflow would update active parameters, setup
+  refs, generated config, or devices without a reviewed proposal/audit path
 - a spec contradicts an accepted ADR
 
 ## Review Questions Before Implementation

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -30,11 +30,8 @@ Product planning uses MVP, post-MVP priority, and ADR-gated labels. Do not
 interpret post-MVP priorities as semantic-version labels; compatible additions
 may remain on the same compatible release line.
 
-Post-MVP priority order:
-
-1. Parameter system.
-2. Managed run.
-3. Calibration chains and reviewable automation.
+Post-MVP priority order and rationale are owned by
+`product/future-concepts.md`.
 
 Primary user model:
 
@@ -70,23 +67,10 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   the exact simplification shape before real script/notebook feedback.
 - Keep sample/session context optional and correctable.
 - Do not turn sample target binding into a heavy physical-component ontology
-  unless a later product decision requires it. Prefer user-defined parameter
-  row keys plus optional sample-map configs/DSLs.
-- Treat sample visualizers as views over parameter snapshots or snapshot query
-  results. Keep config placement, query syntax, and schema-evolution behavior
-  deferred until a focused spec or ADR.
-- Prioritize post-MVP foundations by user pain: parameter diffs and proposals,
-  code/source provenance, calibration evidence tied to affected parameter
-  paths, run manifests and failure investigation, then calibration chains,
-  reviewed routine replay, or automation.
-- Desired-state setup/device reconciliation is a later post-MVP improvement
-  for routines that outgrow imperative nested loops. Keep desired state,
-  observed state, reconciliation plans, and apply executions separate, and do
-  not parallelize or reorder device writes without explicit safety semantics.
-- Do not make detailed confidence-label taxonomies the center of post-MVP
-  planning. First make code state, effective parameters, calibration evidence,
-  calibration task health/confidence gates, before/after diffs, and reviewed
-  durable promotion paths.
+  unless a later product decision requires it.
+- For post-MVP parameter, calibration, run-manifest, sample-visualizer, and
+  setup/device reconciliation details, read `product/future-concepts.md`,
+  `product/glossary.md`, and `domain/invariants.md`.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
 - Use events for lifecycle, notes, corrections, and audit history.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -76,8 +76,12 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   results. Keep config placement, query syntax, and schema-evolution behavior
   deferred until a focused spec or ADR.
 - Prioritize post-MVP foundations by user pain: parameter diffs and proposals,
-  run manifests and failure investigation, then reviewed routine replay or
-  automation.
+  code/source provenance, calibration evidence tied to affected parameter
+  paths, run manifests and failure investigation, then reviewed routine replay
+  or automation.
+- Do not make detailed confidence-label taxonomies the center of post-MVP
+  planning. First make code state, effective parameters, calibration evidence,
+  before/after diffs, and reviewed application durable.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
 - Use events for lifecycle, notes, corrections, and audit history.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -79,6 +79,10 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   code/source provenance, calibration evidence tied to affected parameter
   paths, run manifests and failure investigation, then reviewed routine replay
   or automation.
+- Desired-state setup/device reconciliation is a later post-MVP improvement
+  for routines that outgrow imperative nested loops. Keep desired state,
+  observed state, reconciliation plans, and apply executions separate, and do
+  not parallelize or reorder device writes without explicit safety semantics.
 - Do not make detailed confidence-label taxonomies the center of post-MVP
   planning. First make code state, effective parameters, calibration evidence,
   before/after diffs, and reviewed application durable.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -85,7 +85,8 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   not parallelize or reorder device writes without explicit safety semantics.
 - Do not make detailed confidence-label taxonomies the center of post-MVP
   planning. First make code state, effective parameters, calibration evidence,
-  before/after diffs, and reviewed application durable.
+  calibration task health/confidence gates, before/after diffs, and reviewed
+  durable promotion paths.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
 - Use events for lifecycle, notes, corrections, and audit history.

--- a/docs-next/ai/project-context.md
+++ b/docs-next/ai/project-context.md
@@ -34,7 +34,7 @@ Post-MVP priority order:
 
 1. Parameter system.
 2. Managed run.
-3. Reviewable automation workflow.
+3. Calibration chains and reviewable automation.
 
 Primary user model:
 
@@ -77,8 +77,8 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   deferred until a focused spec or ADR.
 - Prioritize post-MVP foundations by user pain: parameter diffs and proposals,
   code/source provenance, calibration evidence tied to affected parameter
-  paths, run manifests and failure investigation, then reviewed routine replay
-  or automation.
+  paths, run manifests and failure investigation, then calibration chains,
+  reviewed routine replay, or automation.
 - Desired-state setup/device reconciliation is a later post-MVP improvement
   for routines that outgrow imperative nested loops. Keep desired state,
   observed state, reconciliation plans, and apply executions separate, and do

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -55,7 +55,8 @@ DataLibrary
 ## Parameter And Configuration Boundaries
 
 MVP configuration capture should not collapse future parameter management into
-one generic snapshot object.
+one generic snapshot object. `product/glossary.md` owns term definitions; this
+section owns the concept split.
 
 - Parameter context summary: optional user-supplied or imported context for a
   measurement before profiles, refs, overrides, and proposal workflows exist.
@@ -94,11 +95,8 @@ imperative loop scripts.
 - ApplyExecution: attempted writes, readbacks, skipped actions, failures,
   manual overrides, and divergence from the approved plan.
 
-This borrows the useful part of declarative UI and infrastructure systems:
-users describe the expected end state, and the system computes a reviewed plan
-to move current state toward it. It must not hide hardware side effects behind
-an opaque "render" step, and it must not assume device writes are idempotent,
-commutative, or safe to parallelize.
+Detailed reconciliation safety rules belong in `domain/invariants.md` and later
+device/setup ADRs.
 
 ## Code, Parameter, And Calibration Boundaries
 
@@ -120,12 +118,8 @@ calibration and Setup/Device Reconciliation for desired-state apply/readback.
   should be artifacts with source inputs and generator context, not invisible
   files that future runs depend on by accident.
 
-Calibration automation should therefore record evidence, task-chain state,
-health decisions, retries, pause/review points, and promotion proposals.
-Small tasks in an approved calibration chain may update a chain-scoped
-calibration working ref for later tasks to consume. Publishing the final or
-selected chain results to durable named refs remains a separate promotion step.
-Device/setup reconciliation is a separate safety-gated capability.
+Detailed calibration-chain and mutation rules belong in `domain/invariants.md`
+and the post-MVP backlog.
 
 ## Dataset Artifact Shape
 
@@ -195,13 +189,8 @@ DataLibrary
 `ActivityRun` is an internal modeling pattern. Users should see concrete words:
 Measurement, Analysis, Import, Simulation, and Calibration.
 
-Analysis attempts, calibration records, and calibration proposals should remain
-separate concepts. Analysis consumes data and produces results or diagnostics.
-Calibration records describe validity, review state, and affected-run windows.
-Calibration task runs describe a small calibration step, its fitted values,
-diagnostics, health decision, and any chain-scoped working-ref update.
-Calibration chain runs describe ordered bootstrap calibration work with
-dependencies, retries, pause/review decisions, and intermediate working state.
-Calibration proposals recommend reviewed durable parameter changes and carry
-the before/after diff, actor/reviewer, outcome, and rollback target where
-practical.
+Analysis attempts, calibration records, calibration task runs, calibration
+chain runs, and calibration proposals remain separate concepts. Their user
+stories and requirements live in
+`product/future-stories-and-requirements.md`; their hard anti-corruption rules
+live in `domain/invariants.md`.

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -74,6 +74,28 @@ one generic snapshot object.
   calibration evidence. It may propose parameter or setup changes after review;
   it must not silently edit an active parameter ref.
 
+## Desired State And Reconciliation Boundaries
+
+A later managed setup/device model can be more declarative than today's
+imperative loop scripts.
+
+- DesiredSetupState: expected setup or device state derived from parameters,
+  routine inputs, and code. It is an intent record, not proof that hardware
+  changed.
+- ObservedDeviceState: readback, status, freshness, and source facts reported
+  by an integration or operator.
+- ReconciliationPlan: diff between desired state and observed/current state,
+  including no-op writes, ordered dependencies, safe parallel groups,
+  settle/readback checks, and abort behavior.
+- ApplyExecution: attempted writes, readbacks, skipped actions, failures,
+  manual overrides, and divergence from the approved plan.
+
+This borrows the useful part of declarative UI and infrastructure systems:
+users describe the expected end state, and the system computes a reviewed plan
+to move current state toward it. It must not hide hardware side effects behind
+an opaque "render" step, and it must not assume device writes are idempotent,
+commutative, or safe to parallelize.
+
 ## Code, Parameter, And Calibration Boundaries
 
 Fricon should keep code, parameter, and calibration facts separate even when a
@@ -133,6 +155,9 @@ DataLibrary
     ScriptRun
     DeviceIdentity
     DeviceSnapshot
+    DesiredSetupState
+    ReconciliationPlan
+    ApplyExecution
     RunManifest(read model)
     Event/AuditRecord
 
@@ -144,6 +169,8 @@ DataLibrary
     CalibrationRecord -> links -> Measurement | AnalysisAttempt | ParameterSnapshot | Artifact
     CalibrationProposal -> cites -> CalibrationRecord | AnalysisAttempt | CodeSnapshot | ParameterSnapshot | Artifact
     CalibrationProposal -> may propose -> ParameterProfile change | Setup change
+    ReconciliationPlan -> compares -> DesiredSetupState | DeviceSnapshot
+    ApplyExecution -> executes -> ReconciliationPlan
 ```
 
 `ActivityRun` is an internal modeling pattern. Users should see concrete words:

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -63,6 +63,10 @@ one generic snapshot object.
   refs, profiles, and overrides.
 - ParameterProfileRef: future mutable named pointer such as `main` or
   `latest-good`.
+- CalibrationWorkingRef: future chain-scoped mutable pointer used inside an
+  approved calibration chain. Small calibration tasks may update it so later
+  tasks consume the latest fitted values without publishing those values as
+  durable lab state.
 - ParameterProposal: future reviewed change request that may update a named
   parameter ref after approval.
 - RunConfigSnapshot: selected local file references, copies, hashes, and source
@@ -71,8 +75,8 @@ one generic snapshot object.
 - RunManifest: future read model that links available run facts and states
   provenance coverage. It does not own or duplicate the facts it presents.
 - CalibrationProposal: future reviewed recommendation from analysis or
-  calibration evidence. It may propose parameter or setup changes after review;
-  it must not silently edit an active parameter ref.
+  calibration evidence. It may propose durable parameter/profile changes after
+  review; it must not silently edit a named parameter ref.
 
 ## Desired State And Reconciliation Boundaries
 
@@ -101,20 +105,27 @@ commutative, or safe to parallelize.
 Fricon should keep code, parameter, and calibration facts separate even when a
 future run manifest presents them together.
 
+Use Calibration as the unqualified domain term for quantum-experiment
+parameter calibration. Use Instrument Calibration for hardware/setup
+calibration and Setup/Device Reconciliation for desired-state apply/readback.
+
 - Code provenance explains which source, revision, snapshot, or unmanaged
   summary produced the measurement, analysis, or calibration evidence.
 - Parameter snapshots own effective parameter facts. Parameter refs remain
   mutable pointers changed through proposal/audit paths.
-- Calibration records describe validity, review state, affected-run windows,
-  and evidence. Calibration proposals connect fitted values to proposed
-  parameter or setup changes.
+- Calibration records describe validity, review state, task health,
+  affected-run windows, and evidence. Calibration proposals connect fitted
+  sample/control-parameter values to proposed durable parameter changes.
 - Generated sidecars or derived config files used by analysis or calibration
   should be artifacts with source inputs and generator context, not invisible
   files that future runs depend on by accident.
 
-Early calibration automation should therefore stage evidence and proposals
-before applying changes. Direct mutation of active parameter refs, setup refs,
-or devices is a later safety-gated capability.
+Calibration automation should therefore record evidence, task-chain state,
+health decisions, retries, pause/review points, and promotion proposals.
+Small tasks in an approved calibration chain may update a chain-scoped
+calibration working ref for later tasks to consume. Publishing the final or
+selected chain results to durable named refs remains a separate promotion step.
+Device/setup reconciliation is a separate safety-gated capability.
 
 ## Dataset Artifact Shape
 
@@ -148,9 +159,12 @@ DataLibrary
     Artifact(kind: dataset | result | report | log | attachment | generated_sidecar | parameter_proposal | device_snapshot)
     ParameterProfile
     ParameterSnapshot
+    CalibrationWorkingRef
     AnalysisAttempt
     CalibrationRecord
     CalibrationProposal
+    CalibrationTaskRun
+    CalibrationChainRun
     CodeSnapshot
     ScriptRun
     DeviceIdentity
@@ -167,8 +181,13 @@ DataLibrary
     ScriptRun -> optional CodeSnapshot
     AnalysisAttempt -> consumes -> Measurement | Artifact
     CalibrationRecord -> links -> Measurement | AnalysisAttempt | ParameterSnapshot | Artifact
-    CalibrationProposal -> cites -> CalibrationRecord | AnalysisAttempt | CodeSnapshot | ParameterSnapshot | Artifact
-    CalibrationProposal -> may propose -> ParameterProfile change | Setup change
+    CalibrationTaskRun -> consumes -> Measurement | AnalysisAttempt | ParameterSnapshot | Artifact
+    CalibrationTaskRun -> produces -> fitted values | diagnostics | health decision
+    CalibrationTaskRun -> may update -> CalibrationWorkingRef
+    CalibrationChainRun -> contains -> CalibrationTaskRun
+    CalibrationChainRun -> owns -> CalibrationWorkingRef
+    CalibrationProposal -> cites -> CalibrationRecord | CalibrationChainRun | AnalysisAttempt | CodeSnapshot | ParameterSnapshot | Artifact
+    CalibrationProposal -> may propose -> ParameterProfile change
     ReconciliationPlan -> compares -> DesiredSetupState | DeviceSnapshot
     ApplyExecution -> executes -> ReconciliationPlan
 ```
@@ -179,6 +198,10 @@ Measurement, Analysis, Import, Simulation, and Calibration.
 Analysis attempts, calibration records, and calibration proposals should remain
 separate concepts. Analysis consumes data and produces results or diagnostics.
 Calibration records describe validity, review state, and affected-run windows.
-Calibration proposals recommend reviewed parameter or setup changes and carry
+Calibration task runs describe a small calibration step, its fitted values,
+diagnostics, health decision, and any chain-scoped working-ref update.
+Calibration chain runs describe ordered bootstrap calibration work with
+dependencies, retries, pause/review decisions, and intermediate working state.
+Calibration proposals recommend reviewed durable parameter changes and carry
 the before/after diff, actor/reviewer, outcome, and rollback target where
 practical.

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -69,8 +69,30 @@ one generic snapshot object.
   labels for lab-local configuration. It does not own effective parameters,
   code provenance, setup/device identity, or procedure intent.
 - RunManifest: future read model that links available run facts and states
-  coverage/provenance confidence. It does not own or duplicate the facts it
-  presents.
+  provenance coverage. It does not own or duplicate the facts it presents.
+- CalibrationProposal: future reviewed recommendation from analysis or
+  calibration evidence. It may propose parameter or setup changes after review;
+  it must not silently edit an active parameter ref.
+
+## Code, Parameter, And Calibration Boundaries
+
+Fricon should keep code, parameter, and calibration facts separate even when a
+future run manifest presents them together.
+
+- Code provenance explains which source, revision, snapshot, or unmanaged
+  summary produced the measurement, analysis, or calibration evidence.
+- Parameter snapshots own effective parameter facts. Parameter refs remain
+  mutable pointers changed through proposal/audit paths.
+- Calibration records describe validity, review state, affected-run windows,
+  and evidence. Calibration proposals connect fitted values to proposed
+  parameter or setup changes.
+- Generated sidecars or derived config files used by analysis or calibration
+  should be artifacts with source inputs and generator context, not invisible
+  files that future runs depend on by accident.
+
+Early calibration automation should therefore stage evidence and proposals
+before applying changes. Direct mutation of active parameter refs, setup refs,
+or devices is a later safety-gated capability.
 
 ## Dataset Artifact Shape
 
@@ -101,7 +123,7 @@ a normal v0.2 user-facing concept.
 DataLibrary
   records:
     ActivityRun(kind: measurement | analysis | import | simulation | calibration)
-    Artifact(kind: dataset | result | report | log | attachment | parameter_proposal | device_snapshot)
+    Artifact(kind: dataset | result | report | log | attachment | generated_sidecar | parameter_proposal | device_snapshot)
     ParameterProfile
     ParameterSnapshot
     AnalysisAttempt
@@ -119,7 +141,8 @@ DataLibrary
     ActivityRun -> produces -> Artifact
     ScriptRun -> optional CodeSnapshot
     AnalysisAttempt -> consumes -> Measurement | Artifact
-    CalibrationRecord -> links -> Measurement | AnalysisAttempt | ParameterSnapshot
+    CalibrationRecord -> links -> Measurement | AnalysisAttempt | ParameterSnapshot | Artifact
+    CalibrationProposal -> cites -> CalibrationRecord | AnalysisAttempt | CodeSnapshot | ParameterSnapshot | Artifact
     CalibrationProposal -> may propose -> ParameterProfile change | Setup change
 ```
 
@@ -129,4 +152,6 @@ Measurement, Analysis, Import, Simulation, and Calibration.
 Analysis attempts, calibration records, and calibration proposals should remain
 separate concepts. Analysis consumes data and produces results or diagnostics.
 Calibration records describe validity, review state, and affected-run windows.
-Calibration proposals recommend reviewed parameter or setup changes.
+Calibration proposals recommend reviewed parameter or setup changes and carry
+the before/after diff, actor/reviewer, outcome, and rollback target where
+practical.

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -15,6 +15,7 @@ DataLibrary
     DatasetArtifact
     AttachmentArtifact
     ParameterSnapshot
+    RunConfigSnapshot
     CodeProvenanceSummary
     SetupProvenanceSummary
     ProcedureSummary
@@ -26,6 +27,7 @@ DataLibrary
     Measurement -> optional SampleSession
     Measurement -> produces -> DatasetArtifact | AttachmentArtifact
     Measurement -> optional ParameterSnapshot
+    Measurement -> optional RunConfigSnapshot
     Measurement -> optional CodeProvenanceSummary
     Measurement -> optional SetupProvenanceSummary
     Measurement -> optional ProcedureSummary
@@ -44,6 +46,7 @@ DataLibrary
 | DatasetArtifact | Typed table facts, append state, scan schema, variable roles, dataset-local display hints. | Sample identity, measurement notes, code provenance, calibration decisions. |
 | AttachmentArtifact | Light measurement files, images, or logs. | Full artifact management or row-linked large binary storage before an ADR. |
 | ParameterSnapshot | Immutable run facts. | Mutable profile management or calibration promotion. |
+| RunConfigSnapshot | Selected local configuration references, snapshots, hashes, and summaries bound to a measurement. | Automatic tracing of every file read, global parameter profiles, device inventory, or reproducibility claims for unmanaged work. |
 | CodeProvenanceSummary | Provenance level and display summary. | Automatic reproducibility claims for unmanaged code. |
 | SetupProvenanceSummary | Passive setup, device, driver, environment, method, or clock facts supplied by the user or integration. | Device control, resource locking, readback enforcement, or reproducibility claims. |
 | ProcedureSummary | Passive summary of unmanaged script, external runner, or declared plan context. | Managed execution, scan-point checkpointing, task scheduling, or device/resource ownership. |

--- a/docs-next/domain/conceptual-model.md
+++ b/docs-next/domain/conceptual-model.md
@@ -46,11 +46,31 @@ DataLibrary
 | DatasetArtifact | Typed table facts, append state, scan schema, variable roles, dataset-local display hints. | Sample identity, measurement notes, code provenance, calibration decisions. |
 | AttachmentArtifact | Light measurement files, images, or logs. | Full artifact management or row-linked large binary storage before an ADR. |
 | ParameterSnapshot | Immutable run facts. | Mutable profile management or calibration promotion. |
-| RunConfigSnapshot | Selected local configuration references, snapshots, hashes, and summaries bound to a measurement. | Automatic tracing of every file read, global parameter profiles, device inventory, or reproducibility claims for unmanaged work. |
+| RunConfigSnapshot | Selected local configuration references, copied snapshots, hashes, and source labels bound to a measurement. | Effective parameter ownership, code provenance, setup/device identity, procedure intent, run-manifest assembly, automatic tracing of every file read, or reproducibility claims for unmanaged work. |
 | CodeProvenanceSummary | Provenance level and display summary. | Automatic reproducibility claims for unmanaged code. |
 | SetupProvenanceSummary | Passive setup, device, driver, environment, method, or clock facts supplied by the user or integration. | Device control, resource locking, readback enforcement, or reproducibility claims. |
 | ProcedureSummary | Passive summary of unmanaged script, external runner, or declared plan context. | Managed execution, scan-point checkpointing, task scheduling, or device/resource ownership. |
 | Event/AuditRecord | Lifecycle events, notes, corrections, actor labels, system actions. | Fine-grained permission enforcement. |
+
+## Parameter And Configuration Boundaries
+
+MVP configuration capture should not collapse future parameter management into
+one generic snapshot object.
+
+- Parameter context summary: optional user-supplied or imported context for a
+  measurement before profiles, refs, overrides, and proposal workflows exist.
+- ParameterSnapshot: future immutable effective parameter facts resolved from
+  refs, profiles, and overrides.
+- ParameterProfileRef: future mutable named pointer such as `main` or
+  `latest-good`.
+- ParameterProposal: future reviewed change request that may update a named
+  parameter ref after approval.
+- RunConfigSnapshot: selected local file references, copies, hashes, and source
+  labels for lab-local configuration. It does not own effective parameters,
+  code provenance, setup/device identity, or procedure intent.
+- RunManifest: future read model that links available run facts and states
+  coverage/provenance confidence. It does not own or duplicate the facts it
+  presents.
 
 ## Dataset Artifact Shape
 
@@ -84,18 +104,29 @@ DataLibrary
     Artifact(kind: dataset | result | report | log | attachment | parameter_proposal | device_snapshot)
     ParameterProfile
     ParameterSnapshot
+    AnalysisAttempt
+    CalibrationRecord
+    CalibrationProposal
     CodeSnapshot
     ScriptRun
     DeviceIdentity
     DeviceSnapshot
+    RunManifest(read model)
     Event/AuditRecord
 
   links:
     ActivityRun -> consumes -> Artifact | ParameterSnapshot | ActivityRun
     ActivityRun -> produces -> Artifact
     ScriptRun -> optional CodeSnapshot
-    Calibration -> coordinates -> Measurement + Analysis + ParameterProposal
+    AnalysisAttempt -> consumes -> Measurement | Artifact
+    CalibrationRecord -> links -> Measurement | AnalysisAttempt | ParameterSnapshot
+    CalibrationProposal -> may propose -> ParameterProfile change | Setup change
 ```
 
 `ActivityRun` is an internal modeling pattern. Users should see concrete words:
 Measurement, Analysis, Import, Simulation, and Calibration.
+
+Analysis attempts, calibration records, and calibration proposals should remain
+separate concepts. Analysis consumes data and produces results or diagnostics.
+Calibration records describe validity, review state, and affected-run windows.
+Calibration proposals recommend reviewed parameter or setup changes.

--- a/docs-next/domain/context-map.md
+++ b/docs-next/domain/context-map.md
@@ -13,6 +13,8 @@ Draft.
 | Dataset Artifact | Table facts, schema, scan semantics, projections, live append state. | DatasetArtifact, variable, role, scan schema, projection. | Produced by Measurement; read by Desktop, Python, Export, Analysis later. |
 | Sample Context | Samples, sample sessions, active context, corrections. | Sample, SampleSession, active context. | Used by Measurement and views. |
 | Provenance | Code provenance, setup summaries, procedure summaries, parameter snapshot, actor/event records. | CodeProvenanceSummary, SetupProvenanceSummary, ProcedureSummary, ParameterSnapshot, Actor, Event. | Linked by Measurement; extended by future runner/calibration. |
+| Parameter Management | Future named profiles, immutable effective snapshots, diffs, and reviewed proposals. | ParameterProfile, ParameterSnapshot, ParameterProposal, ParameterRef. | Uses Provenance and Analysis evidence; linked by Measurement, Run Manifest, and Calibration. |
+| Analysis And Calibration | Future analysis attempts, fit outputs, calibration records, and calibration proposals. | AnalysisAttempt, CalibrationRecord, CalibrationProposal, GeneratedSidecar. | Consumes DatasetArtifact, ParameterSnapshot, CodeSnapshot; may propose Parameter Management or Setup changes after review. |
 | Service/API | Client compatibility, mutations, events, binary payload transfer. | Service API, capability, write session, event stream. | Exposes domain contexts to Desktop, Python SDK, CLI. |
 | Desktop Experience | Measurement console, live views, sample/session UX, diagnostics. | Console, live list, detail, detached view. | Downstream of Service/API. |
 | Python SDK | Measurement creation, dataset writes, reopen, export reads. | Library handle, Measurement handle, Dataset writer. | Downstream of Service/API. |
@@ -31,6 +33,14 @@ Draft.
   must not imply shared identity with the source data library.
 - Future AI, calibration, or automation actions must enter through audited
   domain mutations, not direct storage edits.
+- Calibration automation must not update active parameter refs directly. It
+  should create evidence and reviewed parameter or calibration proposals first.
+- Code provenance and parameter snapshots remain separate facts. A run manifest
+  may link them, but it must not merge code source, generated config, and
+  effective parameter state into one opaque blob.
+- Generated sidecars or derived config files that affect analysis,
+  calibration, or replay should be artifacts with source inputs and generator
+  context.
 - Run manifests are read models over available facts. They must not become
   owners of parameter, code, setup, analysis, or artifact records.
 - Export manifests describe package contents and integrity. They must not be

--- a/docs-next/domain/context-map.md
+++ b/docs-next/domain/context-map.md
@@ -31,7 +31,13 @@ Draft.
   must not imply shared identity with the source data library.
 - Future AI, calibration, or automation actions must enter through audited
   domain mutations, not direct storage edits.
+- Run manifests are read models over available facts. They must not become
+  owners of parameter, code, setup, analysis, or artifact records.
+- Export manifests describe package contents and integrity. They must not be
+  confused with run manifests used for compare, handoff, or investigation.
 - Passive setup summaries describe context only. Device control and resource
   ownership belong to later ADR-gated device or runner contexts.
 - Passive procedure summaries describe what was intended or invoked. They do
   not imply managed execution, resume support, or runner ownership.
+- AI may summarize or propose, but mutating AI actions must enter through the
+  same reviewed proposal and audit boundaries as non-AI automation.

--- a/docs-next/domain/context-map.md
+++ b/docs-next/domain/context-map.md
@@ -15,6 +15,7 @@ Draft.
 | Provenance | Code provenance, setup summaries, procedure summaries, parameter snapshot, actor/event records. | CodeProvenanceSummary, SetupProvenanceSummary, ProcedureSummary, ParameterSnapshot, Actor, Event. | Linked by Measurement; extended by future runner/calibration. |
 | Parameter Management | Future named profiles, immutable effective snapshots, diffs, and reviewed proposals. | ParameterProfile, ParameterSnapshot, ParameterProposal, ParameterRef. | Uses Provenance and Analysis evidence; linked by Measurement, Run Manifest, and Calibration. |
 | Analysis And Calibration | Future analysis attempts, fit outputs, calibration records, and calibration proposals. | AnalysisAttempt, CalibrationRecord, CalibrationProposal, GeneratedSidecar. | Consumes DatasetArtifact, ParameterSnapshot, CodeSnapshot; may propose Parameter Management or Setup changes after review. |
+| Setup/Device Reconciliation | Future desired setup/device state, observed status, reconciliation plans, and apply executions. | DesiredSetupState, ObservedDeviceState, ReconciliationPlan, ApplyExecution. | Consumes ParameterSnapshot, Setup/Device identity, and CodeSnapshot; produces audit events and may bind to Measurement or Routine Replay. |
 | Service/API | Client compatibility, mutations, events, binary payload transfer. | Service API, capability, write session, event stream. | Exposes domain contexts to Desktop, Python SDK, CLI. |
 | Desktop Experience | Measurement console, live views, sample/session UX, diagnostics. | Console, live list, detail, detached view. | Downstream of Service/API. |
 | Python SDK | Measurement creation, dataset writes, reopen, export reads. | Library handle, Measurement handle, Dataset writer. | Downstream of Service/API. |
@@ -41,6 +42,11 @@ Draft.
 - Generated sidecars or derived config files that affect analysis,
   calibration, or replay should be artifacts with source inputs and generator
   context.
+- Desired setup/device state, observed state, reconciliation plans, and apply
+  executions are separate facts. A desired-state routine must not present
+  intent as readback evidence.
+- Reconciliation may skip, reorder, or parallelize device writes only when the
+  relevant device/setup boundary declares that behavior safe.
 - Run manifests are read models over available facts. They must not become
   owners of parameter, code, setup, analysis, or artifact records.
 - Export manifests describe package contents and integrity. They must not be

--- a/docs-next/domain/context-map.md
+++ b/docs-next/domain/context-map.md
@@ -14,7 +14,7 @@ Draft.
 | Sample Context | Samples, sample sessions, active context, corrections. | Sample, SampleSession, active context. | Used by Measurement and views. |
 | Provenance | Code provenance, setup summaries, procedure summaries, parameter snapshot, actor/event records. | CodeProvenanceSummary, SetupProvenanceSummary, ProcedureSummary, ParameterSnapshot, Actor, Event. | Linked by Measurement; extended by future runner/calibration. |
 | Parameter Management | Future named profiles, immutable effective snapshots, diffs, and reviewed proposals. | ParameterProfile, ParameterSnapshot, ParameterProposal, ParameterRef. | Uses Provenance and Analysis evidence; linked by Measurement, Run Manifest, and Calibration. |
-| Analysis And Calibration | Future analysis attempts, fit outputs, calibration records, and calibration proposals. | AnalysisAttempt, CalibrationRecord, CalibrationProposal, GeneratedSidecar. | Consumes DatasetArtifact, ParameterSnapshot, CodeSnapshot; may propose Parameter Management or Setup changes after review. |
+| Analysis And Calibration | Future analysis attempts, fit outputs, calibration task chains, calibration records, and calibration proposals. | AnalysisAttempt, CalibrationTaskRun, CalibrationChainRun, CalibrationRecord, CalibrationProposal, GeneratedSidecar. | Consumes DatasetArtifact, ParameterSnapshot, CodeSnapshot; may propose Parameter Management changes after review. |
 | Setup/Device Reconciliation | Future desired setup/device state, observed status, reconciliation plans, and apply executions. | DesiredSetupState, ObservedDeviceState, ReconciliationPlan, ApplyExecution. | Consumes ParameterSnapshot, Setup/Device identity, and CodeSnapshot; produces audit events and may bind to Measurement or Routine Replay. |
 | Service/API | Client compatibility, mutations, events, binary payload transfer. | Service API, capability, write session, event stream. | Exposes domain contexts to Desktop, Python SDK, CLI. |
 | Desktop Experience | Measurement console, live views, sample/session UX, diagnostics. | Console, live list, detail, detached view. | Downstream of Service/API. |
@@ -34,8 +34,13 @@ Draft.
   must not imply shared identity with the source data library.
 - Future AI, calibration, or automation actions must enter through audited
   domain mutations, not direct storage edits.
-- Calibration automation must not update active parameter refs directly. It
-  should create evidence and reviewed parameter or calibration proposals first.
+- Calibration automation must not update named parameter refs directly. It
+  should create task evidence, health decisions, chain state, and reviewed
+  parameter or calibration proposals for durable promotion.
+- Healthy tasks in an approved calibration chain may update a chain-scoped
+  calibration working ref for later tasks without requiring review after every
+  small step, but the chain must record working-ref revisions, health-gate
+  decisions, retries, pause/review reasons, and final promotion outcome.
 - Code provenance and parameter snapshots remain separate facts. A run manifest
   may link them, but it must not merge code source, generated config, and
   effective parameter state into one opaque blob.

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -41,6 +41,9 @@ Draft.
 ## Provenance And Audit
 
 - Non-managed code provenance must not be presented as reproducible history.
+- Run-bound local configuration snapshots record selected references, hashes,
+  or summaries only; they must not imply Fricon observed every configuration
+  file the script read.
 - Passive setup/device/environment summaries must not be presented as device
   control or complete reproducibility records.
 - Passive procedure summaries must not be presented as managed execution

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -48,11 +48,22 @@ Draft.
   control or complete reproducibility records.
 - Passive procedure summaries must not be presented as managed execution
   records or resumable plans.
-- Managed-run evidence improves provenance confidence but does not guarantee
+- Managed-run evidence improves provenance coverage but does not guarantee
   scientific reproducibility without parameter, setup/device, environment, and
   calibration coverage.
-- Run manifests link available facts and coverage/confidence signals; they must
-  not silently fill missing context.
+- Run manifests link available facts and provenance coverage signals; they
+  must not silently fill missing context.
+- Code provenance, generated sidecars, and effective parameter snapshots are
+  separate facts. Linking them for compare or replay must not make any one
+  record the owner of the others.
+- Calibration-derived parameter changes must preserve source measurements,
+  analysis or fit attempts, code context, affected parameter paths,
+  before/after diffs, review outcome, and rollback target where practical
+  before active refs are updated.
+- Calibration automation must not silently mutate active parameter refs,
+  setup refs, devices, or generated config that future runs depend on.
+- The absence of a detailed confidence-label taxonomy must never be used as a
+  reason to allow untracked parameter or calibration mutation.
 - Mutating actions should record an actor label when practical.
 - AI-assisted mutating actions require explicit review and durable audit
   records.

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -56,12 +56,16 @@ Draft.
 - Code provenance, generated sidecars, and effective parameter snapshots are
   separate facts. Linking them for compare or replay must not make any one
   record the owner of the others.
-- Calibration-derived parameter changes must preserve source measurements,
-  analysis or fit attempts, code context, affected parameter paths,
-  before/after diffs, review outcome, and rollback target where practical
-  before active refs are updated.
-- Calibration automation must not silently mutate active parameter refs,
-  setup refs, devices, or generated config that future runs depend on.
+- Calibration-derived durable parameter changes must preserve source
+  measurements, analysis or fit attempts, code context, affected parameter
+  paths, health assessments, before/after diffs, review outcome, and rollback
+  target where practical before named refs are updated.
+- Calibration task chains may update chain-scoped calibration working refs
+  without per-step manual approval, but they must record task order,
+  dependencies, working-ref revisions, health-gate decisions, retries,
+  pause/review reasons, and final promotion outcome.
+- Calibration automation must not silently mutate named parameter refs, setup
+  refs, devices, or generated config that future runs depend on.
 - The absence of a detailed confidence-label taxonomy must never be used as a
   reason to allow untracked parameter or calibration mutation.
 - Desired setup/device state is intent, not evidence that hardware changed.

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -48,9 +48,16 @@ Draft.
   control or complete reproducibility records.
 - Passive procedure summaries must not be presented as managed execution
   records or resumable plans.
+- Managed-run evidence improves provenance confidence but does not guarantee
+  scientific reproducibility without parameter, setup/device, environment, and
+  calibration coverage.
+- Run manifests link available facts and coverage/confidence signals; they must
+  not silently fill missing context.
 - Mutating actions should record an actor label when practical.
 - AI-assisted mutating actions require explicit review and durable audit
   records.
+- Durable AI-created conclusions should record source/provenance information
+  and privacy-scoped inputs where practical.
 - Corrections preserve history rather than overwriting meaning silently.
 
 ## Export

--- a/docs-next/domain/invariants.md
+++ b/docs-next/domain/invariants.md
@@ -64,6 +64,13 @@ Draft.
   setup refs, devices, or generated config that future runs depend on.
 - The absence of a detailed confidence-label taxonomy must never be used as a
   reason to allow untracked parameter or calibration mutation.
+- Desired setup/device state is intent, not evidence that hardware changed.
+  Observed/readback state and apply execution state must remain separate.
+- Reconciliation plans must preview no-op writes, required writes,
+  dependencies, safe parallel groups, settle/readback checks, timeout behavior,
+  and abort behavior before hardware mutation.
+- Device writes may be reordered or parallelized only when the affected device
+  boundaries explicitly allow it.
 - Mutating actions should record an actor label when practical.
 - AI-assisted mutating actions require explicit review and durable audit
   records.

--- a/docs-next/implementation-plans/M1-baseline.md
+++ b/docs-next/implementation-plans/M1-baseline.md
@@ -2,7 +2,14 @@
 
 ## Status
 
-Draft implementation plan.
+Draft placeholder. Not implementation-ready.
+
+## Planning Boundary
+
+This file is a downstream milestone landing area. Until the product and domain
+baselines are accepted, `product/`, `domain/`, and ADRs own scope. Re-sync this
+plan after `SPEC-001` is accepted instead of treating the current bullets as an
+implementation commitment.
 
 ## Goal
 
@@ -27,7 +34,6 @@ M1 should prove:
 - readable partial/interrupted measurement data
 - optional passive setup summary
 - optional passive procedure summary
-- optional run-bound local configuration snapshot or summary
 - Python reopen through stable IDs
 - early compatibility negotiation before writes
 

--- a/docs-next/implementation-plans/M1-baseline.md
+++ b/docs-next/implementation-plans/M1-baseline.md
@@ -38,7 +38,12 @@ M1 should prove:
 - remote mode
 - full parameter registry
 - automatic tracing of every local configuration file a script reads
+- run-like-previous drafts
+- parameter proposals or profile promotion
+- compare/handoff dashboards
+- analysis/calibration records or managed calibration workflows
 - managed code execution
+- reviewable routine replay
 - resumable scan-point checkpoint execution
 - user-facing stream concepts inside dataset artifacts
 - broad device framework

--- a/docs-next/implementation-plans/M1-baseline.md
+++ b/docs-next/implementation-plans/M1-baseline.md
@@ -27,6 +27,7 @@ M1 should prove:
 - readable partial/interrupted measurement data
 - optional passive setup summary
 - optional passive procedure summary
+- optional run-bound local configuration snapshot or summary
 - Python reopen through stable IDs
 - early compatibility negotiation before writes
 
@@ -36,6 +37,7 @@ M1 should prove:
 - direct LabRAD/Data Vault import
 - remote mode
 - full parameter registry
+- automatic tracing of every local configuration file a script reads
 - managed code execution
 - resumable scan-point checkpoint execution
 - user-facing stream concepts inside dataset artifacts

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -18,11 +18,8 @@ Vault/Grapher loop for new measurements. Capabilities should support that loop
 without importing old history, emulating LabRAD, or pulling post-MVP parameter,
 code-management, runner, device, or automation systems into the MVP.
 
-Post-MVP capabilities should move Fricon from data-library replacement toward
-local experiment memory and reviewed action: durable facts for compare, trust,
-handoff, interpretation, and replay. Device control, sample visualization, and
-AI should not become the long-term center unless they serve that memory and
-review model.
+Post-MVP capability ordering is owned by `product/future-concepts.md`. This map
+keeps stable IDs and compact scope boundaries only.
 
 Release versions are not product-horizon labels. Compatible post-MVP
 capabilities may still ship on the same compatible release line; use MVP,
@@ -250,10 +247,7 @@ CAP-019: Rich sample maps and saved views.
 - Intent: support user-defined spatial sample maps, richer sample metadata, and
   saved comparison views after the local data-library loop works.
 - Boundary: the MVP only needs optional sample/session context and correction.
-  Post-MVP map configs or DSLs may map parameter row keys and user labels to
-  visual regions, and color or label those regions from parameter snapshot
-  queries, but should not force a sample-component ontology. Config placement,
-  query syntax, and schema-evolution behavior need a later spec or ADR.
+  Post-MVP map details belong in a dedicated spec or ADR.
 
 CAP-020: Measurement-code source setup and approved code update flows.
 
@@ -261,8 +255,7 @@ CAP-020: Measurement-code source setup and approved code update flows.
   measurement scripts, replacing copied working folders as the normal
   explanation for where run, analysis, and calibration code came from.
 - Boundary: the MVP records honest provenance but does not own code deployment.
-  Post-MVP code-source management should support calibration evidence and run
-  history before it becomes a scheduler or mandatory execution model.
+  Scheduler or managed-execution behavior belongs to later capabilities.
 
 CAP-021: Parameter profiles and proposals.
 
@@ -270,9 +263,7 @@ CAP-021: Parameter profiles and proposals.
   reviewed proposals, with diffs and source evidence that make calibration
   changes inspectable instead of anonymous config-file edits.
 - Boundary: the MVP keeps only light parameter context summaries without a
-  registry UI or effective-configuration model. Post-MVP calibration-derived
-  values should enter through proposal/audit paths, not direct mutation of
-  active refs.
+  registry UI or effective-configuration model.
 
 CAP-022: Analysis, interpretation, and calibration records.
 
@@ -281,10 +272,8 @@ CAP-022: Analysis, interpretation, and calibration records.
   records that can cite input measurements, code context, parameter snapshots,
   generated artifacts, fitted values, and affected parameter paths.
 - Boundary: the MVP may export analysis-ready data but does not manage
-  calibration promotion. Analysis attempts, calibration records, and
-  calibration proposals should have distinct lifecycle and audit meaning.
-  Calibration task health/confidence gates are useful before a broad
-  confidence-label taxonomy exists.
+  calibration promotion. Detailed calibration workflow semantics belong in the
+  future backlog and domain invariants.
 
 CAP-023: Managed code snapshots and execution.
 
@@ -299,9 +288,7 @@ CAP-024: Device boundary and managed device communication.
   desired-state planning, observed-state readback, reconciliation diffs, and
   reviewed apply plans.
 - Boundary: the MVP may record passive setup/device summaries but does not talk
-  to instruments. Post-MVP device apply must not assume writes are safe to
-  parallelize or reorder until dependencies, settling, readback, timeout, and
-  abort behavior are designed.
+  to instruments. Device apply is ADR-gated.
 
 CAP-025: AI-assisted reviewed automation.
 
@@ -321,8 +308,7 @@ CAP-031: Run manifest and failure investigation.
   state.
 - Boundary: a run manifest is a composite view over available facts, not a
   duplicate owner of parameter, code, setup, analysis, or artifact records. The
-  first slice supports compare, handoff, export, and anomaly investigation; it
-  is not a scheduler or resume engine.
+  first slice supports compare, handoff, export, and anomaly investigation.
 
 CAP-032: Routine recipes and reviewed replay.
 
@@ -332,9 +318,8 @@ CAP-032: Routine recipes and reviewed replay.
   reviewed promotion to durable parameter refs, or when imperative loop bodies
   would repeatedly issue avoidable device writes.
 - Boundary: read-only batch compare or triage can arrive before
-  mutation-capable automation; durable mutation requires preview, review,
-  before/after diffs, rollback targets, reconciliation/apply records where
-  hardware is involved, and audit.
+  mutation-capable automation; durable mutation requires the reviewed proposal
+  and audit model described by future specs and ADRs.
 
 ## Product Grouping
 

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -18,6 +18,12 @@ Vault/Grapher loop for new measurements. Capabilities should support that loop
 without importing old history, emulating LabRAD, or pulling post-MVP parameter,
 code-management, runner, device, or automation systems into the MVP.
 
+Post-MVP capabilities should move Fricon from data-library replacement toward
+local experiment memory and reviewed action: durable facts for compare, trust,
+handoff, interpretation, and replay. Device control, sample visualization, and
+AI should not become the long-term center unless they serve that memory and
+review model.
+
 Release versions are not product-horizon labels. Compatible post-MVP
 capabilities may still ship on the same compatible release line; use MVP,
 post-MVP priority, and ADR-gated labels for product planning.
@@ -262,17 +268,19 @@ CAP-021: Parameter profiles and proposals.
 - Boundary: the MVP keeps only light parameter context summaries without a
   registry UI or effective-configuration model.
 
-CAP-022: Analysis and calibration records.
+CAP-022: Analysis, interpretation, and calibration records.
 
-- Intent: model downstream analysis, fit attempts, anomaly review,
-  calibration, and derived-result activity as first-class records.
+- Intent: model downstream analysis, fit attempts, interpretation decisions,
+  anomaly review, calibration, and derived-result activity as first-class
+  records.
 - Boundary: the MVP may export analysis-ready data but does not manage
-  calibration promotion.
+  calibration promotion. Analysis attempts, calibration records, and
+  calibration proposals should have distinct lifecycle and audit meaning.
 
 CAP-023: Managed code snapshots and execution.
 
-- Intent: run selected measurement code under Fricon control with reproducible
-  snapshots and lifecycle supervision.
+- Intent: run selected measurement code under Fricon control with
+  higher-confidence code provenance snapshots and lifecycle supervision.
 - Boundary: the MVP records unmanaged execution context only.
 
 CAP-024: Device boundary and managed device communication.
@@ -287,15 +295,20 @@ CAP-025: AI-assisted reviewed automation.
 - Intent: let AI propose actions or analysis steps that are reviewed before
   mutating the data library.
 - Boundary: the MVP should preserve auditability, not implement mutating AI
-  automation.
+  automation. AI-created durable conclusions should record provenance, and
+  mutating AI actions should enter through the same reviewed proposal path as
+  non-AI automation.
 
 CAP-031: Run manifest and failure investigation.
 
 - Intent: give managed or high-provenance runs a compact manifest linking
   parameter snapshots, target keys, code/environment summary, lifecycle, logs,
-  artifacts, operator, timestamps, and diagnostics.
-- Boundary: the first slice supports compare, handoff, export, and anomaly
-  investigation; it is not a scheduler or resume engine.
+  artifacts, operator, timestamps, diagnostics, previous-good baselines, trust
+  summaries, and handoff state.
+- Boundary: a run manifest is a composite view over available facts, not a
+  duplicate owner of parameter, code, setup, analysis, or artifact records. The
+  first slice supports compare, handoff, export, and anomaly investigation; it
+  is not a scheduler or resume engine.
 
 CAP-032: Routine recipes and reviewed replay.
 

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -295,9 +295,13 @@ CAP-023: Managed code snapshots and execution.
 CAP-024: Device boundary and managed device communication.
 
 - Intent: introduce explicit device identity, configuration, and communication
-  boundaries when Fricon begins controlling instruments.
+  boundaries when Fricon begins controlling instruments, including later
+  desired-state planning, observed-state readback, reconciliation diffs, and
+  reviewed apply plans.
 - Boundary: the MVP may record passive setup/device summaries but does not talk
-  to instruments.
+  to instruments. Post-MVP device apply must not assume writes are safe to
+  parallelize or reorder until dependencies, settling, readback, timeout, and
+  abort behavior are designed.
 
 CAP-025: AI-assisted reviewed automation.
 
@@ -324,10 +328,12 @@ CAP-032: Routine recipes and reviewed replay.
 
 - Intent: capture repeated compare, run, and analyze routines as previewable
   recipes so tedious lab work can be replayed without hidden mutation,
-  especially when calibration results would otherwise rewrite parameter state.
+  especially when calibration results would otherwise rewrite parameter state
+  or imperative loop bodies would repeatedly issue avoidable device writes.
 - Boundary: read-only batch compare or triage can arrive before
   mutation-capable automation; durable mutation requires preview, review,
-  before/after diffs, rollback targets, and audit.
+  before/after diffs, rollback targets, reconciliation/apply records where
+  hardware is involved, and audit.
 
 ## Product Grouping
 

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -283,8 +283,8 @@ CAP-022: Analysis, interpretation, and calibration records.
 - Boundary: the MVP may export analysis-ready data but does not manage
   calibration promotion. Analysis attempts, calibration records, and
   calibration proposals should have distinct lifecycle and audit meaning.
-  Detailed confidence-label taxonomies are not required before the evidence and
-  proposal model exists.
+  Calibration task health/confidence gates are useful before a broad
+  confidence-label taxonomy exists.
 
 CAP-023: Managed code snapshots and execution.
 

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -328,8 +328,9 @@ CAP-032: Routine recipes and reviewed replay.
 
 - Intent: capture repeated compare, run, and analyze routines as previewable
   recipes so tedious lab work can be replayed without hidden mutation,
-  especially when calibration results would otherwise rewrite parameter state
-  or imperative loop bodies would repeatedly issue avoidable device writes.
+  especially when calibration chains need working refs, health gates, and
+  reviewed promotion to durable parameter refs, or when imperative loop bodies
+  would repeatedly issue avoidable device writes.
 - Boundary: read-only batch compare or triage can arrive before
   mutation-capable automation; durable mutation requires preview, review,
   before/after diffs, rollback targets, reconciliation/apply records where

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -143,6 +143,18 @@ CAP-015: Light parameter context summary without a registry UI.
 - Excludes: global parameter registry, immutable profile binding, override
   semantics, proposal workflow, and calibration promotion.
 
+CAP-033: Run-bound local configuration snapshot.
+
+- Promise: a measurement can bind selected local configuration files,
+  references, hashes, or summaries so later analysis can identify the effective
+  lab-local state without reading copied folders by hand.
+- Includes: user-selected parameter files, registry files, wiring references,
+  line/chip information, demod/readout settings, runner labels, source aliases,
+  privacy-aware export selection, and correction history.
+- Excludes: automatic tracing of every file read, global parameter profiles,
+  calibration promotion, device control, or claiming unmanaged execution was
+  fully reproducible.
+
 CAP-017: Lightweight operator profile and audit actor.
 
 - Promise: notes, corrections, lifecycle events, and exports can name the local
@@ -300,6 +312,6 @@ Use these planning groups when routing product work:
 - MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007,
   CAP-028, CAP-030.
 - Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
-  CAP-029.
+  CAP-029, CAP-033.
 - Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
 - Post-MVP foundation: CAP-018 through CAP-025, CAP-031, CAP-032.

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -258,29 +258,38 @@ CAP-019: Rich sample maps and saved views.
 CAP-020: Measurement-code source setup and approved code update flows.
 
 - Intent: help labs manage code source locations and reviewed updates for
-  measurement scripts.
+  measurement scripts, replacing copied working folders as the normal
+  explanation for where run, analysis, and calibration code came from.
 - Boundary: the MVP records honest provenance but does not own code deployment.
+  Post-MVP code-source management should support calibration evidence and run
+  history before it becomes a scheduler or mandatory execution model.
 
 CAP-021: Parameter profiles and proposals.
 
 - Intent: promote repeated parameter snapshots into reusable profiles and
-  reviewed proposals.
+  reviewed proposals, with diffs and source evidence that make calibration
+  changes inspectable instead of anonymous config-file edits.
 - Boundary: the MVP keeps only light parameter context summaries without a
-  registry UI or effective-configuration model.
+  registry UI or effective-configuration model. Post-MVP calibration-derived
+  values should enter through proposal/audit paths, not direct mutation of
+  active refs.
 
 CAP-022: Analysis, interpretation, and calibration records.
 
 - Intent: model downstream analysis, fit attempts, interpretation decisions,
   anomaly review, calibration, and derived-result activity as first-class
-  records.
+  records that can cite input measurements, code context, parameter snapshots,
+  generated artifacts, fitted values, and affected parameter paths.
 - Boundary: the MVP may export analysis-ready data but does not manage
   calibration promotion. Analysis attempts, calibration records, and
   calibration proposals should have distinct lifecycle and audit meaning.
+  Detailed confidence-label taxonomies are not required before the evidence and
+  proposal model exists.
 
 CAP-023: Managed code snapshots and execution.
 
 - Intent: run selected measurement code under Fricon control with
-  higher-confidence code provenance snapshots and lifecycle supervision.
+  stronger code provenance snapshots and lifecycle supervision.
 - Boundary: the MVP records unmanaged execution context only.
 
 CAP-024: Device boundary and managed device communication.
@@ -303,8 +312,9 @@ CAP-031: Run manifest and failure investigation.
 
 - Intent: give managed or high-provenance runs a compact manifest linking
   parameter snapshots, target keys, code/environment summary, lifecycle, logs,
-  artifacts, operator, timestamps, diagnostics, previous-good baselines, trust
-  summaries, and handoff state.
+  artifacts, operator, timestamps, diagnostics, previous-good baselines,
+  calibration evidence, generated sidecars, review decisions, and handoff
+  state.
 - Boundary: a run manifest is a composite view over available facts, not a
   duplicate owner of parameter, code, setup, analysis, or artifact records. The
   first slice supports compare, handoff, export, and anomaly investigation; it
@@ -313,9 +323,11 @@ CAP-031: Run manifest and failure investigation.
 CAP-032: Routine recipes and reviewed replay.
 
 - Intent: capture repeated compare, run, and analyze routines as previewable
-  recipes so tedious lab work can be replayed without hidden mutation.
+  recipes so tedious lab work can be replayed without hidden mutation,
+  especially when calibration results would otherwise rewrite parameter state.
 - Boundary: read-only batch compare or triage can arrive before
-  mutation-capable automation; durable mutation requires review and audit.
+  mutation-capable automation; durable mutation requires preview, review,
+  before/after diffs, rollback targets, and audit.
 
 ## Product Grouping
 

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -30,10 +30,11 @@ becoming a legacy import project or a full automation stack.
   where code came from.
 - Rich sample maps, saved views, comparison, and context correction UX.
 - Parameter profiles, effective snapshots, diffs, proposals, and reviewed
-  application of calibration-derived settings.
-- Calibration records and proposals that preserve source measurements,
-  analysis attempts, generated sidecars, affected parameter paths, diffs, and
-  rollback targets before any active parameter ref changes.
+  durable promotion of calibration-derived settings.
+- Calibration records, chains, working refs, health gates, and proposals that
+  preserve source measurements, analysis attempts, generated sidecars,
+  affected parameter paths, diffs, and rollback targets before durable named
+  refs are promoted.
 - Managed execution, device communication, and AI-assisted reviewed automation
   after the code/parameter evidence model is durable.
 

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -25,9 +25,17 @@ becoming a legacy import project or a full automation stack.
 - User-written import helpers for old data when generic APIs mature.
 - Read-only LAN viewing.
 - Measurement-code source setup and approved code update flows.
+- Managed code/source provenance for measurement, analysis, and calibration
+  evidence, replacing copied working folders as the normal explanation for
+  where code came from.
 - Rich sample maps, saved views, comparison, and context correction UX.
-- Parameter profiles, calibration records, managed execution, device
-  communication, and AI-assisted reviewed automation.
+- Parameter profiles, effective snapshots, diffs, proposals, and reviewed
+  application of calibration-derived settings.
+- Calibration records and proposals that preserve source measurements,
+  analysis attempts, generated sidecars, affected parameter paths, diffs, and
+  rollback targets before any active parameter ref changes.
+- Managed execution, device communication, and AI-assisted reviewed automation
+  after the code/parameter evidence model is durable.
 
 ## Key Stories
 

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -22,19 +22,18 @@ becoming a legacy import project or a full automation stack.
 
 ## Post-MVP Scope
 
+Detailed post-MVP priority and acceptance details live in
+`product/future-concepts.md` and
+`product/future-stories-and-requirements.md`.
+
 - User-written import helpers for old data when generic APIs mature.
 - Read-only LAN viewing.
 - Measurement-code source setup and approved code update flows.
-- Managed code/source provenance for measurement, analysis, and calibration
-  evidence, replacing copied working folders as the normal explanation for
-  where code came from.
+- Managed code/source provenance for measurement, analysis, and calibration.
 - Rich sample maps, saved views, comparison, and context correction UX.
 - Parameter profiles, effective snapshots, diffs, proposals, and reviewed
   durable promotion of calibration-derived settings.
-- Calibration records, chains, working refs, health gates, and proposals that
-  preserve source measurements, analysis attempts, generated sidecars,
-  affected parameter paths, diffs, and rollback targets before durable named
-  refs are promoted.
+- Calibration records, chains, working refs, health gates, and proposals.
 - Managed execution, device communication, and AI-assisted reviewed automation
   after the code/parameter evidence model is durable.
 

--- a/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs-next/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -16,6 +16,8 @@ becoming a legacy import project or a full automation stack.
 - Source aliases and old-system references as metadata, not primary identity.
 - Honest code provenance for interactive unmanaged Python.
 - Light contextual summaries for setup, environment, procedure, and parameters.
+- Run-bound local configuration snapshots or summaries for files and references
+  that old scripts currently leave in copied folders.
 - Optional sample/session context that can be corrected after a run.
 
 ## Post-MVP Scope
@@ -35,3 +37,4 @@ becoming a legacy import project or a full automation stack.
 - US-016: Record passive procedure context.
 - US-017: Migrate a Data Vault-style script to Fricon writers.
 - US-018: Start new work in Fricon while old history stays in the old system.
+- US-019: Capture run-bound local configuration.

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -9,6 +9,10 @@ Accepted post-MVP priority ledger.
 Preserve important post-MVP directions without letting future systems inflate
 the MVP measurement loop.
 
+This file owns the accepted priority order for post-MVP concepts. Candidate
+stories and requirement details live in
+`product/future-stories-and-requirements.md`.
+
 These are product priority horizons, not semantic-version promises. Compatible
 capabilities may ship on the same release line as the MVP if the compatibility,
 storage, and API policies allow it.

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -58,7 +58,7 @@ Boundary:
   diffs, source evidence, and rollback target where practical.
 - Treat calibration-derived values as proposed parameter changes first. A
   calibration can produce evidence, fitted values, and affected parameter
-  paths without directly mutating the active profile.
+  paths without directly mutating a durable named profile.
 - Treat sample target binding as a convention first: parameter table row keys
   may be reused by visualization code and snapshot queries, but Fricon does
   not need a mandatory sample-component ontology in the first parameter slice.
@@ -114,8 +114,8 @@ Why third:
   code, devices, or data-library state.
 - Calibration automation is valuable early only when it reduces parameter
   confusion: preview the analysis inputs, generated sidecars or derived
-  artifacts, fitted values, affected parameter paths, diffs, and rollback path
-  before any accepted change is applied.
+  artifacts, fitted values, affected parameter paths, task health, retry or
+  pause decisions, and rollback path before durable changes are promoted.
 - A later managed measurement model can borrow from declarative UI and
   infrastructure systems: users describe expected parameter-derived setup or
   device state, Fricon computes a diff from observed state, previews an apply
@@ -145,9 +145,14 @@ Boundary:
 - Keep imperative Python scripts valid. Desired-state planning is a higher
   provenance option for routines that can declare pure parameter-to-state
   functions and explicit hardware constraints.
-- Calibration workflows should first create durable evidence and proposals.
-  Automatic writeback to active parameter refs or devices is a later
-  safety-gated capability, not the first automation slice.
+- Calibration workflows for sample/control parameters should first create
+  durable evidence, fitted values, health decisions, and promotion proposals.
+  A bootstrap calibration sequence should be able to continue through healthy
+  substeps by updating a chain-scoped calibration working ref, without asking
+  for approval at every small update. Publishing selected results to durable
+  named profiles remains a separate promotion step.
+- Instrument/device calibration and desired-state device apply are separate
+  device/setup capabilities with their own safety model.
 - Device write-back, resumable execution, and AI-assisted mutation need safety,
   readback, partial-failure, and audit ADRs.
 - Reconciliation must not assume device writes are commutative, idempotent, or

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -34,6 +34,9 @@ Why first:
 
 - Fricon's core motivation is dissatisfaction with existing parameter
   management and code management around physical measurements.
+- The most painful legacy failure mode is not a missing label taxonomy; it is
+  copied code and mutable parameter/config files making it unclear which
+  settings a calibration depended on or changed.
 - Parameter state directly shapes whether a completed measurement can be
   understood, compared, repeated, or promoted into better lab practice.
 - Managed runs and automation workflows need a parameter model to avoid
@@ -51,12 +54,17 @@ Boundary:
 - Start with a hybrid parameter tree: flexible structured values first, with
   selected parameters upgraded to typed definitions, units, validation, and UI
   affordances.
-- Use lightweight proposals with actor, reason, and approval history.
+- Use lightweight proposals with actor, reason, approval history, before/after
+  diffs, source evidence, and rollback target where practical.
+- Treat calibration-derived values as proposed parameter changes first. A
+  calibration can produce evidence, fitted values, and affected parameter
+  paths without directly mutating the active profile.
 - Treat sample target binding as a convention first: parameter table row keys
   may be reused by visualization code and snapshot queries, but Fricon does
   not need a mandatory sample-component ontology in the first parameter slice.
 - Do not require a full permissions system, strict global registry, or device
-  write-back for the first parameter slice.
+  write-back for the first parameter slice. A mandatory field-level confidence
+  taxonomy is also deferred unless a concrete workflow proves it is needed.
 
 ## Priority 2: Managed Run
 
@@ -66,6 +74,9 @@ Why second:
   provenance experiment runner when users opt in.
 - Useful run history depends on captured code, parameters, lifecycle, logs, and
   produced artifacts, not manual entry.
+- Calibration evidence needs to cite the code source or code snapshot that
+  produced fitted values; otherwise automated calibration only formalizes the
+  old copied-folder ambiguity.
 - Managed run should grow from ordinary importable Python code, not from a
   separate experiment DSL.
 
@@ -87,6 +98,8 @@ Boundary:
 - Ordinary interactive unmanaged Python remains valid and clearly labeled.
 - Capture enough context for compare and failure investigation before designing
   queues, resumable scan points, or autonomous automation.
+- Managed run should replace copied-code folders as a provenance workflow
+  before it tries to own scheduling or hardware orchestration.
 - Queues, resource leases, retries, workflow DAGs, and resumable execution are
   later or ADR-gated.
 
@@ -99,6 +112,10 @@ Why third:
 - The experiment UX risk is hidden mutation. The product value is preview,
   review, audit, and explicit approval around changes to parameters, setup,
   code, devices, or data-library state.
+- Calibration automation is valuable early only when it reduces parameter
+  confusion: preview the analysis inputs, generated sidecars or derived
+  artifacts, fitted values, affected parameter paths, diffs, and rollback path
+  before any accepted change is applied.
 - AI-assisted workflow is only acceptable after the audit and review model
   exists.
 
@@ -118,6 +135,9 @@ Boundary:
 
 - Store and diff setup, device, and calibration state before applying settings
   back to devices.
+- Calibration workflows should first create durable evidence and proposals.
+  Automatic writeback to active parameter refs or devices is a later
+  safety-gated capability, not the first automation slice.
 - Device write-back, resumable execution, and AI-assisted mutation need safety,
   readback, partial-failure, and audit ADRs.
 - Read-only compare, triage, and preview workflows may arrive before

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -116,6 +116,10 @@ Why third:
   confusion: preview the analysis inputs, generated sidecars or derived
   artifacts, fitted values, affected parameter paths, diffs, and rollback path
   before any accepted change is applied.
+- A later managed measurement model can borrow from declarative UI and
+  infrastructure systems: users describe expected parameter-derived setup or
+  device state, Fricon computes a diff from observed state, previews an apply
+  plan, and only then performs safe parallel or ordered writes.
 - AI-assisted workflow is only acceptable after the audit and review model
   exists.
 
@@ -130,16 +134,25 @@ Included concepts:
 - FC-010: AI-assisted automation after the audit model exists.
 - FC-018: Routine recipes, reviewed replay, and batch compare for repetitive
   work after parameter and run facts are trustworthy.
+- FC-019: Desired-state setup/device planning, reconciliation diffs, and
+  reviewed apply plans for routines where imperative nested loops are too
+  error-prone.
 
 Boundary:
 
 - Store and diff setup, device, and calibration state before applying settings
   back to devices.
+- Keep imperative Python scripts valid. Desired-state planning is a higher
+  provenance option for routines that can declare pure parameter-to-state
+  functions and explicit hardware constraints.
 - Calibration workflows should first create durable evidence and proposals.
   Automatic writeback to active parameter refs or devices is a later
   safety-gated capability, not the first automation slice.
 - Device write-back, resumable execution, and AI-assisted mutation need safety,
   readback, partial-failure, and audit ADRs.
+- Reconciliation must not assume device writes are commutative, idempotent, or
+  safe to parallelize. Apply plans need dependency, settling, readback,
+  timeout, and abort semantics before they can reach hardware.
 - Read-only compare, triage, and preview workflows may arrive before
   mutation-capable automation if they reuse the same record and review model.
 - A broad workflow DAG engine is not the normal way to run ordinary

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -103,7 +103,7 @@ Boundary:
 - Queues, resource leases, retries, workflow DAGs, and resumable execution are
   later or ADR-gated.
 
-## Priority 3: Reviewable Automation Workflow
+## Priority 3: Calibration Chains And Reviewable Automation
 
 Why third:
 

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -13,6 +13,11 @@ These are product priority horizons, not semantic-version promises. Compatible
 capabilities may ship on the same release line as the MVP if the compatibility,
 storage, and API policies allow it.
 
+Post-MVP concepts should move Fricon toward local experiment memory and
+reviewed action. The point is to explain, compare, hand off, repeat, and safely
+automate work from recorded facts, not to imitate legacy acquisition tools or
+make device control, sample visualization, or AI the product center by itself.
+
 ## Promotion Rule
 
 A future concept can move into implementation only after it has a clear story,

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -28,7 +28,7 @@ Post-MVP work should prioritize:
 
 - parameter system first
 - managed run second
-- reviewable automation workflow third
+- calibration chains and reviewable automation third
 
 Analysis of representative legacy measurement workflows suggests read-only
 comparison, run like a previous measurement, and failure investigation should
@@ -329,7 +329,7 @@ Not first managed-run slice:
 - Making managed execution mandatory for ordinary exploratory scripts.
 - Treating shell-command wrapping as the primary runner UX.
 
-## Priority 3: Reviewable Automation Workflow
+## Priority 3: Calibration Chains And Reviewable Automation
 
 FEPIC-004: Setup And Calibration State Store/Diff.
 
@@ -349,7 +349,7 @@ FEPIC-004: Setup And Calibration State Store/Diff.
   decisions, and promoted parameter changes inspectable enough that users can
   trust the next run.
 
-FEPIC-005: Reviewable Automation Workflow.
+FEPIC-005: Calibration Chains And Reviewable Automation Workflow.
 
 - Users can preview automation actions before they mutate durable Fricon state,
   device state, named parameter refs, or calibration records.

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -18,11 +18,9 @@ compatibility, storage, and API policies allow it.
 
 ## Planning Stance
 
-Post-MVP Fricon should move from data-library replacement toward local
-experiment memory and reviewed action. The product should capture enough facts
-to explain, compare, hand off, replay, and safely automate lab work without
-pretending to own code, parameters, setup, or devices before those boundaries
-are designed.
+`product/future-concepts.md` owns the accepted post-MVP priority ledger and
+rationale. This backlog expands that ledger into candidate future epics,
+stories, and requirements.
 
 Post-MVP work should prioritize:
 
@@ -30,47 +28,15 @@ Post-MVP work should prioritize:
 - managed run second
 - calibration chains and reviewable automation third
 
-Analysis of representative legacy measurement workflows suggests read-only
-comparison, run like a previous measurement, and failure investigation should
-arrive before mutation-capable automation. These workflows can build trust from
-recorded facts without taking control of parameters, devices, or code.
-
-The dominant pain is code and parameter management disorder. Copied measurement
-folders, mutable parameter files, generated sidecars, and notebook-local
-analysis make it hard to know which settings produced a calibration result.
-Post-MVP Fricon should therefore prioritize durable code provenance, effective
-parameter snapshots, parameter diffs, analysis evidence, and reviewed
-calibration proposals before investing in broad automation.
-
-Calibration is the accepted domain term because quantum experimenters use it
-for this workflow. In this backlog, unqualified calibration means estimating
-better sample, qubit, gate, pulse, readout, fit, or analysis parameters from
-measurement evidence. Use qualified terms for other meanings: instrument
-calibration for hardware/setup calibration, and setup/device reconciliation
-for desired-state apply/readback workflows.
-
 The product rule is: the system captures context automatically where practical;
 the user confirms, annotates, or corrects it. Any workflow that mutates
 parameters, setup, devices, code, or data-library state needs explicit preview,
 review, and audit semantics.
 
-Prefer features that make experiments explainable, comparable, repeatable, or
-safely reviewable. Deprioritize features that merely imitate legacy acquisition
-tools, add device control without recorded state, or create automation before
-Fricon can explain the facts automation depends on. Detailed field-level
-confidence labels are a later refinement unless a concrete workflow requires
-them. Calibration task health/confidence gates are a concrete workflow need,
-but broad confidence taxonomies for every field are not. The first priority is
-recording the source facts and review decisions that calibration and repeat
-work depend on.
-
-Current imperative lab scripts are valid adoption targets, not design ideals.
-Many routines scan parameters through nested loops and calculate per-device
-writes inside the loop body. Post-MVP Fricon should leave room for a more
-declarative model inspired by UI rendering and infrastructure planning: users
-define how parameters produce expected setup or device state, Fricon computes
-the difference from observed state, previews an ordered or parallel-safe apply
-plan, and records what was intended, written, read back, skipped, or failed.
+Use `product/glossary.md` and `domain/conceptual-model.md` for term
+boundaries. This backlog may mention those terms, but it should not become the
+canonical definition for calibration, run manifests, working refs, or
+setup/device reconciliation.
 
 ## Priority 1: Parameter System
 

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -24,6 +24,11 @@ Post-MVP work should prioritize:
 - managed run second
 - reviewable automation workflow third
 
+Concrete legacy measurement sample analysis suggests read-only comparison, run
+like a previous measurement, and failure investigation should arrive before
+mutation-capable automation. These workflows can build trust from recorded
+facts without taking control of parameters, devices, or code.
+
 The product rule is: the system captures context automatically where practical;
 the user confirms, annotates, or corrects it. Any workflow that mutates
 parameters, setup, devices, code, or data-library state needs explicit preview,

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -35,6 +35,13 @@ comparison, run like a previous measurement, and failure investigation should
 arrive before mutation-capable automation. These workflows can build trust from
 recorded facts without taking control of parameters, devices, or code.
 
+The dominant pain is code and parameter management disorder. Copied measurement
+folders, mutable parameter files, generated sidecars, and notebook-local
+analysis make it hard to know which settings produced a calibration result.
+Post-MVP Fricon should therefore prioritize durable code provenance, effective
+parameter snapshots, parameter diffs, analysis evidence, and reviewed
+calibration proposals before investing in broad automation.
+
 The product rule is: the system captures context automatically where practical;
 the user confirms, annotates, or corrects it. Any workflow that mutates
 parameters, setup, devices, code, or data-library state needs explicit preview,
@@ -43,7 +50,10 @@ review, and audit semantics.
 Prefer features that make experiments explainable, comparable, repeatable, or
 safely reviewable. Deprioritize features that merely imitate legacy acquisition
 tools, add device control without recorded state, or create automation before
-Fricon can explain the facts automation depends on.
+Fricon can explain the facts automation depends on. Detailed field-level
+confidence labels are a later refinement unless a concrete workflow requires
+them; the first priority is recording the source facts and review decisions
+that calibration and repeat work depend on.
 
 ## Priority 1: Parameter System
 
@@ -89,6 +99,8 @@ FUS-004: Promote a good run into a parameter proposal.
   profile intentionally.
 - Success: promotion records source run, changed fields, reviewer/actor, and
   approval or rejection outcome.
+- Success: promotion can cite analysis or calibration evidence when the source
+  run produced fitted settings.
 - Success: proposal review is distinct from run-like-previous convenience; a
   named parameter ref changes only after explicit review.
 - Success: this is a lightweight proposal flow, not a permissions or compliance
@@ -105,6 +117,8 @@ FUS-008: Run like a previous measurement.
   source run; nothing starts or mutates until the user confirms.
 - Success: unmanaged source facts remain labeled unmanaged instead of being
   promoted to managed provenance.
+- Success: calibration-derived parameters remain tied to their source evidence
+  instead of becoming anonymous copied values.
 
 FUS-015: Use parameter row keys as visual targets.
 
@@ -135,6 +149,9 @@ Parameter requirements:
   or source snapshot, changed fields, actor, reason, approval/rejection
   outcome, and timestamp. They do not require a permissions system in the first
   parameter workflow slice.
+- FREQ-023: Calibration-derived parameter changes must flow through parameter
+  proposals or calibration proposals. Direct edits to active parameter refs
+  should not be the normal automation path.
 - FREQ-016: Parameter table rows can expose stable, user-defined target keys
   for visualization and compare views. Fricon must not require those keys to
   imply a first-class physical sample-component model.
@@ -149,6 +166,7 @@ Not first parameter slice:
 - Strict global registry for every parameter.
 - Permissions, compliance, or multi-user approval system.
 - Automatic tracing of every parameter read without explicit design.
+- A mandatory field-level confidence taxonomy for every parameter value.
 - Heavyweight sample-component ontology.
 - Mandatory 2D sample-map authoring.
 - Visualizer schema migration or compatibility policy.
@@ -163,11 +181,11 @@ FEPIC-002: Managed Code Source And Run Capture.
   summary, stdout/stderr, status, diagnostics, and produced artifacts.
 - Fricon can assemble a compact run manifest for compare, handoff, export, and
   failure investigation.
-- Managed run improves provenance confidence; it does not by itself guarantee
+- Managed run improves provenance coverage; it does not by itself guarantee
   scientific reproducibility without parameter, setup/device, environment, and
   calibration coverage.
 - Ordinary interactive unmanaged Python remains possible, but shows lower
-  provenance confidence.
+  provenance coverage.
 
 FEPIC-003: Measurement History, Compare, And Handoff.
 
@@ -182,6 +200,8 @@ FUS-005: Configure a measurement code source.
   folders as the only code provenance story.
 - Success: source location, selected revision, environment file, and local
   checkout status are visible before a managed run.
+- Success: code-source setup can replace copied working folders as the normal
+  explanation for where measurement code came from.
 
 FUS-006: Capture a managed code snapshot.
 
@@ -189,8 +209,10 @@ FUS-006: Capture a managed code snapshot.
   source hashes, dependency summary, SDK runner entry point, and runner
   invocation when it starts a managed run so that measurement history is not
   hand-entered.
-- Success: provenance confidence is visible as unmanaged, observed, or managed
+- Success: provenance level is visible as unmanaged, observed, or managed
   snapshot.
+- Success: calibration evidence records which code snapshot or unmanaged code
+  summary produced the analysis or fitted values.
 
 FUS-007: Run through an opt-in SDK runner.
 
@@ -209,7 +231,7 @@ FUS-009: Compare two measurements.
   can explain why results differ.
 - Success: comparison is generated from recorded facts, not a manual report.
 - Success: a previous-good run can be selected as a baseline, and missing or
-  low-confidence facts are shown rather than hidden.
+  incomplete facts are shown rather than hidden.
 
 FUS-010: See operator handoff.
 
@@ -227,7 +249,7 @@ FUS-016: Inspect a run manifest.
   lifecycle, logs, artifacts, operator, and timestamps so that I can understand
   a run without opening several unrelated stores.
 - Success: the manifest can be opened from Desktop, Python, and export bundles.
-- Success: the manifest states provenance confidence instead of implying that
+- Success: the manifest states provenance coverage instead of implying that
   unmanaged work was fully captured.
 - Success: the manifest is a composite view over recorded facts; it does not
   own or duplicate parameter, code, setup, analysis, or artifact records.
@@ -242,6 +264,8 @@ FUS-017: Investigate a failed fit or anomalous measurement.
   input artifacts, method/code reference, quality metrics, failure reason, and
   produced outputs when available.
 - Success: comparison to a previous-good run is generated from recorded facts.
+- Success: investigation can show whether code, parameter snapshot, generated
+  sidecars, or calibration evidence changed from the previous-good baseline.
 
 FUS-019: Record measurement intent and outcome.
 
@@ -260,7 +284,7 @@ Managed-run requirements:
 - FREQ-006: Managed code provenance records source URI/path, selected revision,
   dirty state, source hashes where practical, SDK runner entry point, runner
   invocation, and environment summary.
-- FREQ-007: Fricon shows provenance confidence instead of claiming
+- FREQ-007: Fricon shows provenance level and coverage instead of claiming
   reproducibility from Git metadata alone.
 - FREQ-008: The first managed-runner slice is SDK runner integration. It
   captures stdout/stderr excerpts or logs, start/end timestamps, status,
@@ -273,14 +297,13 @@ Managed-run requirements:
 - FREQ-017: A run manifest links the durable measurement identity to parameter
   snapshot/ref facts, row/target keys when present, code/environment summary,
   lifecycle/log events, artifacts, operator, timestamps, and provenance
-  confidence.
+  coverage.
 - FREQ-018: Analysis or fit attempts can be represented as investigation
   records with inputs, method/code reference, status, diagnostics, quality
   metrics, failure reason, and outputs when available.
 - FREQ-021: Measurement intent and outcome records preserve question, decision,
-  linked evidence, actor, timestamp, and trust label without turning Fricon into
-  a full ELN.
-
+  linked evidence, actor, timestamp, and review state without turning Fricon
+  into a full ELN.
 Not first managed-run slice:
 
 - Scheduler, queues, resource leases, broad retry policy, or workflow DAG.
@@ -299,6 +322,9 @@ FEPIC-004: Setup And Calibration State Store/Diff.
   distinct: setup records declared or passive context; device snapshots record
   identity and observed/readback facts when available; calibration ledgers
   record validity and review state.
+- The first calibration-state value is not autonomous device control. It is
+  making calibration evidence, affected parameters, and applied changes
+  inspectable enough that users can trust the next run.
 
 FEPIC-005: Reviewable Automation Workflow.
 
@@ -320,7 +346,7 @@ FUS-011: Store and diff setup snapshots.
 - Success: Fricon can diff snapshots and bind a snapshot to a run without
   controlling devices.
 - Success: readback freshness states whether it is user-supplied,
-  integration-supplied, or device-observed, with source and confidence.
+  integration-supplied, or device-observed, with source and timestamp.
 
 FUS-012: Track calibration state.
 
@@ -329,6 +355,23 @@ FUS-012: Track calibration state.
   links so that questionable data can be reviewed.
 - Success: out-of-tolerance records can flag a review window without silently
   invalidating data.
+- Success: a calibration record can link to the parameter proposal or
+  calibration proposal that applied its derived settings.
+- Success: fit quality, residuals, warnings, and manual rationale can be
+  preserved when they materially affect whether a calibration should be used.
+
+FUS-020: Stage calibration results before applying parameter changes.
+
+- As an experimentalist, I want fitted calibration outputs to become reviewed
+  proposals before they update active parameters so that automation does not
+  silently overwrite the state future runs depend on.
+- Success: a proposal records source measurements, analysis attempts, fitted
+  values, generated sidecars or derived artifacts where relevant, affected
+  parameter paths, before/after diff, code context, and reviewer/actor.
+- Success: acceptance creates or updates the target parameter profile/ref
+  through the same proposal/audit path as manual parameter promotion.
+- Success: rejection or deferral preserves the evidence without mutating active
+  parameter state.
 
 FUS-013: Preview an automation workflow.
 
@@ -339,6 +382,9 @@ FUS-013: Preview an automation workflow.
   runs, analysis steps, calibration proposals, and data-library mutations.
 - Success: preview identifies whether each action is read-only, produces a
   durable record, mutates Fricon state, or reaches an ADR-gated device boundary.
+- Success: calibration automation previews generated artifacts, affected
+  parameter paths, before/after diffs, and rollback targets before applying
+  accepted changes.
 
 FUS-014: Review and apply automation proposals.
 
@@ -354,6 +400,8 @@ FUS-018: Replay a routine recipe after review.
   hiding what will change.
 - Success: preview shows parameter refs or overrides, code entry point,
   expected artifacts, analysis steps, and durable mutations before execution.
+- Success: replay states which routine/code version, parameter snapshot,
+  calibration evidence, generated sidecars, and safety envelope it depends on.
 - Success: read-only batch compare or triage can be useful before
   mutation-capable automation exists.
 - Success: replay records recipe template, automation proposal, review
@@ -380,6 +428,17 @@ Automation requirements:
 - FREQ-022: AI may summarize, propose, or assist, but mutating actions enter as
   ordinary reviewed proposals. Durable AI-created conclusions record model or
   tool provenance and privacy-scoped inputs where practical.
+- FREQ-024: Calibration proposals preserve source measurements, analysis
+  attempts, fitted values, affected parameter paths, before/after diffs, code
+  context, review outcome, and rollback target where practical.
+- FREQ-025: Automation previews classify intended effects at least as
+  read-only inspection, derived artifact creation, data-library mutation,
+  parameter/profile mutation, device/hardware mutation, or ADR-gated
+  OS/network mutation.
+- FREQ-026: Generated sidecars or derived config files that influence analysis,
+  calibration, or replay are recorded as artifacts with source inputs,
+  generator/code context, and links to the proposal or run that depends on
+  them.
 
 Not first automation slice:
 
@@ -388,6 +447,8 @@ Not first automation slice:
   sources, or data-library state.
 - Device write-back before store/diff, readback, safety, and partial-failure
   behavior are accepted by ADR.
+- Fully automatic calibration writeback before code provenance, parameter
+  proposals, calibration evidence, and rollback paths are durable.
 - Generic workflow DAG engine as the normal way to run ordinary measurements.
 - Cloud-first dashboard, account, or team-permission system.
 

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -18,21 +18,32 @@ compatibility, storage, and API policies allow it.
 
 ## Planning Stance
 
+Post-MVP Fricon should move from data-library replacement toward local
+experiment memory and reviewed action. The product should capture enough facts
+to explain, compare, hand off, replay, and safely automate lab work without
+pretending to own code, parameters, setup, or devices before those boundaries
+are designed.
+
 Post-MVP work should prioritize:
 
 - parameter system first
 - managed run second
 - reviewable automation workflow third
 
-Concrete legacy measurement sample analysis suggests read-only comparison, run
-like a previous measurement, and failure investigation should arrive before
-mutation-capable automation. These workflows can build trust from recorded
-facts without taking control of parameters, devices, or code.
+Analysis of representative legacy measurement workflows suggests read-only
+comparison, run like a previous measurement, and failure investigation should
+arrive before mutation-capable automation. These workflows can build trust from
+recorded facts without taking control of parameters, devices, or code.
 
 The product rule is: the system captures context automatically where practical;
 the user confirms, annotates, or corrects it. Any workflow that mutates
 parameters, setup, devices, code, or data-library state needs explicit preview,
 review, and audit semantics.
+
+Prefer features that make experiments explainable, comparable, repeatable, or
+safely reviewable. Deprioritize features that merely imitate legacy acquisition
+tools, add device control without recorded state, or create automation before
+Fricon can explain the facts automation depends on.
 
 ## Priority 1: Parameter System
 
@@ -78,6 +89,8 @@ FUS-004: Promote a good run into a parameter proposal.
   profile intentionally.
 - Success: promotion records source run, changed fields, reviewer/actor, and
   approval or rejection outcome.
+- Success: proposal review is distinct from run-like-previous convenience; a
+  named parameter ref changes only after explicit review.
 - Success: this is a lightweight proposal flow, not a permissions or compliance
   system.
 
@@ -88,6 +101,10 @@ FUS-008: Run like a previous measurement.
   layout so that repeat work is faster without hiding what changed.
 - Success: reused facts are copied by reference or snapshot, and changes are
   shown before the new run starts.
+- Success: the new run starts from a draft with visible differences from the
+  source run; nothing starts or mutates until the user confirms.
+- Success: unmanaged source facts remain labeled unmanaged instead of being
+  promoted to managed provenance.
 
 FUS-015: Use parameter row keys as visual targets.
 
@@ -146,6 +163,9 @@ FEPIC-002: Managed Code Source And Run Capture.
   summary, stdout/stderr, status, diagnostics, and produced artifacts.
 - Fricon can assemble a compact run manifest for compare, handoff, export, and
   failure investigation.
+- Managed run improves provenance confidence; it does not by itself guarantee
+  scientific reproducibility without parameter, setup/device, environment, and
+  calibration coverage.
 - Ordinary interactive unmanaged Python remains possible, but shows lower
   provenance confidence.
 
@@ -188,6 +208,8 @@ FUS-009: Compare two measurements.
   setup, calibration status, lifecycle, notes, and output artifacts so that I
   can explain why results differ.
 - Success: comparison is generated from recorded facts, not a manual report.
+- Success: a previous-good run can be selected as a baseline, and missing or
+  low-confidence facts are shown rather than hidden.
 
 FUS-010: See operator handoff.
 
@@ -195,16 +217,20 @@ FUS-010: See operator handoff.
   that I can trust the lab computer state before starting work.
 - Success: handoff includes parameter ref changes, setup snapshot changes,
   calibration due/expired state, failed runs, imports, exports, and notes.
+- Success: handoff distinguishes facts, warnings, decisions, and missing
+  provenance so the next operator knows what remains uncertain.
 
 FUS-016: Inspect a run manifest.
 
-- As an experimentalist, I want a single run manifest that links the
+- As an experimentalist, I want a run manifest that links the available
   measurement, parameter snapshot, row/target keys, code/environment summary,
   lifecycle, logs, artifacts, operator, and timestamps so that I can understand
   a run without opening several unrelated stores.
 - Success: the manifest can be opened from Desktop, Python, and export bundles.
 - Success: the manifest states provenance confidence instead of implying that
   unmanaged work was fully captured.
+- Success: the manifest is a composite view over recorded facts; it does not
+  own or duplicate parameter, code, setup, analysis, or artifact records.
 
 FUS-017: Investigate a failed fit or anomalous measurement.
 
@@ -216,6 +242,18 @@ FUS-017: Investigate a failed fit or anomalous measurement.
   input artifacts, method/code reference, quality metrics, failure reason, and
   produced outputs when available.
 - Success: comparison to a previous-good run is generated from recorded facts.
+
+FUS-019: Record measurement intent and outcome.
+
+- As an experimentalist, I want to record the question, intent, outcome, and
+  trust decision for a measurement so that future compare, handoff, and repeat
+  work can use more than raw data and filenames.
+- Success: intent can be recorded before or during a run, and outcome can be
+  recorded after review.
+- Success: outcomes can link to datasets, analysis attempts, notes, and
+  lifecycle events.
+- Success: lightweight labels such as accepted, questionable, invalidated, or
+  repeat-needed can explain review state without becoming a full ELN.
 
 Managed-run requirements:
 
@@ -239,6 +277,9 @@ Managed-run requirements:
 - FREQ-018: Analysis or fit attempts can be represented as investigation
   records with inputs, method/code reference, status, diagnostics, quality
   metrics, failure reason, and outputs when available.
+- FREQ-021: Measurement intent and outcome records preserve question, decision,
+  linked evidence, actor, timestamp, and trust label without turning Fricon into
+  a full ELN.
 
 Not first managed-run slice:
 
@@ -254,6 +295,10 @@ FEPIC-004: Setup And Calibration State Store/Diff.
 - Users record setup/device/calibration state as structured snapshots and
   ledgers.
 - Fricon can diff and bind state to runs without applying settings to devices.
+- Setup snapshots, device snapshots, and calibration ledgers are related but
+  distinct: setup records declared or passive context; device snapshots record
+  identity and observed/readback facts when available; calibration ledgers
+  record validity and review state.
 
 FEPIC-005: Reviewable Automation Workflow.
 
@@ -263,6 +308,9 @@ FEPIC-005: Reviewable Automation Workflow.
   objects, actor, review outcome, and audit events.
 - Automation grows from parameter system and managed run records instead of
   becoming an unrelated workflow engine.
+- Automation records are distinct from managed measurement execution: reusable
+  recipes, previewable proposals, review decisions, and execution records each
+  own different facts.
 
 FUS-011: Store and diff setup snapshots.
 
@@ -271,6 +319,8 @@ FUS-011: Store and diff setup snapshots.
   freshness so that setup drift is inspectable.
 - Success: Fricon can diff snapshots and bind a snapshot to a run without
   controlling devices.
+- Success: readback freshness states whether it is user-supplied,
+  integration-supplied, or device-observed, with source and confidence.
 
 FUS-012: Track calibration state.
 
@@ -287,6 +337,8 @@ FUS-013: Preview an automation workflow.
   not surprise me.
 - Success: preview separates parameter changes, setup/device changes, managed
   runs, analysis steps, calibration proposals, and data-library mutations.
+- Success: preview identifies whether each action is read-only, produces a
+  durable record, mutates Fricon state, or reaches an ADR-gated device boundary.
 
 FUS-014: Review and apply automation proposals.
 
@@ -304,6 +356,8 @@ FUS-018: Replay a routine recipe after review.
   expected artifacts, analysis steps, and durable mutations before execution.
 - Success: read-only batch compare or triage can be useful before
   mutation-capable automation exists.
+- Success: replay records recipe template, automation proposal, review
+  decision, execution status, produced records, and failure handling separately.
 
 Automation requirements:
 
@@ -323,6 +377,9 @@ Automation requirements:
 - FREQ-019: Routine recipes and reviewed replay use parameter snapshots and
   run manifests as inputs. Read-only compare or triage may run first; mutation
   requires preview, review, execution status, and audit records.
+- FREQ-022: AI may summarize, propose, or assist, but mutating actions enter as
+  ordinary reviewed proposals. Durable AI-created conclusions record model or
+  tool provenance and privacy-scoped inputs where practical.
 
 Not first automation slice:
 

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -55,6 +55,14 @@ confidence labels are a later refinement unless a concrete workflow requires
 them; the first priority is recording the source facts and review decisions
 that calibration and repeat work depend on.
 
+Current imperative lab scripts are valid adoption targets, not design ideals.
+Many routines scan parameters through nested loops and calculate per-device
+writes inside the loop body. Post-MVP Fricon should leave room for a more
+declarative model inspired by UI rendering and infrastructure planning: users
+define how parameters produce expected setup or device state, Fricon computes
+the difference from observed state, previews an ordered or parallel-safe apply
+plan, and records what was intended, written, read back, skipped, or failed.
+
 ## Priority 1: Parameter System
 
 FEPIC-001: Parameter System And Snapshot Binding.
@@ -318,6 +326,9 @@ FEPIC-004: Setup And Calibration State Store/Diff.
 - Users record setup/device/calibration state as structured snapshots and
   ledgers.
 - Fricon can diff and bind state to runs without applying settings to devices.
+- Later, Fricon can separate desired setup/device state from observed
+  setup/device status so managed routines can compute reconciliation plans
+  before touching hardware.
 - Setup snapshots, device snapshots, and calibration ledgers are related but
   distinct: setup records declared or passive context; device snapshots record
   identity and observed/readback facts when available; calibration ledgers
@@ -334,6 +345,9 @@ FEPIC-005: Reviewable Automation Workflow.
   objects, actor, review outcome, and audit events.
 - Automation grows from parameter system and managed run records instead of
   becoming an unrelated workflow engine.
+- Automation may eventually reconcile declared desired state against current
+  state, but only through plans that expose dependencies, parallelization,
+  settle/readback checks, and failure handling.
 - Automation records are distinct from managed measurement execution: reusable
   recipes, previewable proposals, review decisions, and execution records each
   own different facts.
@@ -386,6 +400,22 @@ FUS-013: Preview an automation workflow.
   parameter paths, before/after diffs, and rollback targets before applying
   accepted changes.
 
+FUS-021: Declare expected setup/device state and reconcile it.
+
+- As an experimentalist, I want a managed routine to describe the expected
+  setup or device state derived from parameters so that Fricon can compute
+  what actually needs to change instead of every loop body manually writing
+  every device in sequence.
+- Success: the desired state is a durable plan input separate from observed
+  device/readback status and from completed measurement facts.
+- Success: Fricon previews per-device diffs, skipped no-op writes, ordered
+  dependencies, safe parallel groups, expected settle/readback checks, and
+  abort behavior before applying changes.
+- Success: execution records the intended values, write attempts, readbacks,
+  failures, manual overrides, and any divergence from the approved plan.
+- Success: imperative scripts remain supported for exploratory work and for
+  devices whose side effects are not yet modeled safely.
+
 FUS-014: Review and apply automation proposals.
 
 - As a lab maintainer, I want automation proposals to require explicit review
@@ -422,6 +452,8 @@ Automation requirements:
 - FREQ-015: Automation records must preserve actor, trigger, reviewed plan,
   accepted or rejected changes, execution status, produced artifacts, and audit
   events.
+- FREQ-027: Desired-state routines distinguish desired state, observed/current
+  state, planned actions, attempted writes, readbacks, and final status.
 - FREQ-019: Routine recipes and reviewed replay use parameter snapshots and
   run manifests as inputs. Read-only compare or triage may run first; mutation
   requires preview, review, execution status, and audit records.
@@ -439,6 +471,9 @@ Automation requirements:
   calibration, or replay are recorded as artifacts with source inputs,
   generator/code context, and links to the proposal or run that depends on
   them.
+- FREQ-028: Reconciliation plans may parallelize device writes only when
+  dependency, safety, settle, readback, timeout, and abort semantics are
+  explicit enough for the affected devices and setup.
 
 Not first automation slice:
 
@@ -449,6 +484,8 @@ Not first automation slice:
   behavior are accepted by ADR.
 - Fully automatic calibration writeback before code provenance, parameter
   proposals, calibration evidence, and rollback paths are durable.
+- A general optimizer that rewrites arbitrary imperative scan loops into
+  parallel device operations.
 - Generic workflow DAG engine as the normal way to run ordinary measurements.
 - Cloud-first dashboard, account, or team-permission system.
 

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -42,6 +42,13 @@ Post-MVP Fricon should therefore prioritize durable code provenance, effective
 parameter snapshots, parameter diffs, analysis evidence, and reviewed
 calibration proposals before investing in broad automation.
 
+Calibration is the accepted domain term because quantum experimenters use it
+for this workflow. In this backlog, unqualified calibration means estimating
+better sample, qubit, gate, pulse, readout, fit, or analysis parameters from
+measurement evidence. Use qualified terms for other meanings: instrument
+calibration for hardware/setup calibration, and setup/device reconciliation
+for desired-state apply/readback workflows.
+
 The product rule is: the system captures context automatically where practical;
 the user confirms, annotates, or corrects it. Any workflow that mutates
 parameters, setup, devices, code, or data-library state needs explicit preview,
@@ -52,8 +59,10 @@ safely reviewable. Deprioritize features that merely imitate legacy acquisition
 tools, add device control without recorded state, or create automation before
 Fricon can explain the facts automation depends on. Detailed field-level
 confidence labels are a later refinement unless a concrete workflow requires
-them; the first priority is recording the source facts and review decisions
-that calibration and repeat work depend on.
+them. Calibration task health/confidence gates are a concrete workflow need,
+but broad confidence taxonomies for every field are not. The first priority is
+recording the source facts and review decisions that calibration and repeat
+work depend on.
 
 Current imperative lab scripts are valid adoption targets, not design ideals.
 Many routines scan parameters through nested loops and calculate per-device
@@ -158,8 +167,9 @@ Parameter requirements:
   outcome, and timestamp. They do not require a permissions system in the first
   parameter workflow slice.
 - FREQ-023: Calibration-derived parameter changes must flow through parameter
-  proposals or calibration proposals. Direct edits to active parameter refs
-  should not be the normal automation path.
+  proposals, calibration proposals, or chain-scoped calibration working refs.
+  Direct edits to durable named parameter refs should not be the normal
+  automation path.
 - FREQ-016: Parameter table rows can expose stable, user-defined target keys
   for visualization and compare views. Fricon must not require those keys to
   imply a first-class physical sample-component model.
@@ -323,24 +333,26 @@ Not first managed-run slice:
 
 FEPIC-004: Setup And Calibration State Store/Diff.
 
-- Users record setup/device/calibration state as structured snapshots and
-  ledgers.
+- Users record setup/device state and calibration-task evidence as structured
+  snapshots and ledgers.
 - Fricon can diff and bind state to runs without applying settings to devices.
 - Later, Fricon can separate desired setup/device state from observed
   setup/device status so managed routines can compute reconciliation plans
   before touching hardware.
-- Setup snapshots, device snapshots, and calibration ledgers are related but
-  distinct: setup records declared or passive context; device snapshots record
-  identity and observed/readback facts when available; calibration ledgers
-  record validity and review state.
+- Setup snapshots, device snapshots, calibration task records, and calibration
+  ledgers are related but distinct: setup records declared or passive context;
+  device snapshots record identity and observed/readback facts when available;
+  calibration task records preserve measurement evidence, fitted values,
+  diagnostics, and health decisions.
 - The first calibration-state value is not autonomous device control. It is
-  making calibration evidence, affected parameters, and applied changes
-  inspectable enough that users can trust the next run.
+  making calibration evidence, affected parameters, task health, retry/pause
+  decisions, and promoted parameter changes inspectable enough that users can
+  trust the next run.
 
 FEPIC-005: Reviewable Automation Workflow.
 
-- Users can preview automation actions before they mutate Fricon state, device
-  state, parameter refs, or calibration records.
+- Users can preview automation actions before they mutate durable Fricon state,
+  device state, named parameter refs, or calibration records.
 - Automation proposals record intended inputs, expected mutations, affected
   objects, actor, review outcome, and audit events.
 - Automation grows from parameter system and managed run records instead of
@@ -364,28 +376,38 @@ FUS-011: Store and diff setup snapshots.
 
 FUS-012: Track calibration state.
 
-- As an experimentalist, I want calibration records with due dates,
-  certificates, as-found/as-left values, pass/fail status, and affected-run
-  links so that questionable data can be reviewed.
-- Success: out-of-tolerance records can flag a review window without silently
-  invalidating data.
+- As an experimentalist, I want calibration records with source measurements,
+  fitted values, diagnostics, health decisions, and affected-run links so that
+  questionable data can be reviewed.
+- Success: records can distinguish sample/control-parameter calibration from
+  instrument/device calibration.
+- Success: unhealthy or out-of-family task results can pause a calibration
+  chain, request review, retry a previous step, or flag a review window without
+  silently invalidating data.
 - Success: a calibration record can link to the parameter proposal or
   calibration proposal that applied its derived settings.
-- Success: fit quality, residuals, warnings, and manual rationale can be
-  preserved when they materially affect whether a calibration should be used.
+- Success: fit quality, residuals, warnings, statistical checks, AI or algorithm
+  assessment, and manual rationale can be preserved when they materially affect
+  whether a calibration should be used.
 
-FUS-020: Stage calibration results before applying parameter changes.
+FUS-020: Run a bootstrap calibration chain with health gates.
 
-- As an experimentalist, I want fitted calibration outputs to become reviewed
-  proposals before they update active parameters so that automation does not
-  silently overwrite the state future runs depend on.
-- Success: a proposal records source measurements, analysis attempts, fitted
+- As an experimentalist, I want a calibration sequence made of smaller
+  calibration tasks to continue automatically through healthy intermediate
+  results, but pause, retry, or ask for review when a task result looks wrong.
+- Success: each task records source measurements, analysis attempts, fitted
   values, generated sidecars or derived artifacts where relevant, affected
-  parameter paths, before/after diff, code context, and reviewer/actor.
-- Success: acceptance creates or updates the target parameter profile/ref
-  through the same proposal/audit path as manual parameter promotion.
-- Success: rejection or deferral preserves the evidence without mutating active
-  parameter state.
+  parameter paths, code context, task status, and health assessment.
+- Success: task health can be assessed by deterministic checks, statistical
+  thresholds, operator rules, or AI assistance with recorded provenance.
+- Success: each healthy small task can update a chain-scoped calibration
+  working ref that later tasks consume, without requiring operator approval
+  after every small update.
+- Success: durable promotion to a named parameter profile/ref records the final
+  diff from the source working ref, source task chain, reviewer/actor where
+  required, and rollback target.
+- Success: rejection, retry, or deferral preserves evidence without mutating
+  durable named parameter state.
 
 FUS-013: Preview an automation workflow.
 
@@ -397,8 +419,8 @@ FUS-013: Preview an automation workflow.
 - Success: preview identifies whether each action is read-only, produces a
   durable record, mutates Fricon state, or reaches an ADR-gated device boundary.
 - Success: calibration automation previews generated artifacts, affected
-  parameter paths, before/after diffs, and rollback targets before applying
-  accepted changes.
+  parameter paths, task-chain health gates, before/after diffs for durable
+  promotion, and rollback targets before applying accepted durable changes.
 
 FUS-021: Declare expected setup/device state and reconcile it.
 
@@ -461,8 +483,12 @@ Automation requirements:
   ordinary reviewed proposals. Durable AI-created conclusions record model or
   tool provenance and privacy-scoped inputs where practical.
 - FREQ-024: Calibration proposals preserve source measurements, analysis
-  attempts, fitted values, affected parameter paths, before/after diffs, code
-  context, review outcome, and rollback target where practical.
+  attempts, fitted values, affected parameter paths, task health assessments,
+  before/after diffs for durable promotion, code context, review outcome, and
+  rollback target where practical.
+- FREQ-029: Bootstrap calibration chains preserve task order, dependencies,
+  chain-scoped working-ref revisions, health-gate decisions, retries,
+  pause/review reasons, and final promotion outcome.
 - FREQ-025: Automation previews classify intended effects at least as
   read-only inspection, derived artifact creation, data-library mutation,
   parameter/profile mutation, device/hardware mutation, or ADR-gated

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -44,6 +44,9 @@ Accepted.
 - Parameter Snapshot: immutable parameter facts captured by future parameter
   profile or managed-run workflows.
 - Parameter Profile: mutable named reference to a useful parameter state.
+- Calibration Working Ref: chain-scoped mutable parameter reference updated by
+  small calibration tasks so later tasks can consume the latest fitted values.
+  It is not a durable published profile such as `latest-good`.
 - Parameter Proposal: reviewed request to update a named parameter profile or
   related setup state from a source run, snapshot, analysis result, or
   calibration result. It carries source evidence and a before/after diff where
@@ -83,11 +86,27 @@ Accepted.
 - Measurement Outcome: lightweight interpretation or trust decision attached to
   a measurement, such as accepted, questionable, invalidated, or repeat-needed.
   It is not a full electronic lab notebook entry.
-- Calibration Record: later record of calibration validity, due/expired state,
-  as-found/as-left facts, affected-run windows, and review state.
+- Calibration: Fricon's accepted domain term for quantum-experiment parameter
+  calibration unless qualified otherwise. It means measurement plus analysis or
+  fit that estimates better sample, qubit, gate, pulse, readout, or analysis
+  parameters. It does not mean device desired-state apply/readback by default.
+- Calibration Record: later record of calibration evidence, task health,
+  fitted values, affected-run windows, and review state.
+- Calibration Task Run: one small calibration step with source measurements,
+  fitted values, diagnostics, health decision, and optional update to a
+  calibration working ref.
+- Calibration Chain Run: ordered bootstrap, daily, or targeted calibration
+  sequence composed of task runs, working-ref revisions, dependencies, retries,
+  pauses, and final promotion outcome.
 - Calibration Proposal: reviewed recommendation from calibration evidence that
-  may produce parameter or setup changes after approval. It is not a direct
-  edit to active configuration.
+  may publish selected chain results to a durable parameter profile/ref after
+  approval. It is not a direct edit to active configuration.
+- Calibration Promotion: publishing selected calibration working-ref results to
+  a durable named parameter profile/ref with source evidence, diff, actor, and
+  rollback target where practical.
+- Instrument Calibration: calibration of instruments, electronics, device
+  chain, timing, or setup infrastructure. Use this qualified term when the
+  workflow is about hardware/setup state rather than experiment parameters.
 - Desired Setup State: expected setup or device state derived from parameters,
   routine inputs, and code. It is intent, not proof that hardware changed.
 - Observed Device State: readback/status facts for a device or setup, including

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -88,6 +88,15 @@ Accepted.
 - Calibration Proposal: reviewed recommendation from calibration evidence that
   may produce parameter or setup changes after approval. It is not a direct
   edit to active configuration.
+- Desired Setup State: expected setup or device state derived from parameters,
+  routine inputs, and code. It is intent, not proof that hardware changed.
+- Observed Device State: readback/status facts for a device or setup, including
+  source and freshness where practical.
+- Reconciliation Plan: previewed diff from current or observed state to desired
+  state, including ordered actions, no-op writes, safe parallel groups,
+  settle/readback checks, and abort behavior.
+- Apply Execution: audit record for attempting a reconciliation plan, including
+  writes, skipped actions, readbacks, failures, and manual overrides.
 - Routine Recipe: reviewable description of a repeated compare, run, or analyze
   routine that can be previewed before replay.
 - Automation Proposal: previewable plan for a routine or AI-assisted action

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -19,6 +19,10 @@ Accepted.
   to a measurement.
 - Parameter Summary: optional light parameter context recorded for a
   measurement; not a full profile or effective-configuration model.
+- Run Config Snapshot: optional run-bound snapshot, reference, hash set, or
+  summary for selected local files and settings such as parameters, registries,
+  wiring references, line/chip info, demod settings, or external runner config.
+  It is not a global parameter profile or device inventory.
 - Code Provenance Summary: human-readable code context and provenance level.
 - Setup Summary: optional passive setup, device, driver, environment, clock, or
   method context; describes, does not control.

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -34,6 +34,8 @@ Accepted.
   action, or actor-labeled mutation.
 - Export Bundle: read-only portable package for analysis without importing into
   another data library.
+- Export Manifest: read-only package manifest for an export bundle. It records
+  package contents, source identity, format version, and integrity metadata.
 
 ## Later Or Advanced Terms
 
@@ -42,6 +44,12 @@ Accepted.
 - Parameter Snapshot: immutable parameter facts captured by future parameter
   profile or managed-run workflows.
 - Parameter Profile: mutable named reference to a useful parameter state.
+- Parameter Proposal: reviewed request to update a named parameter profile or
+  related setup state from a source run, snapshot, or analysis result.
+- Run Manifest: future read model that links available measurement facts such
+  as parameter snapshot, code/environment summary, setup/procedure context,
+  lifecycle/log events, artifacts, operator, timestamps, trust labels, and
+  provenance confidence. It is not the owner of those facts.
 - Target Key: user-defined parameter table row key or label that a visualization
   may use to locate a sample-map element. It is not durable sample identity by
   itself.
@@ -58,18 +66,26 @@ Accepted.
   such as Git/Gitea, package, mirror, or folder.
 - Code Snapshot: immutable resolved code state used by future managed
   execution.
-- Run Manifest: compact immutable summary linking one run to parameters,
-  code/environment context, lifecycle, logs, artifacts, actor, timestamps, and
-  diagnostics.
 - Analysis: later work that consumes artifacts and may produce results,
   reports, or derived datasets.
 - Analysis/Fit Attempt: recorded analysis execution or fit attempt with inputs,
   method/code reference, status, diagnostics, quality metrics, failure reason,
   and outputs when available.
-- Calibration: later workflow that turns measurements/analysis into parameter
-  proposals or approved updates.
+- Measurement Outcome: lightweight interpretation or trust decision attached to
+  a measurement, such as accepted, questionable, invalidated, or repeat-needed.
+  It is not a full electronic lab notebook entry.
+- Calibration Record: later record of calibration validity, due/expired state,
+  as-found/as-left facts, affected-run windows, and review state.
+- Calibration Proposal: reviewed recommendation that may produce parameter or
+  setup changes.
 - Routine Recipe: reviewable description of a repeated compare, run, or analyze
   routine that can be previewed before replay.
+- Automation Proposal: previewable plan for a routine or AI-assisted action
+  that may read, produce records, or mutate durable state after review.
+- Review Decision: approval or rejection record for an automation proposal,
+  parameter proposal, or calibration proposal.
+- Automation Execution: status record for a reviewed action, including produced
+  records and failure handling.
 
 ## Avoid As Primary MVP User Terms
 

--- a/docs-next/product/glossary.md
+++ b/docs-next/product/glossary.md
@@ -45,11 +45,14 @@ Accepted.
   profile or managed-run workflows.
 - Parameter Profile: mutable named reference to a useful parameter state.
 - Parameter Proposal: reviewed request to update a named parameter profile or
-  related setup state from a source run, snapshot, or analysis result.
+  related setup state from a source run, snapshot, analysis result, or
+  calibration result. It carries source evidence and a before/after diff where
+  practical.
 - Run Manifest: future read model that links available measurement facts such
   as parameter snapshot, code/environment summary, setup/procedure context,
-  lifecycle/log events, artifacts, operator, timestamps, trust labels, and
-  provenance confidence. It is not the owner of those facts.
+  lifecycle/log events, artifacts, operator, timestamps, calibration evidence,
+  review decisions, and provenance coverage. It is not the owner of those
+  facts.
 - Target Key: user-defined parameter table row key or label that a visualization
   may use to locate a sample-map element. It is not durable sample identity by
   itself.
@@ -63,9 +66,15 @@ Accepted.
 - Snapshot Query: later product concept for selecting values from a parameter
   snapshot to drive labels, color maps, comparisons, or visualizer state.
 - Measurement Code Source: configured upstream source for lab measurement code,
-  such as Git/Gitea, package, mirror, or folder.
+  such as Git/Gitea, package, mirror, or folder. Post-MVP, this should replace
+  copied working folders as the normal code provenance story for managed
+  measurement, analysis, and calibration work.
 - Code Snapshot: immutable resolved code state used by future managed
-  execution.
+  execution, analysis evidence, or calibration evidence.
+- Generated Sidecar: derived local file, config fragment, waveform, cache, or
+  helper artifact produced by code and later consumed by analysis,
+  calibration, or replay. It should record source inputs and generator context
+  when it affects future interpretation.
 - Analysis: later work that consumes artifacts and may produce results,
   reports, or derived datasets.
 - Analysis/Fit Attempt: recorded analysis execution or fit attempt with inputs,
@@ -76,8 +85,9 @@ Accepted.
   It is not a full electronic lab notebook entry.
 - Calibration Record: later record of calibration validity, due/expired state,
   as-found/as-left facts, affected-run windows, and review state.
-- Calibration Proposal: reviewed recommendation that may produce parameter or
-  setup changes.
+- Calibration Proposal: reviewed recommendation from calibration evidence that
+  may produce parameter or setup changes after approval. It is not a direct
+  edit to active configuration.
 - Routine Recipe: reviewable description of a repeated compare, run, or analyze
   routine that can be previewed before replay.
 - Automation Proposal: previewable plan for a routine or AI-assisted action

--- a/docs-next/product/python-sdk-ux.md
+++ b/docs-next/product/python-sdk-ux.md
@@ -26,13 +26,14 @@ concepts:
 - a visible notebook context for the current local library and lab context
 - an interactive unmanaged path for exploratory runs
 - an importable decorated managed-run path for higher provenance
+- a lightweight way to bind selected local configuration context to a run
 - Python-native scan-plan authoring for routine scans
 - public reopen/export APIs for later analysis
 
 The main ergonomic constraint is low ceremony. Fricon should ask for structure
 only where it changes user understanding: which context is active, whether a
-run is unmanaged or managed, what scan shape should be plotted, and how results
-are reopened later.
+run is unmanaged or managed, which selected local configuration helps explain
+the run, what scan shape should be plotted, and how results are reopened later.
 
 For common workflows, Fricon should provide appropriate simplification without
 pretending the right simplification is known before use. The exact API shape
@@ -74,6 +75,8 @@ ceremony should be justified by one of these user-visible benefits:
 - creating a real measurement rather than a loose file or anonymous table
 - declaring scan shape so live and historical plots know what the axes mean
 - choosing unmanaged versus managed execution honestly
+- binding selected local configuration context when copied files or sidecars
+  explain the run
 - reopening or exporting results through stable public APIs
 
 Boilerplate that exists only for transport, storage layout, service startup,
@@ -142,7 +145,8 @@ Do not settle these in this guideline:
 
 - exact Python names, decorator syntax, context-manager syntax, or function
   signatures
-- parameter binding, parameter capture, override, or snapshot mechanics
+- parameter binding, parameter capture, override, run configuration, or snapshot
+  mechanics
 - code snapshot format, environment capture details, stdout/stderr handling, or
   managed-run lifecycle protocol
 - dataset-writer object model, storage layout, service transport, or local

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -111,13 +111,9 @@ Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;
 detailed API signatures and capture mechanics belong in later ADRs/specs.
 
-Post-MVP work should turn the MVP facts into local experiment memory: compare
-against previous-good runs, hand off state to another operator, start a
-run-like-previous draft with visible differences, promote parameter proposals
-after review, capture managed-run provenance, record analysis/calibration
-evidence, run calibration chains with working refs and health gates, promote
-selected calibration results to durable parameter refs, and replay routines
-only through preview and audit. These remain outside the MVP story index.
+Post-MVP work should turn the MVP facts into local experiment memory and
+reviewed action. Those priorities are outside the MVP story index and are owned
+by `product/future-concepts.md`.
 
 SPEC-002 owns the export/offline-analysis details. Export remains an MVP
 product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -115,9 +115,9 @@ Post-MVP work should turn the MVP facts into local experiment memory: compare
 against previous-good runs, hand off state to another operator, start a
 run-like-previous draft with visible differences, promote parameter proposals
 after review, capture managed-run provenance, record analysis/calibration
-evidence, stage calibration-derived parameter changes before applying them, and
-replay routines only through preview and audit. These remain outside the MVP
-story index.
+evidence, run calibration chains with working refs and health gates, promote
+selected calibration results to durable parameter refs, and replay routines
+only through preview and audit. These remain outside the MVP story index.
 
 SPEC-002 owns the export/offline-analysis details. Export remains an MVP
 product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -71,6 +71,7 @@ Context and provenance:
 - US-012: Register a sample and sample session when useful.
 - US-014: Record passive setup context.
 - US-016: Record passive procedure context.
+- US-019: Capture run-bound local configuration.
 
 Recovery and analysis:
 
@@ -100,9 +101,11 @@ M1 should prove enough of US-001 through US-008 and US-015 to record, inspect,
 recover, and reopen a Python measurement while preserving first-class dataset
 discovery.
 
-The full MVP also needs US-009 for export and US-017/US-018 to validate the
-incremental adoption posture: users can translate new Data Vault-style scripts
-and keep old history in the old system.
+The full MVP also needs US-009 for export, US-017/US-018 to validate the
+incremental adoption posture, and US-019 to make copied local configuration
+visible: users can translate new Data Vault-style scripts, keep old history in
+the old system, and bind the run-relevant files or summaries that old scripts
+currently leave in folders and operator memory.
 
 Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -115,8 +115,9 @@ Post-MVP work should turn the MVP facts into local experiment memory: compare
 against previous-good runs, hand off state to another operator, start a
 run-like-previous draft with visible differences, promote parameter proposals
 after review, capture managed-run provenance, record analysis/calibration
-evidence, and replay routines only through preview and audit. These remain
-outside the MVP story index.
+evidence, stage calibration-derived parameter changes before applying them, and
+replay routines only through preview and audit. These remain outside the MVP
+story index.
 
 SPEC-002 owns the export/offline-analysis details. Export remains an MVP
 product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/story-map.md
+++ b/docs-next/product/story-map.md
@@ -111,5 +111,12 @@ Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;
 detailed API signatures and capture mechanics belong in later ADRs/specs.
 
+Post-MVP work should turn the MVP facts into local experiment memory: compare
+against previous-good runs, hand off state to another operator, start a
+run-like-previous draft with visible differences, promote parameter proposals
+after review, capture managed-run provenance, record analysis/calibration
+evidence, and replay routines only through preview and audit. These remain
+outside the MVP story index.
+
 SPEC-002 owns the export/offline-analysis details. Export remains an MVP
 product promise; it is split out only to keep SPEC-001 focused.

--- a/docs-next/product/user-stories/US-009-export-measurement.md
+++ b/docs-next/product/user-stories/US-009-export-measurement.md
@@ -20,6 +20,8 @@ importing the data first.
 - Produced datasets and semantic metadata are included.
 - Common analysis files are included where practical, but the Fricon manifest
   remains the source of meaning.
+- Selected code, setup, procedure, and run-bound configuration summaries can be
+  included so the bundle explains the measurement without old local folders.
 - Sensitive provenance is previewed or opt-in.
 - Python can open the bundle directly.
 

--- a/docs-next/product/user-stories/US-011-record-code-provenance.md
+++ b/docs-next/product/user-stories/US-011-record-code-provenance.md
@@ -20,6 +20,8 @@ trustworthiness without pretending Fricon managed execution.
   execution.
 - Optional script path, Git revision, dirty-state signal, and user summary can
   be recorded where available.
+- Copied-folder workflows can record a source-root path, folder fingerprint, or
+  user-supplied source label without implying managed code history.
 - Provenance can be previewed or omitted during export when it contains
   sensitive local details.
 - Corrections to provenance are visible as events.

--- a/docs-next/product/user-stories/US-014-record-passive-setup-context.md
+++ b/docs-next/product/user-stories/US-014-record-passive-setup-context.md
@@ -20,6 +20,11 @@ practical context without requiring Fricon to control instruments.
   environment labels and summaries.
 - Context may be user-supplied, imported from an external reference, or
   corrected after the run.
+- Structured passive context can include runner labels, device-map labels,
+  wiring/config references, software environment notes, machine labels, and
+  selected network or address summaries when the user chooses to record them.
+- Setup context can link to a run-bound local configuration summary without
+  making that summary a managed hardware inventory.
 - Export previews sensitive local paths, machine names, or environment details.
 - Passive setup context is clearly separate from device control.
 

--- a/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
+++ b/docs-next/product/user-stories/US-016-record-passive-procedure-context.md
@@ -20,6 +20,9 @@ even before Fricon manages execution.
   reference, or declared plan summary.
 - Procedure context can mention planned shape and external identifiers without
   becoming a managed plan.
+- Procedure context can record runner name/version, external run identifier,
+  readout timing summary, demod settings summary, validity-mask semantics, or
+  shot-group meaning when supplied by the user or integration.
 - Corrections to procedure context are visible after the run.
 - Procedure context remains distinct from code provenance and setup context.
 

--- a/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs-next/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -20,8 +20,15 @@ logger for new measurements without rewriting the whole experiment stack.
   server.
 - Independent/dependent variable declarations map naturally to Fricon scan
   schema helpers or raw schema.
+- Common writer calls shaped like Data Vault `prepDataset`, `Dataset.add`, or
+  independent/dependent variable setup can be translated without rewriting the
+  whole hardware runner.
 - Labels, units, legends, source aliases, original paths, and old numbered
   titles can be recorded without becoming primary identity.
+- Original Data Vault folder, session, title, numeric ID, and file path can be
+  retained as legacy aliases while stable Fricon IDs remain the reopen path.
+- Run-bound configuration summaries can carry old parameter/registry file
+  references that the old script relied on.
 - The writer model does not block later user-written import scripts, but old
   data import is not part of the migration path for starting new work.
 - The MVP does not ship a built-in Data Vault parser or legacy browser.

--- a/docs-next/product/user-stories/US-019-capture-run-bound-local-configuration.md
+++ b/docs-next/product/user-stories/US-019-capture-run-bound-local-configuration.md
@@ -1,0 +1,39 @@
+# US-019: Capture Run-Bound Local Configuration
+
+## Status
+
+Accepted.
+
+## Primary Epic
+
+EPIC-005: Migration ergonomics and future lab scaling.
+
+## Story
+
+As an experimentalist, I want to bind selected local configuration files,
+references, hashes, or summaries to a measurement so that later analysis can
+explain which lab-local state was active without reading copied folders by hand.
+
+## Success Criteria
+
+- A measurement can attach a run-bound configuration summary at creation time
+  or during the run.
+- The summary can reference or snapshot selected files such as
+  `parameters.json`, `registry.json`, wiring sheets, line/chip info, demod
+  settings, readout settings, or external runner configuration.
+- Fricon records enough source identity to distinguish a copied file reference,
+  a copied file snapshot, a content hash, and a user-entered summary.
+- Corrections to configuration context are visible as events.
+- Export previews sensitive local paths, machine names, IP addresses, and other
+  local setup details before including them.
+
+## Not In Scope
+
+- Automatic tracing of every file a script reads.
+- Global parameter profiles, proposal workflows, or calibration promotion.
+- Device control, hardware inventory, or claiming unmanaged execution is fully
+  reproducible.
+
+## Related Capabilities / Specs
+
+CAP-015, CAP-027, CAP-029, CAP-033, SPEC-001, SPEC-002.

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -56,6 +56,13 @@ scripts and notebooks remain first-class, local lab computers remain useful
 without a server account model, and higher-provenance workflows grow from the
 same core experience instead of becoming a separate system.
 
+Staying close to current practice does not mean freezing current practice as
+the ideal model. Post-MVP Fricon should explore declarative, desired-state
+workflows for routines that are currently written as imperative nested loops:
+derive expected setup or device state from parameters, diff it against
+observed state, preview the writes, apply only reviewed and safe changes, and
+record readbacks and failures.
+
 ## MVP Goal
 
 The MVP goal is practical: replace the simple LabRAD Data Vault/Grapher loop
@@ -89,6 +96,8 @@ After the MVP, Fricon should also help answer:
 - Which code source and parameter snapshot did this calibration depend on?
 - Is this calibration result evidence, a reviewed proposal, or an applied
   parameter change?
+- For a managed routine, what setup or device state was desired, what was
+  already current, what did Fricon plan to change, and what actually happened?
 - What did we conclude from this measurement?
 - Can I repeat this work safely, and what will change if I do?
 
@@ -187,7 +196,10 @@ Implementation should follow this order:
   reviews, audits, and applies changes only through explicit safety
   boundaries. Calibration automation should first produce reviewed proposals
   backed by code, parameter, and analysis evidence; direct device or parameter
-  mutation remains a later safety-gated step.
+  mutation remains a later safety-gated step. Desired-state reconciliation for
+  setup/device changes belongs here: useful for reducing imperative loop
+  boilerplate, but only after dependencies, readback, settling, timeout, and
+  abort behavior are explicit.
 
 Sample visualization should stay lightweight until product evidence says
 otherwise. Treat a sample visualizer as a view over parameter snapshots and

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -22,7 +22,10 @@ Physical measurement work is hard to make reliable when data, parameters,
 measurement code, setup state, notes, and later analysis live in separate tools
 or informal files. Existing frameworks can help users collect data, but they
 often leave the broader experiment record to conventions that are difficult to
-inspect, compare, migrate, or automate.
+inspect, compare, migrate, or automate. Fricon should replace not only the
+write-to-logger step, but also the informal folder discipline around copied
+measurement code, mutable local JSON configuration, setup sidecars, and later
+analysis handoff.
 
 Fricon should give experimenters one local-first product model for defining,
 running, inspecting, explaining, and reusing measurement work. The long-term
@@ -42,9 +45,10 @@ for new measurements.
 
 Success means a user can start new measurement work in Fricon, write data from
 Python, watch it live, recover partial results, reopen it later, and export it
-without depending on old storage paths. The MVP does not need to import old
-history or emulate LabRAD; old LabRAD, QCoDeS, Labber, or folder-based history
-can remain where it is while new work moves to Fricon.
+without depending on old storage paths or notebook-only reconstruction. The MVP
+does not need to import old history or emulate LabRAD; old LabRAD, QCoDeS,
+Labber, or folder-based history can remain where it is while new work moves to
+Fricon.
 
 ## User Promise
 
@@ -55,6 +59,7 @@ Fricon should help a researcher answer:
 - What datasets and attachments did it produce?
 - Was the run finished, interrupted, failed, invalidated, or recovered?
 - What notes, parameters, code provenance, and setup labels explain it?
+- Which selected local configuration files or summaries were bound to it?
 - How do I inspect it live, reopen it from Python, export it, or recover it?
 
 ## Primary Mental Model
@@ -106,6 +111,9 @@ To meet the MVP goal, the MVP should include:
 - light attachments
 - light contextual summaries for parameters, code provenance, setup,
   environment, and unmanaged procedure context
+- selected run-bound local configuration snapshots or summaries, such as
+  parameter files, registry files, wiring references, line/chip info, or
+  demod/readout settings, without turning MVP into a full parameter registry
 - Python reopen snippets through public APIs
 - a near-term measurement export spec for portable bundles and common analysis
   formats

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -198,14 +198,15 @@ Implementation should follow this order:
   and generated run history. This is the code-management counterpart to
   parameter snapshots: it should replace copied-code folders with visible code
   source context before it becomes a scheduler or mandatory execution model.
-- Priority 3: reviewable routine replay and automation workflow that previews,
-  reviews, audits, and applies changes only through explicit safety
-  boundaries. Calibration automation should first support task-chain evidence,
-  health checks, retries, pause points, chain-scoped working parameter refs,
-  and reviewed promotion of final or durable parameter changes. Desired-state
-  reconciliation for setup/device changes is a separate later capability:
-  useful for reducing imperative loop boilerplate, but only after dependencies,
-  readback, settling, timeout, and abort behavior are explicit.
+- Priority 3: calibration chains, reviewable routine replay, and automation
+  workflow that previews, reviews, audits, and applies changes only through
+  explicit safety boundaries. Calibration automation should first support
+  task-chain evidence, health checks, retries, pause points, chain-scoped
+  working parameter refs, and reviewed promotion of final or durable parameter
+  changes. Desired-state reconciliation for setup/device changes is a separate
+  later capability: useful for reducing imperative loop boilerplate, but only
+  after dependencies, readback, settling, timeout, and abort behavior are
+  explicit.
 
 Sample visualization should stay lightweight until product evidence says
 otherwise. Treat a sample visualizer as a view over parameter snapshots and

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -46,6 +46,12 @@ Fricon should first make code provenance, effective parameter state, diffs,
 reviewed parameter changes, and calibration evidence durable enough that
 experimenters can understand why a result should be trusted.
 
+Calibration should remain the primary domain term because quantum
+experimenters use it for this workflow. In Fricon, unqualified calibration
+means estimating better sample, qubit, gate, pulse, readout, fit, or analysis
+parameters from measurement evidence. Instrument calibration and setup/device
+desired-state reconciliation are qualified, separate meanings.
+
 The product should exceed legacy loggers by helping users explain, compare, and
 repeat scientific work from recorded facts. The long-term center is not device
 control, sample visualization, or AI by itself; those capabilities matter when
@@ -94,8 +100,8 @@ After the MVP, Fricon should also help answer:
 - Which parameter, setup, code, analysis, or calibration facts explain the
   difference?
 - Which code source and parameter snapshot did this calibration depend on?
-- Is this calibration result evidence, a reviewed proposal, or an applied
-  parameter change?
+- Did each calibration task look healthy, need retry, pause for review, or
+  produce fitted parameters that should update a parameter snapshot/profile?
 - For a managed routine, what setup or device state was desired, what was
   already current, what did Fricon plan to change, and what actually happened?
 - What did we conclude from this measurement?
@@ -194,12 +200,12 @@ Implementation should follow this order:
   source context before it becomes a scheduler or mandatory execution model.
 - Priority 3: reviewable routine replay and automation workflow that previews,
   reviews, audits, and applies changes only through explicit safety
-  boundaries. Calibration automation should first produce reviewed proposals
-  backed by code, parameter, and analysis evidence; direct device or parameter
-  mutation remains a later safety-gated step. Desired-state reconciliation for
-  setup/device changes belongs here: useful for reducing imperative loop
-  boilerplate, but only after dependencies, readback, settling, timeout, and
-  abort behavior are explicit.
+  boundaries. Calibration automation should first support task-chain evidence,
+  health checks, retries, pause points, chain-scoped working parameter refs,
+  and reviewed promotion of final or durable parameter changes. Desired-state
+  reconciliation for setup/device changes is a separate later capability:
+  useful for reducing imperative loop boilerplate, but only after dependencies,
+  readback, settling, timeout, and abort behavior are explicit.
 
 Sample visualization should stay lightweight until product evidence says
 otherwise. Treat a sample visualizer as a view over parameter snapshots and
@@ -211,10 +217,11 @@ visualizer migration policy are later design questions.
 Lower-priority or ADR-gated directions include read-only LAN monitoring, richer
 sample-map authoring, device communication, resumable execution, user-facing
 stream concepts, and AI-assisted automation. Detailed confidence-label
-taxonomies may be useful later, but they should not block the core design:
-durable code and parameter state, analysis evidence, reviewed calibration
-proposals, and auditable application of accepted changes. Mutation-capable
-calibration or device apply remains ADR-gated.
+taxonomies may be useful later, but they should not block the core design.
+Calibration task health/confidence gates are narrower and more important than
+a broad label taxonomy: they help decide whether a bootstrap calibration should
+continue, retry, pause, or ask for review. Mutation-capable calibration or
+device apply remains ADR-gated.
 
 ## Non-Goals For MVP
 

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -39,6 +39,13 @@ aim is not only to store results, but to make the relationship between a
 measurement, its datasets, its Python code, its context, and its later
 interpretation explicit enough for humans and future automation to trust.
 
+The highest-value post-MVP problem is the code-and-parameter management loop.
+When measurement code is copied by hand and active parameters are mutable local
+files, calibration becomes difficult to trust and harder to automate safely.
+Fricon should first make code provenance, effective parameter state, diffs,
+reviewed parameter changes, and calibration evidence durable enough that
+experimenters can understand why a result should be trusted.
+
 The product should exceed legacy loggers by helping users explain, compare, and
 repeat scientific work from recorded facts. The long-term center is not device
 control, sample visualization, or AI by itself; those capabilities matter when
@@ -79,6 +86,9 @@ After the MVP, Fricon should also help answer:
 - Why did this run succeed, fail, or become questionable?
 - Which parameter, setup, code, analysis, or calibration facts explain the
   difference?
+- Which code source and parameter snapshot did this calibration depend on?
+- Is this calibration result evidence, a reviewed proposal, or an applied
+  parameter change?
 - What did we conclude from this measurement?
 - Can I repeat this work safely, and what will change if I do?
 
@@ -166,14 +176,18 @@ Implementation should follow this order:
 - Priority 1: parameter system for profiles, immutable run-bound snapshots,
   diffs, proposal review, and user-defined table row keys that can later
   support visualization lookup. This enables read-only compare and handoff
-  before mutation-capable automation.
+  before mutation-capable automation, and it directly addresses the mutable
+  config-file problem that makes calibration hard to trust.
 - Priority 2: managed run for importable SDK runner entry points, code/source
   capture, lifecycle capture, compact run manifests, failure investigation,
-  and generated run history. Managed run raises provenance confidence, but it
-  should not become a scheduler or mandatory execution model first.
+  and generated run history. This is the code-management counterpart to
+  parameter snapshots: it should replace copied-code folders with visible code
+  source context before it becomes a scheduler or mandatory execution model.
 - Priority 3: reviewable routine replay and automation workflow that previews,
   reviews, audits, and applies changes only through explicit safety
-  boundaries.
+  boundaries. Calibration automation should first produce reviewed proposals
+  backed by code, parameter, and analysis evidence; direct device or parameter
+  mutation remains a later safety-gated step.
 
 Sample visualization should stay lightweight until product evidence says
 otherwise. Treat a sample visualizer as a view over parameter snapshots and
@@ -184,9 +198,11 @@ visualizer migration policy are later design questions.
 
 Lower-priority or ADR-gated directions include read-only LAN monitoring, richer
 sample-map authoring, device communication, resumable execution, user-facing
-stream concepts, and AI-assisted automation. Analysis and calibration records
-belong on the path to explain/compare/repeat, but mutation-capable calibration
-or device apply remains ADR-gated.
+stream concepts, and AI-assisted automation. Detailed confidence-label
+taxonomies may be useful later, but they should not block the core design:
+durable code and parameter state, analysis evidence, reviewed calibration
+proposals, and auditable application of accepted changes. Mutation-capable
+calibration or device apply remains ADR-gated.
 
 ## Non-Goals For MVP
 

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -9,6 +9,12 @@ Accepted clean-reset product baseline.
 Fricon is a local lab data library and automation foundation for scientific
 measurement work.
 
+The near-term product proves a better local measurement write, watch, recover,
+reopen, and export loop. The long-term product should become the lab's local
+experiment memory and reviewed action layer: a system of record for measurement
+intent, effective parameters, code provenance, setup state, analysis attempts,
+trust decisions, handoff, and reviewed replay.
+
 ## Planning Language
 
 This document uses MVP, post-MVP, and ADR-gated as product priority labels.
@@ -32,6 +38,11 @@ running, inspecting, explaining, and reusing measurement work. The long-term
 aim is not only to store results, but to make the relationship between a
 measurement, its datasets, its Python code, its context, and its later
 interpretation explicit enough for humans and future automation to trust.
+
+The product should exceed legacy loggers by helping users explain, compare, and
+repeat scientific work from recorded facts. The long-term center is not device
+control, sample visualization, or AI by itself; those capabilities matter when
+they serve trustworthy experiment memory, reviewable changes, and safer reuse.
 
 The product should stay close to how experimentalists already work: Python
 scripts and notebooks remain first-class, local lab computers remain useful
@@ -62,6 +73,15 @@ Fricon should help a researcher answer:
 - Which selected local configuration files or summaries were bound to it?
 - How do I inspect it live, reopen it from Python, export it, or recover it?
 
+After the MVP, Fricon should also help answer:
+
+- What changed since the previous good run?
+- Why did this run succeed, fail, or become questionable?
+- Which parameter, setup, code, analysis, or calibration facts explain the
+  difference?
+- What did we conclude from this measurement?
+- Can I repeat this work safely, and what will change if I do?
+
 ## Primary Mental Model
 
 ```text
@@ -69,6 +89,15 @@ I selected an active sample/session when it mattered.
 I ran a measurement from Python.
 It produced datasets.
 Fricon helps me inspect, annotate, recover, reopen, and export them.
+```
+
+Post-MVP, the product should extend that model:
+
+```text
+I can choose a previous-good run or routine.
+Fricon shows the effective parameters, code, setup, and expected artifacts.
+I review what will change before anything durable is mutated.
+Afterward, Fricon records the outcome, evidence, and handoff state.
 ```
 
 ## Python SDK Experience
@@ -123,14 +152,25 @@ To meet the MVP goal, the MVP should include:
 ## Post-MVP Direction
 
 These priorities matter most after the MVP because they change the experiment
-experience most directly:
+experience most directly. They should be understood as product loops first:
+
+- Explain: run manifests, parameter/code/setup provenance, lifecycle evidence,
+  analysis attempts, and failure or anomaly investigation.
+- Compare: previous-good baselines, drift detection, operator handoff,
+  analysis/calibration status, and visible differences before repeat work.
+- Repeat: run-like-previous drafts, reviewed parameter proposals, routine
+  recipes, and audited automation after the facts are trustworthy.
+
+Implementation should follow this order:
 
 - Priority 1: parameter system for profiles, immutable run-bound snapshots,
   diffs, proposal review, and user-defined table row keys that can later
-  support visualization lookup.
+  support visualization lookup. This enables read-only compare and handoff
+  before mutation-capable automation.
 - Priority 2: managed run for importable SDK runner entry points, code/source
   capture, lifecycle capture, compact run manifests, failure investigation,
-  and generated run history.
+  and generated run history. Managed run raises provenance confidence, but it
+  should not become a scheduler or mandatory execution model first.
 - Priority 3: reviewable routine replay and automation workflow that previews,
   reviews, audits, and applies changes only through explicit safety
   boundaries.
@@ -143,8 +183,10 @@ records for discoverability, but schema evolution, invalid visualizers, and
 visualizer migration policy are later design questions.
 
 Lower-priority or ADR-gated directions include read-only LAN monitoring, richer
-sample-map authoring, analysis/calibration records, device communication,
-resumable execution, user-facing stream concepts, and AI-assisted automation.
+sample-map authoring, device communication, resumable execution, user-facing
+stream concepts, and AI-assisted automation. Analysis and calibration records
+belong on the path to explain/compare/repeat, but mutation-capable calibration
+or device apply remains ADR-gated.
 
 ## Non-Goals For MVP
 

--- a/docs-next/product/vision.md
+++ b/docs-next/product/vision.md
@@ -39,23 +39,17 @@ aim is not only to store results, but to make the relationship between a
 measurement, its datasets, its Python code, its context, and its later
 interpretation explicit enough for humans and future automation to trust.
 
-The highest-value post-MVP problem is the code-and-parameter management loop.
-When measurement code is copied by hand and active parameters are mutable local
-files, calibration becomes difficult to trust and harder to automate safely.
-Fricon should first make code provenance, effective parameter state, diffs,
-reviewed parameter changes, and calibration evidence durable enough that
-experimenters can understand why a result should be trusted.
+The highest-value post-MVP lesson from legacy workflows is the code-and-parameter
+management loop: copied code, mutable local configuration, generated sidecars,
+and notebook-local analysis make calibration hard to trust. Fricon should first
+make the recorded facts durable enough to explain, compare, hand off, repeat,
+and then safely automate work.
 
-Calibration should remain the primary domain term because quantum
-experimenters use it for this workflow. In Fricon, unqualified calibration
-means estimating better sample, qubit, gate, pulse, readout, fit, or analysis
-parameters from measurement evidence. Instrument calibration and setup/device
-desired-state reconciliation are qualified, separate meanings.
-
-The product should exceed legacy loggers by helping users explain, compare, and
-repeat scientific work from recorded facts. The long-term center is not device
-control, sample visualization, or AI by itself; those capabilities matter when
-they serve trustworthy experiment memory, reviewable changes, and safer reuse.
+The long-term center is not device control, sample visualization, or AI by
+itself. Those capabilities matter when they serve trustworthy experiment
+memory, reviewable changes, and safer reuse. Detailed post-MVP ordering lives
+in `product/future-concepts.md`; future terminology is owned by
+`product/glossary.md` and the domain model.
 
 The product should stay close to how experimentalists already work: Python
 scripts and notebooks remain first-class, local lab computers remain useful
@@ -63,11 +57,8 @@ without a server account model, and higher-provenance workflows grow from the
 same core experience instead of becoming a separate system.
 
 Staying close to current practice does not mean freezing current practice as
-the ideal model. Post-MVP Fricon should explore declarative, desired-state
-workflows for routines that are currently written as imperative nested loops:
-derive expected setup or device state from parameters, diff it against
-observed state, preview the writes, apply only reviewed and safe changes, and
-record readbacks and failures.
+the ideal model. Post-MVP Fricon can introduce higher-provenance workflows, but
+only after the relevant facts, review boundaries, and safety model are explicit.
 
 ## MVP Goal
 
@@ -176,8 +167,8 @@ To meet the MVP goal, the MVP should include:
 
 ## Post-MVP Direction
 
-These priorities matter most after the MVP because they change the experiment
-experience most directly. They should be understood as product loops first:
+At the vision level, post-MVP work should extend the MVP facts into three user
+loops:
 
 - Explain: run manifests, parameter/code/setup provenance, lifecycle evidence,
   analysis attempts, and failure or anomaly investigation.
@@ -186,27 +177,11 @@ experience most directly. They should be understood as product loops first:
 - Repeat: run-like-previous drafts, reviewed parameter proposals, routine
   recipes, and audited automation after the facts are trustworthy.
 
-Implementation should follow this order:
+Implementation should follow the accepted priority ledger:
 
-- Priority 1: parameter system for profiles, immutable run-bound snapshots,
-  diffs, proposal review, and user-defined table row keys that can later
-  support visualization lookup. This enables read-only compare and handoff
-  before mutation-capable automation, and it directly addresses the mutable
-  config-file problem that makes calibration hard to trust.
-- Priority 2: managed run for importable SDK runner entry points, code/source
-  capture, lifecycle capture, compact run manifests, failure investigation,
-  and generated run history. This is the code-management counterpart to
-  parameter snapshots: it should replace copied-code folders with visible code
-  source context before it becomes a scheduler or mandatory execution model.
-- Priority 3: calibration chains, reviewable routine replay, and automation
-  workflow that previews, reviews, audits, and applies changes only through
-  explicit safety boundaries. Calibration automation should first support
-  task-chain evidence, health checks, retries, pause points, chain-scoped
-  working parameter refs, and reviewed promotion of final or durable parameter
-  changes. Desired-state reconciliation for setup/device changes is a separate
-  later capability: useful for reducing imperative loop boilerplate, but only
-  after dependencies, readback, settling, timeout, and abort behavior are
-  explicit.
+- parameter system first
+- managed run second
+- calibration chains and reviewable automation third
 
 Sample visualization should stay lightweight until product evidence says
 otherwise. Treat a sample visualizer as a view over parameter snapshots and
@@ -217,11 +192,7 @@ visualizer migration policy are later design questions.
 
 Lower-priority or ADR-gated directions include read-only LAN monitoring, richer
 sample-map authoring, device communication, resumable execution, user-facing
-stream concepts, and AI-assisted automation. Detailed confidence-label
-taxonomies may be useful later, but they should not block the core design.
-Calibration task health/confidence gates are narrower and more important than
-a broad label taxonomy: they help decide whether a bootstrap calibration should
-continue, retry, pause, or ask for review. Mutation-capable calibration or
+stream concepts, and AI-assisted automation. Mutation-capable calibration or
 device apply remains ADR-gated.
 
 ## Non-Goals For MVP

--- a/docs-next/research/README.md
+++ b/docs-next/research/README.md
@@ -36,3 +36,5 @@ Covered:
 
 Accepted synthesis lives in `lessons-for-fricon.md`. The broader source list
 and post-MVP planning synthesis live in `post-mvp-future-systems.md`.
+Concrete migration pressure from local legacy measurement sample work
+directories lives in `legacy-measurement-sample-lessons.md`.

--- a/docs-next/research/legacy-measurement-sample-lessons.md
+++ b/docs-next/research/legacy-measurement-sample-lessons.md
@@ -81,10 +81,11 @@ The samples also point beyond the MVP replacement loop:
   review, with before/after diffs and rollback targets where practical.
 - Analysis and calibration records should provide evidence for trust decisions
   and proposed parameter changes before they become automation inputs.
-- Calibration automation should stage proposals instead of directly rewriting
-  active parameter refs or generated config files.
+- Calibration automation should use chain-scoped working refs or staged
+  proposals instead of directly rewriting durable named parameter refs or
+  generated config files.
 - Automation should grow from trustworthy manifests, snapshots, diffs, and
   review records, not from a generic workflow engine.
-- Detailed confidence-label taxonomies can wait. The urgent need is durable
-  source facts, visible diffs, reviewed application, and an audit trail that
-  lets an experimenter trust the next run.
+- Broad confidence-label taxonomies can wait. The urgent need is durable
+  source facts, calibration task health gates, visible diffs, reviewed
+  promotion, and an audit trail that lets an experimenter trust the next run.

--- a/docs-next/research/legacy-measurement-sample-lessons.md
+++ b/docs-next/research/legacy-measurement-sample-lessons.md
@@ -1,0 +1,60 @@
+# Legacy Measurement Sample Lessons
+
+## Status
+
+Draft research synthesis.
+
+## Review Date
+
+2026-05-07.
+
+## Sources
+
+Two local legacy measurement sample work directories supplied by the user were
+reviewed. Exact paths, local project names, and lab-specific identifiers are
+intentionally omitted from this note.
+
+These are concrete lab snapshots, not official framework references. Treat them
+as product pressure from real migration-shaped code.
+
+## Observations
+
+The samples show a working but fragile legacy LabRAD-era pattern:
+
+- Measurement identity is spread across Data Vault paths, numeric IDs,
+  notebooks, sidecar files, and copied parameter files.
+- Hardware/runtime setup is machine-local: LabRAD services, vendor or lab-local
+  driver paths, Windows drive paths, static IPs, local registries, and operator
+  memory.
+- Code versioning is mostly folder copying: backups, old notebooks, nested
+  package snapshots, dated JSON, generated caches, and partially used Git.
+- Parameters and setup are mutable files such as `parameters.json`,
+  `registry.json`, wiring spreadsheets, line/chip info, spectrum CSVs, and
+  demod/readout settings.
+- Plotting and analysis reconstruct scan meaning after the fact from column
+  order, filename conventions, sidecars, and notebook-local arrays.
+- Partial or interrupted acquisition is treated as a cleanup/debugging problem,
+  not as a first-class readable lifecycle state.
+
+## Lessons For Fricon
+
+The replacement target is not only LabRAD Data Vault writes. The target is the
+informal folder discipline around new measurements.
+
+Fricon should make the following facts first-class for new work:
+
+- `Measurement` identity independent of old paths and numbered titles.
+- One or more `DatasetArtifact`s per measurement.
+- Explicit scan and trace schema at write time.
+- Lifecycle state that makes partial/interrupted data readable.
+- Stable Fricon IDs and Python reopen snippets.
+- Legacy paths, folders, titles, and numeric IDs as aliases, not identity.
+- Honest unmanaged code provenance.
+- Passive setup and procedure summaries.
+- Run-bound local configuration snapshots or summaries for selected parameter,
+  registry, wiring, line/chip, demod/readout, and runner configuration.
+- Measurement-centered export that carries semantic context, not just bytes.
+
+The MVP should still avoid LabRAD emulation, old-history import, broad device
+control, a full parameter registry, and automatic tracing of every file an
+unmanaged script reads.

--- a/docs-next/research/legacy-measurement-sample-lessons.md
+++ b/docs-next/research/legacy-measurement-sample-lessons.md
@@ -33,6 +33,10 @@ The samples show a working but fragile legacy LabRAD-era pattern:
   demod/readout settings.
 - Plotting and analysis reconstruct scan meaning after the fact from column
   order, filename conventions, sidecars, and notebook-local arrays.
+- Calibration code already contains ad hoc attempts to compare, fit, update, or
+  regenerate settings. The problem is that those outputs are mixed with copied
+  code folders, mutable parameter files, generated sidecars, and operator
+  judgment rather than becoming a reviewed calibration-to-parameter workflow.
 - Partial or interrupted acquisition is treated as a cleanup/debugging problem,
   not as a first-class readable lifecycle state.
 
@@ -66,12 +70,21 @@ The samples also point beyond the MVP replacement loop:
 - Legacy folders are not just storage debt; they are missing experiment memory.
 - Repetition currently depends on copied code, mutable config, and operator
   recall.
+- The most valuable post-MVP improvement is to make code provenance,
+  effective parameter snapshots, generated sidecars, calibration evidence, and
+  accepted parameter changes inspectable together.
 - Fricon's post-MVP advantage should be reviewed reuse of recorded facts, not
   emulation of legacy paths.
 - Read-only compare, handoff, run-like-previous drafts, and failure
   investigation should arrive before mutation-capable automation.
-- Parameter proposals should promote effective settings only after review.
+- Parameter proposals should promote effective or fitted settings only after
+  review, with before/after diffs and rollback targets where practical.
 - Analysis and calibration records should provide evidence for trust decisions
-  before they become automation inputs.
+  and proposed parameter changes before they become automation inputs.
+- Calibration automation should stage proposals instead of directly rewriting
+  active parameter refs or generated config files.
 - Automation should grow from trustworthy manifests, snapshots, diffs, and
   review records, not from a generic workflow engine.
+- Detailed confidence-label taxonomies can wait. The urgent need is durable
+  source facts, visible diffs, reviewed application, and an audit trail that
+  lets an experimenter trust the next run.

--- a/docs-next/research/legacy-measurement-sample-lessons.md
+++ b/docs-next/research/legacy-measurement-sample-lessons.md
@@ -58,3 +58,20 @@ Fricon should make the following facts first-class for new work:
 The MVP should still avoid LabRAD emulation, old-history import, broad device
 control, a full parameter registry, and automatic tracing of every file an
 unmanaged script reads.
+
+## Post-MVP Product Pressure
+
+The samples also point beyond the MVP replacement loop:
+
+- Legacy folders are not just storage debt; they are missing experiment memory.
+- Repetition currently depends on copied code, mutable config, and operator
+  recall.
+- Fricon's post-MVP advantage should be reviewed reuse of recorded facts, not
+  emulation of legacy paths.
+- Read-only compare, handoff, run-like-previous drafts, and failure
+  investigation should arrive before mutation-capable automation.
+- Parameter proposals should promote effective settings only after review.
+- Analysis and calibration records should provide evidence for trust decisions
+  before they become automation inputs.
+- Automation should grow from trustworthy manifests, snapshots, diffs, and
+  review records, not from a generic workflow engine.

--- a/docs-next/research/post-mvp-future-systems.md
+++ b/docs-next/research/post-mvp-future-systems.md
@@ -113,15 +113,21 @@ Modern desired-state and reviewable-apply references:
   be opt-in at first, not a forced replacement for Python scripts.
 - Provenance level must be honest: unmanaged, observed, and managed snapshots
   are different product states.
-- Calibration should first produce evidence and reviewed parameter/setup
-  proposals: source measurements, analysis attempts, code context, fitted
-  values, affected parameter paths, diffs, review outcome, and rollback target
-  where practical.
+- Experiment-parameter calibration should first produce evidence, fitted
+  values, chain-scoped working-ref updates, health decisions, retries, and
+  pause/review reasons. Durable named profile promotion can then carry source
+  measurements, analysis attempts, code context, affected parameter paths,
+  diffs, review outcome, and rollback target where practical.
+- Keep Calibration as the field-standard product term, but qualify other
+  meanings. Instrument calibration and setup/device reconciliation have
+  different safety, readback, and audit semantics from qubit/gate/readout
+  parameter calibration.
 - Setup/device/calibration state should start with store, bind, search, and
   diff. Applying settings to devices comes later and needs safety ADRs.
-- Detailed confidence-label schemes are secondary. They should not block the
-  core code/parameter/calibration evidence model, and they can be added later
-  where a concrete workflow needs them.
+- Broad confidence-label schemes are secondary. Calibration task
+  health/confidence gates are different: they are a concrete automation
+  requirement for deciding whether a bootstrap calibration should continue,
+  retry, pause, or ask for review.
 - Local-first experiment history aligns better with Fricon than cloud-first ML
   tracking, model registries, or hyperparameter leaderboards.
 - Borrow lifecycle, event, and schema rigor from Bluesky, but avoid exposing
@@ -138,7 +144,7 @@ Modern desired-state and reviewable-apply references:
 - Desired-state reconciliation should be a reviewable plan/apply workflow, not
   hidden magic. A saved plan should record the observed state it was based on,
   dependencies, expected mutations, readback checks, and failure handling
-  before hardware or active parameter refs are changed.
+  before hardware or durable named parameter refs are changed.
 - Separate spec/status-style facts. Desired state is intent; observed device
   state, readbacks, and apply execution status are evidence. Mixing those
   concepts recreates the old problem where generated config and mutable state

--- a/docs-next/research/post-mvp-future-systems.md
+++ b/docs-next/research/post-mvp-future-systems.md
@@ -78,6 +78,21 @@ Lab state, audit, and calibration references:
 - openBIS data model:
   https://openbis.readthedocs.io/en/20.10.12-plus/user-documentation/advance-features/openbis-data-modelling.html
 
+Modern desired-state and reviewable-apply references:
+
+- React render/state model:
+  https://react.dev/learn/state-as-a-snapshot
+  https://react.dev/learn/render-and-commit
+  https://react.dev/learn/managing-state
+- Terraform plan/apply and dependency graph:
+  https://developer.hashicorp.com/terraform/cli/commands/plan
+  https://developer.hashicorp.com/terraform/cli/commands/apply
+  https://developer.hashicorp.com/terraform/internals/graph
+- Kubernetes desired/current state and controller pattern:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/
+  https://kubernetes.io/docs/concepts/architecture/controller/
+  https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config
+
 ## Product Lessons
 
 - Parameter drift is a standalone product problem. Post-MVP parameter work
@@ -115,3 +130,31 @@ Lab state, audit, and calibration references:
   as the main user experience. Diffs and named groups matter.
 - Borrow ELN/logbook links and audit primitives, but avoid becoming a full
   ELN, LIMS, or compliance platform.
+- Borrow declarative desired-state thinking from modern UI and infrastructure
+  systems, but translate it carefully for hardware. Instead of writing every
+  device in every nested scan-loop body, a managed routine could compute the
+  expected setup/device state from parameters, diff it against observed state,
+  preview an apply plan, skip no-op writes, and group safe independent writes.
+- Desired-state reconciliation should be a reviewable plan/apply workflow, not
+  hidden magic. A saved plan should record the observed state it was based on,
+  dependencies, expected mutations, readback checks, and failure handling
+  before hardware or active parameter refs are changed.
+- Separate spec/status-style facts. Desired state is intent; observed device
+  state, readbacks, and apply execution status are evidence. Mixing those
+  concepts recreates the old problem where generated config and mutable state
+  become hard to trust.
+- Prefer small specialized controllers or reconcilers over one monolithic
+  workflow engine. Calibration, parameter proposals, setup state, device apply,
+  and routine replay have different safety and audit semantics.
+- Treat long-running or replayable automation like a state machine with durable
+  events. Non-deterministic side effects such as device I/O, time-sensitive
+  readings, random choices, and external services should happen at explicit
+  activity boundaries with recorded inputs and outputs.
+- Use Git-like review habits for lab state: propose, diff, review, apply, and
+  rollback. This maps naturally to parameter proposals, calibration proposals,
+  and setup/device apply plans without requiring a heavyweight permissions
+  system.
+- Use dataflow-style invalidation for derived facts. If a parameter snapshot,
+  code snapshot, calibration record, or generated sidecar changes, derived
+  analysis results and routine previews should be able to show what they depend
+  on and whether they need to be recomputed or reviewed.

--- a/docs-next/research/post-mvp-future-systems.md
+++ b/docs-next/research/post-mvp-future-systems.md
@@ -83,6 +83,10 @@ Lab state, audit, and calibration references:
 - Parameter drift is a standalone product problem. Post-MVP parameter work
   should treat named parameter profiles, immutable snapshots, proposals,
   overrides, and diffs as first-class concepts.
+- Code and parameter drift are coupled in practice. Calibration cannot be
+  reliably automated while fitted values depend on copied measurement folders,
+  mutable config files, notebook-local analysis, or generated sidecars that are
+  not visible in the experiment record.
 - Sample visualization can stay convention-friendly: parameter table row keys
   and user-authored 2D map configs can provide useful target binding without
   forcing a full sample-component ontology early.
@@ -90,12 +94,19 @@ Lab state, audit, and calibration references:
   reliably hand-enter code, parameter, setup, calibration, and environment
   context after every run.
 - Managed code snapshot and runner capture matter early because they create
-  trustworthy history. They should be opt-in at first, not a forced replacement
-  for Python scripts.
-- Provenance confidence must be honest: unmanaged, observed, and managed
-  snapshots are different product states.
+  inspectable history for measurements, analysis, and calibration. They should
+  be opt-in at first, not a forced replacement for Python scripts.
+- Provenance level must be honest: unmanaged, observed, and managed snapshots
+  are different product states.
+- Calibration should first produce evidence and reviewed parameter/setup
+  proposals: source measurements, analysis attempts, code context, fitted
+  values, affected parameter paths, diffs, review outcome, and rollback target
+  where practical.
 - Setup/device/calibration state should start with store, bind, search, and
   diff. Applying settings to devices comes later and needs safety ADRs.
+- Detailed confidence-label schemes are secondary. They should not block the
+  core code/parameter/calibration evidence model, and they can be added later
+  where a concrete workflow needs them.
 - Local-first experiment history aligns better with Fricon than cloud-first ML
   tracking, model registries, or hyperparameter leaderboards.
 - Borrow lifecycle, event, and schema rigor from Bluesky, but avoid exposing

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Draft.
+Draft placeholder. Not implementation-ready.
+
+## Planning Boundary
+
+Product and domain documents own scope while v0.2+ analysis is still in
+progress. This design records likely implementation pressure only; re-sync it
+after the product/domain baseline and required ADRs are accepted.
 
 ## Design Summary
 
@@ -27,7 +33,6 @@ First implementation records:
 - Event/AuditRecord
 - optional Sample and SampleSession links
 - optional ParameterSnapshot
-- optional RunConfigSnapshot
 - optional CodeProvenanceSummary
 - optional SetupProvenanceSummary
 - optional ProcedureSummary
@@ -49,7 +54,6 @@ Candidate operation groups:
 - `measurements.finish`
 - `measurements.abort`
 - `measurements.record_event`
-- `measurements.attach_run_config`
 - `datasets.create_writer`
 - `datasets.append`
 - `datasets.finish`
@@ -122,8 +126,6 @@ Storage ADR must decide physical layout. The design requires only:
   points, repeated points, fixed-shape traces, and variable-length traces
 - partial-read semantics for interrupted or incomplete data
 - optional internal stream-like groups for advanced storage/export/read needs
-- optional run-bound local configuration references, snapshots, hashes, or
-  summaries
 - event timeline records
 - compatibility version and migration state
 - active writer state sufficient for recovery
@@ -141,5 +143,3 @@ Storage ADR must decide physical layout. The design requires only:
 8. Passive procedure summary shape.
 9. Whether internal stream groups are required for first implementation or only
    reserved in the storage/export ADRs.
-10. Run configuration snapshot shape: inline summary, copied file, hash-only
-    reference, external URI, or a mix.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/design.md
@@ -27,6 +27,7 @@ First implementation records:
 - Event/AuditRecord
 - optional Sample and SampleSession links
 - optional ParameterSnapshot
+- optional RunConfigSnapshot
 - optional CodeProvenanceSummary
 - optional SetupProvenanceSummary
 - optional ProcedureSummary
@@ -48,6 +49,7 @@ Candidate operation groups:
 - `measurements.finish`
 - `measurements.abort`
 - `measurements.record_event`
+- `measurements.attach_run_config`
 - `datasets.create_writer`
 - `datasets.append`
 - `datasets.finish`
@@ -120,6 +122,8 @@ Storage ADR must decide physical layout. The design requires only:
   points, repeated points, fixed-shape traces, and variable-length traces
 - partial-read semantics for interrupted or incomplete data
 - optional internal stream-like groups for advanced storage/export/read needs
+- optional run-bound local configuration references, snapshots, hashes, or
+  summaries
 - event timeline records
 - compatibility version and migration state
 - active writer state sufficient for recovery
@@ -137,3 +141,5 @@ Storage ADR must decide physical layout. The design requires only:
 8. Passive procedure summary shape.
 9. Whether internal stream groups are required for first implementation or only
    reserved in the storage/export ADRs.
+10. Run configuration snapshot shape: inline summary, copied file, hash-only
+    reference, external URI, or a mix.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Draft.
+Draft placeholder. Not implementation-ready.
+
+## Planning Boundary
+
+Product and domain documents own scope while v0.2+ analysis is still in
+progress. This file is a candidate first-slice shape, not an accepted
+implementation contract.
 
 ## Purpose
 
@@ -14,7 +20,7 @@ inspection, partial recovery, and Python reopen.
 
 CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
 CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017, CAP-026,
-CAP-027, CAP-028, CAP-029, CAP-033.
+CAP-027, CAP-028, CAP-029.
 
 ## Requirements
 
@@ -41,7 +47,6 @@ CAP-027, CAP-028, CAP-029, CAP-033.
 | REQ-019 | Provide scan schema authoring helpers. | Common 1D/2D/N-D scan and trace cases have Python-native scan plans or helpers; advanced cases can use raw schema. Exact helper shape should be refined from usage feedback. |
 | REQ-020 | Record passive procedure summaries. | Measurements can link unmanaged script, external runner, or declared plan summaries without managed execution. |
 | REQ-021 | Allow internal artifact streams below the user concept. | Storage/export/read APIs may model internal streams, but v0.2 UI and public examples keep one dataset artifact as the normal concept. |
-| REQ-022 | Capture run-bound local configuration. | Measurements can attach selected local configuration references, snapshots, hashes, or summaries with privacy-aware export handling and correction history. |
 
 ## Non-Goals
 

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/requirements.md
@@ -14,7 +14,7 @@ inspection, partial recovery, and Python reopen.
 
 CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
 CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017, CAP-026,
-CAP-027, CAP-028, CAP-029.
+CAP-027, CAP-028, CAP-029, CAP-033.
 
 ## Requirements
 
@@ -41,6 +41,7 @@ CAP-027, CAP-028, CAP-029.
 | REQ-019 | Provide scan schema authoring helpers. | Common 1D/2D/N-D scan and trace cases have Python-native scan plans or helpers; advanced cases can use raw schema. Exact helper shape should be refined from usage feedback. |
 | REQ-020 | Record passive procedure summaries. | Measurements can link unmanaged script, external runner, or declared plan summaries without managed execution. |
 | REQ-021 | Allow internal artifact streams below the user concept. | Storage/export/read APIs may model internal streams, but v0.2 UI and public examples keep one dataset artifact as the normal concept. |
+| REQ-022 | Capture run-bound local configuration. | Measurements can attach selected local configuration references, snapshots, hashes, or summaries with privacy-aware export handling and correction history. |
 
 ## Non-Goals
 
@@ -52,6 +53,7 @@ CAP-027, CAP-028, CAP-029.
 - Managed runner or task queue.
 - User-facing dataset streams as a normal v0.2 concept.
 - Full parameter registry or calibration workflow.
+- Automatic tracing of every file a script reads.
 - Device communication.
 - Large detector-file/image asset management unless a focused ADR pulls a
   narrow hook into scope.

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
@@ -15,9 +15,9 @@ Draft. Not implementation-ready until required ADRs are accepted.
 | T-005 | Design scan shape and readable-partial semantics for regular, partial, irregular, repeated, and trace data. | Pending |
 | T-006 | Design Python-native scan-plan/helper API shape for common 1D/2D/N-D scans and traces. | Pending |
 | T-007 | Decide whether internal stream groups are implementation scope or ADR-reserved only. | Pending |
-| T-008 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, SetupProvenanceSummary, ProcedureSummary, and Event. | Pending |
+| T-008 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, RunConfigSnapshot, SetupProvenanceSummary, ProcedureSummary, and Event. | Pending |
 | T-009 | Add persistence adapters and migrations for first-slice records. | Pending |
-| T-010 | Add local service operations for compatibility, measurement, dataset writer/search/read, and events. | Pending |
+| T-010 | Add local service operations for compatibility, measurement, run configuration context, dataset writer/search/read, and events. | Pending |
 | T-011 | Redesign Python SDK measurement-scoped writer API. | Pending |
 | T-012 | Add semantic read/reopen path from Python. | Pending |
 | T-013 | Build Desktop measurement console skeleton with dataset direct-open entry points. | Pending |

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/tasks.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Draft. Not implementation-ready until required ADRs are accepted.
+Draft placeholder. Not implementation-ready until product/domain scope and
+required ADRs are accepted.
 
 ## Tasks
 
@@ -15,9 +16,9 @@ Draft. Not implementation-ready until required ADRs are accepted.
 | T-005 | Design scan shape and readable-partial semantics for regular, partial, irregular, repeated, and trace data. | Pending |
 | T-006 | Design Python-native scan-plan/helper API shape for common 1D/2D/N-D scans and traces. | Pending |
 | T-007 | Decide whether internal stream groups are implementation scope or ADR-reserved only. | Pending |
-| T-008 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, RunConfigSnapshot, SetupProvenanceSummary, ProcedureSummary, and Event. | Pending |
+| T-008 | Add core domain types for DataLibrary, Measurement, DatasetArtifact, SetupProvenanceSummary, ProcedureSummary, and Event. | Pending |
 | T-009 | Add persistence adapters and migrations for first-slice records. | Pending |
-| T-010 | Add local service operations for compatibility, measurement, run configuration context, dataset writer/search/read, and events. | Pending |
+| T-010 | Add local service operations for compatibility, measurement, dataset writer/search/read, and events. | Pending |
 | T-011 | Redesign Python SDK measurement-scoped writer API. | Pending |
 | T-012 | Add semantic read/reopen path from Python. | Pending |
 | T-013 | Build Desktop measurement console skeleton with dataset direct-open entry points. | Pending |

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
@@ -2,24 +2,30 @@
 
 ## Status
 
-Draft.
+Draft placeholder. Not implementation-ready.
+
+## Planning Boundary
+
+Traceability is provisional until product/domain scope and required ADRs are
+accepted. Do not use this file as the source of truth for whether a product
+story belongs to M1.
 
 ## Related Capabilities
 
 CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
 CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017, CAP-026,
-CAP-027, CAP-028, CAP-029, CAP-033.
+CAP-027, CAP-028, CAP-029.
 
 ## Related User Stories
 
 US-001, US-002, US-003, US-004, US-005, US-006, US-007, US-008, US-010,
-US-011, US-012, US-013, US-014, US-015, US-016, US-019.
+US-011, US-012, US-013, US-014, US-015, US-016.
 
 ## Related Domain Concepts
 
 DataLibrary, Measurement, DatasetArtifact, Sample, SampleSession,
 ParameterSnapshot, CodeProvenanceSummary, SetupProvenanceSummary,
-RunConfigSnapshot, ProcedureSummary, Event/AuditRecord, OperatorProfile.
+ProcedureSummary, Event/AuditRecord, OperatorProfile.
 
 ## Related Architecture Docs
 
@@ -43,7 +49,6 @@ RunConfigSnapshot, ProcedureSummary, Event/AuditRecord, OperatorProfile.
 - Pending: passive procedure summary shape
 - Pending: Python-native scan-plan/helper API shape
 - Pending: internal stream/subpayload representation, if needed
-- Pending: run-bound local configuration snapshot shape
 
 ## Affected Modules
 

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/traceability.md
@@ -8,18 +8,18 @@ Draft.
 
 CAP-001, CAP-002, CAP-003, CAP-004, CAP-005, CAP-006, CAP-007, CAP-008,
 CAP-009, CAP-010, CAP-012, CAP-013, CAP-014, CAP-015, CAP-017, CAP-026,
-CAP-027, CAP-028, CAP-029.
+CAP-027, CAP-028, CAP-029, CAP-033.
 
 ## Related User Stories
 
 US-001, US-002, US-003, US-004, US-005, US-006, US-007, US-008, US-010,
-US-011, US-012, US-013, US-014, US-015, US-016.
+US-011, US-012, US-013, US-014, US-015, US-016, US-019.
 
 ## Related Domain Concepts
 
 DataLibrary, Measurement, DatasetArtifact, Sample, SampleSession,
 ParameterSnapshot, CodeProvenanceSummary, SetupProvenanceSummary,
-ProcedureSummary, Event/AuditRecord, OperatorProfile.
+RunConfigSnapshot, ProcedureSummary, Event/AuditRecord, OperatorProfile.
 
 ## Related Architecture Docs
 
@@ -43,6 +43,7 @@ ProcedureSummary, Event/AuditRecord, OperatorProfile.
 - Pending: passive procedure summary shape
 - Pending: Python-native scan-plan/helper API shape
 - Pending: internal stream/subpayload representation, if needed
+- Pending: run-bound local configuration snapshot shape
 
 ## Affected Modules
 

--- a/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
+++ b/docs-next/specs/SPEC-001-data-library-measurement-foundation/validation.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-Draft.
+Draft placeholder. Not implementation-ready.
+
+## Planning Boundary
+
+Validation scenarios are candidate checks for later implementation planning.
+Re-sync them after product/domain scope and required ADRs are accepted.
 
 ## Validation Strategy
 

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/design.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/design.md
@@ -4,6 +4,11 @@
 
 Draft placeholder.
 
+## Planning Boundary
+
+Product and domain documents own scope while v0.2+ analysis is still in
+progress. This design records a likely export direction only.
+
 ## Direction
 
 Treat export bundles as read-only analysis packages:

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/requirements.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/requirements.md
@@ -11,7 +11,7 @@ v0.2 product promise, but it should not be hidden inside the foundation spec.
 
 ## Related Capabilities
 
-CAP-010, CAP-011, CAP-026.
+CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029, CAP-033.
 
 ## Requirements To Refine
 
@@ -25,6 +25,7 @@ CAP-010, CAP-011, CAP-026.
 | REQ-006 | Preview sensitive provenance. | Local paths, source computer labels, detailed environment summaries, and dirty code state are opt-in or previewed. |
 | REQ-007 | Preserve passive summaries when selected. | Code provenance, setup summaries, and procedure summaries can travel in the export with privacy preview. |
 | REQ-008 | Preserve internal artifact grouping when needed. | Internal streams/subpayloads remain readable without making stream names the primary user-facing concept. |
+| REQ-009 | Preserve selected run configuration context. | Run-bound configuration snapshots, references, hashes, and summaries can travel with the export when selected, while sensitive local paths, machine names, IP addresses, and source-folder details are previewed. |
 
 ## Non-Goals
 

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/requirements.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/requirements.md
@@ -9,9 +9,15 @@ Draft placeholder.
 Define the near-term export slice that follows SPEC-001. Export is part of the
 v0.2 product promise, but it should not be hidden inside the foundation spec.
 
+## Planning Boundary
+
+Product and domain documents own scope while v0.2+ analysis is still in
+progress. This file is a placeholder for later export planning, not an accepted
+implementation contract.
+
 ## Related Capabilities
 
-CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029, CAP-033.
+CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029.
 
 ## Requirements To Refine
 
@@ -25,7 +31,6 @@ CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029, CAP-033.
 | REQ-006 | Preview sensitive provenance. | Local paths, source computer labels, detailed environment summaries, and dirty code state are opt-in or previewed. |
 | REQ-007 | Preserve passive summaries when selected. | Code provenance, setup summaries, and procedure summaries can travel in the export with privacy preview. |
 | REQ-008 | Preserve internal artifact grouping when needed. | Internal streams/subpayloads remain readable without making stream names the primary user-facing concept. |
-| REQ-009 | Preserve selected run configuration context. | Run-bound configuration snapshots, references, hashes, and summaries can travel with the export when selected, while sensitive local paths, machine names, IP addresses, and source-folder details are previewed. |
 
 ## Non-Goals
 

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/tasks.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/tasks.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Draft placeholder.
+Draft placeholder. Not implementation-ready until product/domain scope and
+required ADRs are accepted.
 
 ## Tasks
 
@@ -14,4 +15,3 @@ Draft placeholder.
 | T-004 | Design direct Python export reader API. | Pending |
 | T-005 | Design privacy preview defaults. | Pending |
 | T-006 | Add validation scenarios for regular grids, partial grids, irregular scans, and variable-length traces. | Pending |
-| T-007 | Define export handling for selected run configuration snapshots, references, hashes, and summaries. | Pending |

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/tasks.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/tasks.md
@@ -14,3 +14,4 @@ Draft placeholder.
 | T-004 | Design direct Python export reader API. | Pending |
 | T-005 | Design privacy preview defaults. | Pending |
 | T-006 | Add validation scenarios for regular grids, partial grids, irregular scans, and variable-length traces. | Pending |
+| T-007 | Define export handling for selected run configuration snapshots, references, hashes, and summaries. | Pending |

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/traceability.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/traceability.md
@@ -4,19 +4,25 @@
 
 Draft placeholder.
 
+## Planning Boundary
+
+Traceability is provisional until product/domain scope and required ADRs are
+accepted. Do not use this file as the source of truth for whether a product
+story belongs to the export slice.
+
 ## Related Capabilities
 
-CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029, CAP-033.
+CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029.
 
 ## Related User Stories
 
-US-008, US-009, US-013, US-019.
+US-008, US-009, US-013.
 
 ## Related Domain Concepts
 
 Measurement, DatasetArtifact, ExportBundle, DataLibrary,
-ParameterSnapshot, RunConfigSnapshot, CodeProvenanceSummary,
-SetupProvenanceSummary, ProcedureSummary, Event/AuditRecord.
+ParameterSnapshot, CodeProvenanceSummary, SetupProvenanceSummary,
+ProcedureSummary, Event/AuditRecord.
 
 ## Related Docs
 
@@ -32,4 +38,3 @@ SetupProvenanceSummary, ProcedureSummary, Event/AuditRecord.
 - export bundle format
 - common analysis format policy
 - export privacy defaults
-- run configuration export selection and privacy policy

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/traceability.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/traceability.md
@@ -6,17 +6,17 @@ Draft placeholder.
 
 ## Related Capabilities
 
-CAP-010, CAP-011, CAP-026.
+CAP-010, CAP-011, CAP-014, CAP-015, CAP-026, CAP-027, CAP-029, CAP-033.
 
 ## Related User Stories
 
-US-008, US-009, US-013.
+US-008, US-009, US-013, US-019.
 
 ## Related Domain Concepts
 
 Measurement, DatasetArtifact, ExportBundle, DataLibrary,
-ParameterSnapshot, CodeProvenanceSummary, SetupProvenanceSummary,
-Event/AuditRecord.
+ParameterSnapshot, RunConfigSnapshot, CodeProvenanceSummary,
+SetupProvenanceSummary, ProcedureSummary, Event/AuditRecord.
 
 ## Related Docs
 
@@ -25,9 +25,11 @@ Event/AuditRecord.
 - `architecture/storage-model.md`
 - `architecture/compatibility-policy.md`
 - `research/lessons-for-fricon.md`
+- `research/legacy-measurement-sample-lessons.md`
 
 ## ADRs Needed
 
 - export bundle format
 - common analysis format policy
 - export privacy defaults
+- run configuration export selection and privacy policy

--- a/docs-next/specs/SPEC-002-measurement-export-offline-analysis/validation.md
+++ b/docs-next/specs/SPEC-002-measurement-export-offline-analysis/validation.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-Draft placeholder.
+Draft placeholder. Not implementation-ready.
+
+## Planning Boundary
+
+Validation scenarios are candidate checks for later export planning. Re-sync
+them after product/domain scope and required ADRs are accepted.
 
 ## Scenario Checks
 


### PR DESCRIPTION
## Summary
- Consolidates the branch into a coherent docs-next baseline for the data library measurement initiative
- Updates the product, domain, research, and implementation docs to align on concepts, invariants, stories, and future concepts
- Adds the initial SPEC-001 and SPEC-002 requirements, design, tasks, and traceability needed to guide the measurement and export work

## Testing
- Not run (not requested)