### PR TITLE
docs: sort numbered ids and centralize authoring guidance

### DIFF
--- a/docs-next/README.md
+++ b/docs-next/README.md
@@ -120,6 +120,9 @@ Keep each idea in the narrowest durable owner:
   decisions that are not already owned upstream.
 - `ai/` owns agent routing and update policy, not product or domain rationale.
 
+Detailed editing rules live in `ai/documentation-update-policy.md`; load that
+file only when authoring or reorganizing `docs-next/` documents.
+
 ## Source Inputs
 
 This baseline was bootstrapped from:

--- a/docs-next/ai/documentation-update-policy.md
+++ b/docs-next/ai/documentation-update-policy.md
@@ -26,6 +26,31 @@ Keep docs token-efficient. Avoid large tables and broad duplicated lists. If a
 table starts to grow, split the stable overview from the detailed story, spec,
 or ADR that actually needs the detail.
 
+## Numbered ID Management
+
+Stable numbered IDs must be easy to allocate without scanning unrelated
+priority lists.
+
+- For substantial entries, prefer one file per ID in a directory whose filenames
+  sort numerically, like `product/user-stories/US-001-...md`.
+- For short entries kept in one file, keep the authoritative definitions in
+  ascending ID order within that file.
+- Put unstable ordering concerns such as priority, release slice, or milestone
+  sequence in separate index sections that reference IDs.
+- To allocate a new ID, list or search only the owning directory/file, choose
+  the lowest unused number after the current maximum for that prefix, and never
+  fill an old gap by reusing a removed ID.
+- When a numbered entry moves between priority or milestone groups, update the
+  index reference only; do not move the definition unless the owning file's ID
+  order requires it.
+
+## Compact Authoring
+
+- Keep top-level maps short enough for future AI sessions to skim.
+- Split detailed acceptance criteria into the owning story, spec, or ADR.
+- Prefer ID indexes over duplicated tables when the same entries need multiple
+  views.
+
 ## After Implementation
 
 Gate D documentation sync requires:

--- a/docs-next/decisions/ADR-002-documentation-governance.md
+++ b/docs-next/decisions/ADR-002-documentation-governance.md
@@ -39,6 +39,9 @@ Important IDs are stable:
 - ADR-### for decisions
 - M# for milestones
 
+Detailed authoring and ID-allocation workflow is maintained in
+`ai/documentation-update-policy.md`.
+
 ## Consequences
 
 - Do not implement major v0.2 features from chat history or archived proposals

--- a/docs-next/product/capability-map.md
+++ b/docs-next/product/capability-map.md
@@ -4,13 +4,6 @@
 
 Accepted.
 
-## ID Rules
-
-Capability IDs are stable. Do not reuse or renumber them.
-
-Keep this file compact. Put detailed acceptance notes in epics, user stories,
-or specs instead of expanding this map into a large table.
-
 ## Vision Alignment
 
 The capability baseline serves one MVP goal: replace the simple LabRAD Data
@@ -25,9 +18,19 @@ Release versions are not product-horizon labels. Compatible post-MVP
 capabilities may still ship on the same compatible release line; use MVP,
 post-MVP priority, and ADR-gated labels for product planning.
 
-## MVP Foundation Capabilities
+## Product Grouping
 
-### Local Adoption
+Use these planning groups when routing product work:
+
+- Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
+- MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007, CAP-028,
+  CAP-030.
+- Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
+  CAP-029, CAP-033.
+- Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
+- Post-MVP foundation: CAP-018 through CAP-025, CAP-031, CAP-032.
+
+## Capability Definitions
 
 CAP-001: Local data library.
 
@@ -47,24 +50,6 @@ CAP-002: Install and launch local Fricon.
 - Excludes: polished enterprise deployment and third-party protocol stability.
   Exact runtime/process packaging belongs to architecture.
 
-CAP-012: Backup, restore, and migration checkpoints.
-
-- Promise: format-changing operations have a recovery posture before user data
-  is mutated.
-- Includes: backup/restore guidance, repair or migration checkpoints, and
-  ordinary recoverable cleanup paths.
-- Excludes: full legacy-system migration and distributed backup service.
-
-CAP-013: Compatibility diagnostics and fail-before-write checks.
-
-- Promise: incompatible client, local runtime, or library combinations fail
-  before mutation with actionable diagnostics.
-- Includes: version negotiation for Desktop, local runtime components, CLI,
-  Python SDK, and data library format.
-- Excludes: accepting best-effort writes from unknown or stale clients.
-
-### MVP Measurement Replacement
-
 CAP-003: Python measurement recording.
 
 - Promise: a Python script or notebook can explicitly create an unmanaged
@@ -74,6 +59,14 @@ CAP-003: Python measurement recording.
   writers, and readable crash outcomes.
 - Excludes: managed runner, task queue, visual sweep builder, and device
   control.
+
+CAP-004: Optional, visible, correctable sample/session context.
+
+- Promise: sample and sample-session context can explain a measurement when it
+  matters, without blocking quick exploratory work.
+- Includes: optional active context, visible context on creation, and correction
+  after a run.
+- Excludes: requiring a complete sample registry before recording data.
 
 CAP-005: Dataset artifact recording.
 
@@ -98,92 +91,6 @@ CAP-007: Nonblocking live inspection.
 - Includes: live events, table view, line/scatter plot, basic heatmap, simple
   trace inspection, and stale/lag indicators.
 - Excludes: live consumers as required write acknowledgements.
-
-CAP-028: Python-native scan plans plus raw schema escape hatch.
-
-- Promise: common scan shapes are easy to declare in ordinary Python while
-  uncommon schemas remain possible.
-- Includes: a low-ceremony scan-plan shape for common 1D, 2D, N-D, and trace
-  cases; dict/literal-friendly authoring where useful; optional convenience
-  helpers; and raw schema construction for advanced users.
-- Excludes: a fixed framework-specific helper name, a framework-specific
-  parameter-object model, treating first-draft helper syntax as accepted
-  without usage feedback, a visual sweep builder, or a managed execution plan.
-
-CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
-
-- Promise: users can translate new Data Vault-style scripts to Fricon writers
-  without a full experiment-stack rewrite.
-- Includes: natural mapping for independent/dependent variables, labels, units,
-  legends, old path aliases, and numbered legacy titles as metadata.
-- Excludes: a LabRAD compatibility server, built-in Data Vault parser, or old
-  history browser.
-
-### Context And Provenance
-
-CAP-004: Optional, visible, correctable sample/session context.
-
-- Promise: sample and sample-session context can explain a measurement when it
-  matters, without blocking quick exploratory work.
-- Includes: optional active context, visible context on creation, and correction
-  after a run.
-- Excludes: requiring a complete sample registry before recording data.
-
-CAP-014: Honest code provenance summary.
-
-- Promise: Fricon records what it can honestly know about unmanaged Python code
-  without pretending it owns execution.
-- Includes: unmanaged labels, optional script path, Git summary, dirty-state
-  signal, user-supplied summary, and privacy-aware export handling.
-- Excludes: automatic notebook state capture and managed code snapshots.
-
-CAP-015: Light parameter context summary without a registry UI.
-
-- Promise: a measurement can keep optional parameter context before Fricon has
-  parameter profiles, effective snapshots, or calibration workflows.
-- Includes: user-supplied structured or semi-structured parameter summaries,
-  units where supplied, and links to measurement context.
-- Excludes: global parameter registry, immutable profile binding, override
-  semantics, proposal workflow, and calibration promotion.
-
-CAP-033: Run-bound local configuration snapshot.
-
-- Promise: a measurement can bind selected local configuration files,
-  references, hashes, or summaries so later analysis can identify the effective
-  lab-local state without reading copied folders by hand.
-- Includes: user-selected parameter files, registry files, wiring references,
-  line/chip information, demod/readout settings, runner labels, source aliases,
-  privacy-aware export selection, and correction history.
-- Excludes: automatic tracing of every file read, global parameter profiles,
-  calibration promotion, device control, or claiming unmanaged execution was
-  fully reproducible.
-
-CAP-017: Lightweight operator profile and audit actor.
-
-- Promise: notes, corrections, lifecycle events, and exports can name the local
-  operator or actor responsible.
-- Includes: local operator label, audit actor on events, and correction history.
-- Excludes: accounts, permissions, teams, and identity-provider integration.
-
-CAP-027: Passive setup and environment summary.
-
-- Promise: measurements can record setup, device, method, software, or
-  environment context without controlling the lab setup.
-- Includes: optional labels, freeform summaries, external references, and
-  privacy-aware export selection.
-- Excludes: device identity registry, calibration records, and communication
-  with instruments.
-
-CAP-029: Passive procedure summary.
-
-- Promise: users can describe the procedure that produced data even when Fricon
-  did not execute that procedure.
-- Includes: unmanaged script summary, external-runner reference, declared plan
-  summary, and operator correction.
-- Excludes: managed measurement plans, resumable execution, and scan-point
-  checkpoints.
-
-### Review And Analysis
 
 CAP-008: Lifecycle and readable partial recovery.
 
@@ -217,6 +124,39 @@ CAP-011: Measurement-centered export.
 - Excludes: importing old history and a fully polished offline Desktop viewer
   before the write/reopen loop is proven.
 
+CAP-012: Backup, restore, and migration checkpoints.
+
+- Promise: format-changing operations have a recovery posture before user data
+  is mutated.
+- Includes: backup/restore guidance, repair or migration checkpoints, and
+  ordinary recoverable cleanup paths.
+- Excludes: full legacy-system migration and distributed backup service.
+
+CAP-013: Compatibility diagnostics and fail-before-write checks.
+
+- Promise: incompatible client, local runtime, or library combinations fail
+  before mutation with actionable diagnostics.
+- Includes: version negotiation for Desktop, local runtime components, CLI,
+  Python SDK, and data library format.
+- Excludes: accepting best-effort writes from unknown or stale clients.
+
+CAP-014: Honest code provenance summary.
+
+- Promise: Fricon records what it can honestly know about unmanaged Python code
+  without pretending it owns execution.
+- Includes: unmanaged labels, optional script path, Git summary, dirty-state
+  signal, user-supplied summary, and privacy-aware export handling.
+- Excludes: automatic notebook state capture and managed code snapshots.
+
+CAP-015: Light parameter context summary without a registry UI.
+
+- Promise: a measurement can keep optional parameter context before Fricon has
+  parameter profiles, effective snapshots, or calibration workflows.
+- Includes: user-supplied structured or semi-structured parameter summaries,
+  units where supplied, and links to measurement context.
+- Excludes: global parameter registry, immutable profile binding, override
+  semantics, proposal workflow, and calibration promotion.
+
 CAP-016: Light measurement attachments.
 
 - Promise: a measurement can reference small supporting files needed to
@@ -225,15 +165,12 @@ CAP-016: Light measurement attachments.
   selection.
 - Excludes: large detector-file management and general media asset library.
 
-CAP-026: Dataset artifact discovery and direct open.
+CAP-017: Lightweight operator profile and audit actor.
 
-- Promise: dataset artifacts remain searchable and directly openable even when
-  the Desktop home is measurement-first.
-- Includes: stable artifact IDs, measurement context, search/open entry points,
-  and direct navigation to table or plot views.
-- Excludes: returning to a dataset-first product model.
-
-## Post-MVP Capabilities
+- Promise: notes, corrections, lifecycle events, and exports can name the local
+  operator or actor responsible.
+- Includes: local operator label, audit actor on events, and correction history.
+- Excludes: accounts, permissions, teams, and identity-provider integration.
 
 CAP-018: Read-only remote monitoring.
 
@@ -277,8 +214,8 @@ CAP-022: Analysis, interpretation, and calibration records.
 
 CAP-023: Managed code snapshots and execution.
 
-- Intent: run selected measurement code under Fricon control with
-  stronger code provenance snapshots and lifecycle supervision.
+- Intent: run selected measurement code under Fricon control with stronger code
+  provenance snapshots and lifecycle supervision.
 - Boundary: the MVP records unmanaged execution context only.
 
 CAP-024: Device boundary and managed device communication.
@@ -298,6 +235,52 @@ CAP-025: AI-assisted reviewed automation.
   automation. AI-created durable conclusions should record provenance, and
   mutating AI actions should enter through the same reviewed proposal path as
   non-AI automation.
+
+CAP-026: Dataset artifact discovery and direct open.
+
+- Promise: dataset artifacts remain searchable and directly openable even when
+  the Desktop home is measurement-first.
+- Includes: stable artifact IDs, measurement context, search/open entry points,
+  and direct navigation to table or plot views.
+- Excludes: returning to a dataset-first product model.
+
+CAP-027: Passive setup and environment summary.
+
+- Promise: measurements can record setup, device, method, software, or
+  environment context without controlling the lab setup.
+- Includes: optional labels, freeform summaries, external references, and
+  privacy-aware export selection.
+- Excludes: device identity registry, calibration records, and communication
+  with instruments.
+
+CAP-028: Python-native scan plans plus raw schema escape hatch.
+
+- Promise: common scan shapes are easy to declare in ordinary Python while
+  uncommon schemas remain possible.
+- Includes: a low-ceremony scan-plan shape for common 1D, 2D, N-D, and trace
+  cases; dict/literal-friendly authoring where useful; optional convenience
+  helpers; and raw schema construction for advanced users.
+- Excludes: a fixed framework-specific helper name, a framework-specific
+  parameter-object model, treating first-draft helper syntax as accepted
+  without usage feedback, a visual sweep builder, or a managed execution plan.
+
+CAP-029: Passive procedure summary.
+
+- Promise: users can describe the procedure that produced data even when Fricon
+  did not execute that procedure.
+- Includes: unmanaged script summary, external-runner reference, declared plan
+  summary, and operator correction.
+- Excludes: managed measurement plans, resumable execution, and scan-point
+  checkpoints.
+
+CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
+
+- Promise: users can translate new Data Vault-style scripts to Fricon writers
+  without a full experiment-stack rewrite.
+- Includes: natural mapping for independent/dependent variables, labels, units,
+  legends, old path aliases, and numbered legacy titles as metadata.
+- Excludes: a LabRAD compatibility server, built-in Data Vault parser, or old
+  history browser.
 
 CAP-031: Run manifest and failure investigation.
 
@@ -321,14 +304,14 @@ CAP-032: Routine recipes and reviewed replay.
   mutation-capable automation; durable mutation requires the reviewed proposal
   and audit model described by future specs and ADRs.
 
-## Product Grouping
+CAP-033: Run-bound local configuration snapshot.
 
-Use these planning groups when routing product work:
-
-- Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
-- MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007,
-  CAP-028, CAP-030.
-- Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
-  CAP-029, CAP-033.
-- Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
-- Post-MVP foundation: CAP-018 through CAP-025, CAP-031, CAP-032.
+- Promise: a measurement can bind selected local configuration files,
+  references, hashes, or summaries so later analysis can identify the effective
+  lab-local state without reading copied folders by hand.
+- Includes: user-selected parameter files, registry files, wiring references,
+  line/chip information, demod/readout settings, runner labels, source aliases,
+  privacy-aware export selection, and correction history.
+- Excludes: automatic tracing of every file read, global parameter profiles,
+  calibration promotion, device control, or claiming unmanaged execution was
+  fully reproducible.

--- a/docs-next/product/future-concepts.md
+++ b/docs-next/product/future-concepts.md
@@ -32,7 +32,9 @@ The priority order is a planning default, not a release-number commitment. A
 lower-priority item can move earlier only when it is small, compatible, and does
 not weaken the higher-priority product model.
 
-## Priority 1: Parameter System
+## Priority Index
+
+### Priority 1: Parameter System
 
 Why first:
 
@@ -46,12 +48,7 @@ Why first:
 - Managed runs and automation workflows need a parameter model to avoid
   recording only half of the experiment record.
 
-Included concepts:
-
-- FC-004: Parameter profiles, immutable run-bound snapshot binding, history,
-  proposals, diff views, and table row keys usable as lightweight target keys.
-- FC-014: Measurement history and compare views generated from captured
-  parameter, setup, lifecycle, code, and artifact facts.
+Included concepts: FC-004, FC-014.
 
 Boundary:
 
@@ -61,16 +58,16 @@ Boundary:
 - Use lightweight proposals with actor, reason, approval history, before/after
   diffs, source evidence, and rollback target where practical.
 - Treat calibration-derived values as proposed parameter changes first. A
-  calibration can produce evidence, fitted values, and affected parameter
-  paths without directly mutating a durable named profile.
+  calibration can produce evidence, fitted values, and affected parameter paths
+  without directly mutating a durable named profile.
 - Treat sample target binding as a convention first: parameter table row keys
-  may be reused by visualization code and snapshot queries, but Fricon does
-  not need a mandatory sample-component ontology in the first parameter slice.
+  may be reused by visualization code and snapshot queries, but Fricon does not
+  need a mandatory sample-component ontology in the first parameter slice.
 - Do not require a full permissions system, strict global registry, or device
   write-back for the first parameter slice. A mandatory field-level confidence
   taxonomy is also deferred unless a concrete workflow proves it is needed.
 
-## Priority 2: Managed Run
+### Priority 2: Managed Run
 
 Why second:
 
@@ -84,16 +81,7 @@ Why second:
 - Managed run should grow from ordinary importable Python code, not from a
   separate experiment DSL.
 
-Included concepts:
-
-- FC-003: Measurement-code source setup that replaces copied-code folders with
-  approved-code update flows, local checkout/environment guidance, and no
-  central Fricon server.
-- FC-007: Managed code snapshots and opt-in managed run capture.
-- FC-014: Operator handoff and run history views generated from captured facts.
-- FC-017: Run manifest and investigation record linking parameter snapshot,
-  target keys, code/environment summary, lifecycle, logs, artifacts, and
-  failure/anomaly evidence.
+Included concepts: FC-003, FC-007, FC-014, FC-017.
 
 Boundary:
 
@@ -107,7 +95,7 @@ Boundary:
 - Queues, resource leases, retries, workflow DAGs, and resumable execution are
   later or ADR-gated.
 
-## Priority 3: Calibration Chains And Reviewable Automation
+### Priority 3: Calibration Chains And Reviewable Automation
 
 Why third:
 
@@ -127,20 +115,8 @@ Why third:
 - AI-assisted workflow is only acceptable after the audit and review model
   exists.
 
-Included concepts:
-
-- FC-005: Analysis records that consume artifacts and produce derived outputs.
-- FC-006: Calibration records with reviewable proposals.
-- FC-008: Device identity and managed communication.
-- FC-009: Managed measurement plans.
-- FC-015: Workflow preview layer for calibration, benchmark, and reviewed
-  automation flows.
-- FC-010: AI-assisted automation after the audit model exists.
-- FC-018: Routine recipes, reviewed replay, and batch compare for repetitive
-  work after parameter and run facts are trustworthy.
-- FC-019: Desired-state setup/device planning, reconciliation diffs, and
-  reviewed apply plans for routines where imperative nested loops are too
-  error-prone.
+Included concepts: FC-005, FC-006, FC-008, FC-009, FC-010, FC-015, FC-018,
+  FC-019.
 
 Boundary:
 
@@ -150,8 +126,8 @@ Boundary:
   provenance option for routines that can declare pure parameter-to-state
   functions and explicit hardware constraints.
 - Calibration workflows for sample/control parameters should first create
-  durable evidence, fitted values, health decisions, and promotion proposals.
-  A bootstrap calibration sequence should be able to continue through healthy
+  durable evidence, fitted values, health decisions, and promotion proposals. A
+  bootstrap calibration sequence should be able to continue through healthy
   substeps by updating a chain-scoped calibration working ref, without asking
   for approval at every small update. Publishing selected results to durable
   named profiles remains a separate promotion step.
@@ -160,30 +136,150 @@ Boundary:
 - Device write-back, resumable execution, and AI-assisted mutation need safety,
   readback, partial-failure, and audit ADRs.
 - Reconciliation must not assume device writes are commutative, idempotent, or
-  safe to parallelize. Apply plans need dependency, settling, readback,
-  timeout, and abort semantics before they can reach hardware.
+  safe to parallelize. Apply plans need dependency, settling, readback, timeout,
+  and abort semantics before they can reach hardware.
 - Read-only compare, triage, and preview workflows may arrive before
   mutation-capable automation if they reuse the same record and review model.
 - A broad workflow DAG engine is not the normal way to run ordinary
   measurements.
 
-## Supporting Or Lower-Priority Concepts
+### Supporting Or Lower-Priority Concepts
 
-- FC-001: Read-only LAN monitoring for viewing, browsing, and export without
-  remote writes.
-- FC-002: Rich sample fields, user-defined 2D sample-map configs/DSLs, sample
-  visualizers, and saved views. These may map parameter row keys or user labels
-  to visual regions and color/query parameter snapshots without owning sample
-  identity or sample geometry.
-- FC-011: Resumable execution checkpoints with a managed runner.
-- FC-012: External large asset references for detector files, images, and
-  waveforms.
-- FC-013: User-facing dataset streams, if internal stream support proves useful
-  enough to expose later.
-- FC-016: Applying stored parameter or setup state back to devices.
+Included concepts: FC-001, FC-002, FC-011, FC-012, FC-013, FC-016.
 
 Candidate post-MVP stories and requirements live in
 `product/future-stories-and-requirements.md`.
+
+## Future Concept Definitions
+
+FC-001: Read-only LAN monitoring.
+
+- Intent: support viewing, browsing, and export from trusted local-network
+  clients without remote writes.
+- Boundary: this remains outside the MVP data-writing loop.
+
+FC-002: Rich sample maps and saved views.
+
+- Intent: support rich sample fields, user-defined 2D sample-map configs/DSLs,
+  sample visualizers, and saved views.
+- Boundary: sample maps may use parameter row keys or user labels to visual
+  regions and color/query parameter snapshots, but they must not own sample
+  identity or sample geometry by default.
+
+FC-003: Measurement-code source setup.
+
+- Intent: replace copied-code folders with approved-code update flows, local
+  checkout/environment guidance, and no central Fricon server.
+- Boundary: this manages provenance setup before moving into managed execution.
+
+FC-004: Parameter profiles and run-bound snapshots.
+
+- Intent: introduce parameter profiles, immutable run-bound snapshot binding,
+  history, proposals, diff views, and table row keys usable as lightweight
+  target keys.
+- Boundary: start with a hybrid parameter tree and lightweight proposal flow,
+  not a mandatory global registry or device write-back system.
+
+FC-005: Analysis records.
+
+- Intent: represent analysis records that consume artifacts and produce derived
+  outputs.
+- Boundary: analysis records cite inputs and generated outputs without becoming
+  a full publication notebook.
+
+FC-006: Calibration records with reviewable proposals.
+
+- Intent: preserve calibration evidence, fitted values, affected parameter
+  paths, health decisions, and promotion proposals.
+- Boundary: calibration-derived values flow through reviewable proposals or
+  working refs before durable named profiles change.
+
+FC-007: Managed code snapshots and opt-in managed run capture.
+
+- Intent: capture managed code snapshots and run context when users opt in to a
+  higher-provenance SDK runner.
+- Boundary: ordinary interactive unmanaged Python remains valid and labeled.
+
+FC-008: Device identity and managed communication.
+
+- Intent: introduce explicit device identity and managed communication
+  boundaries.
+- Boundary: device write-back requires safety, readback, partial-failure, and
+  audit ADRs.
+
+FC-009: Managed measurement plans.
+
+- Intent: support managed measurement plans for routines that need more
+  structure than ordinary Python logging.
+- Boundary: plans must not make a broad workflow DAG the normal way to run
+  ordinary measurements.
+
+FC-010: AI-assisted automation.
+
+- Intent: allow AI-assisted workflow after the audit and review model exists.
+- Boundary: AI may propose or summarize, but mutation enters through reviewed
+  proposal paths.
+
+FC-011: Resumable execution checkpoints.
+
+- Intent: add resumable execution checkpoints with a managed runner.
+- Boundary: this is later or ADR-gated and should not complicate unmanaged MVP
+  recovery.
+
+FC-012: External large asset references.
+
+- Intent: reference detector files, images, waveforms, and other large external
+  assets.
+- Boundary: this avoids turning the MVP into a general media asset library.
+
+FC-013: User-facing dataset streams.
+
+- Intent: expose user-facing dataset streams if internal stream support proves
+  useful enough.
+- Boundary: streams should not pull the product back to a dataset-first model.
+
+FC-014: Experiment history, compare, and handoff.
+
+- Intent: generate measurement history, compare views, operator handoff, and
+  run history from captured parameter, setup, lifecycle, code, artifact, and
+  operator facts.
+- Boundary: views are generated from recorded facts and should expose missing
+  provenance instead of hiding it.
+
+FC-015: Workflow preview layer.
+
+- Intent: preview calibration, benchmark, and reviewed automation flows before
+  mutation.
+- Boundary: preview must classify intended reads, writes, generated records,
+  durable state changes, and ADR-gated device or OS/network effects.
+
+FC-016: Applying stored state back to devices.
+
+- Intent: apply stored parameter or setup state back to devices.
+- Boundary: apply behavior remains ADR-gated until safety, readback,
+  partial-failure, and audit behavior are accepted.
+
+FC-017: Run manifest and investigation record.
+
+- Intent: link parameter snapshot, target keys, code/environment summary,
+  lifecycle, logs, artifacts, diagnostics, previous-good baselines, and
+  failure/anomaly evidence.
+- Boundary: the manifest is a composite view over available facts, not a
+  duplicate owner of parameter, code, setup, analysis, or artifact records.
+
+FC-018: Routine recipes, reviewed replay, and batch compare.
+
+- Intent: support repetitive work after parameter and run facts are trustworthy.
+- Boundary: read-only batch compare or triage can arrive before
+  mutation-capable automation; durable mutation requires reviewed proposal and
+  audit semantics.
+
+FC-019: Desired-state setup/device planning.
+
+- Intent: support setup/device planning, reconciliation diffs, and reviewed
+  apply plans for routines where imperative nested loops are too error-prone.
+- Boundary: reconciliation must not assume device writes are commutative,
+  idempotent, or safe to parallelize.
 
 ## Deferred Discussion Topics
 

--- a/docs-next/product/future-stories-and-requirements.md
+++ b/docs-next/product/future-stories-and-requirements.md
@@ -38,7 +38,63 @@ boundaries. This backlog may mention those terms, but it should not become the
 canonical definition for calibration, run manifests, working refs, or
 setup/device reconciliation.
 
-## Priority 1: Parameter System
+## Priority Index
+
+### Priority 1: Parameter System
+
+- Epics: FEPIC-001.
+- Stories: FUS-001, FUS-002, FUS-003, FUS-004, FUS-008, FUS-015.
+- Requirements: FREQ-001, FREQ-002, FREQ-003, FREQ-004, FREQ-005, FREQ-016,
+  FREQ-020, FREQ-023.
+
+Not first parameter slice:
+
+- Device write-back.
+- Strict global registry for every parameter.
+- Permissions, compliance, or multi-user approval system.
+- Automatic tracing of every parameter read without explicit design.
+- A mandatory field-level confidence taxonomy for every parameter value.
+- Heavyweight sample-component ontology.
+- Mandatory 2D sample-map authoring.
+- Visualizer schema migration or compatibility policy.
+
+### Priority 2: Managed Run
+
+- Epics: FEPIC-002, FEPIC-003.
+- Stories: FUS-005, FUS-006, FUS-007, FUS-009, FUS-010, FUS-016, FUS-017,
+  FUS-019.
+- Requirements: FREQ-006, FREQ-007, FREQ-008, FREQ-009, FREQ-010, FREQ-017,
+  FREQ-018, FREQ-021.
+
+Not first managed-run slice:
+
+- Scheduler, queues, resource leases, broad retry policy, or workflow DAG.
+- Resumable scan-point execution.
+- Making managed execution mandatory for ordinary exploratory scripts.
+- Treating shell-command wrapping as the primary runner UX.
+
+### Priority 3: Calibration Chains And Reviewable Automation
+
+- Epics: FEPIC-004, FEPIC-005.
+- Stories: FUS-011, FUS-012, FUS-013, FUS-014, FUS-018, FUS-020, FUS-021.
+- Requirements: FREQ-011, FREQ-012, FREQ-013, FREQ-014, FREQ-015, FREQ-019,
+  FREQ-022, FREQ-024, FREQ-025, FREQ-026, FREQ-027, FREQ-028, FREQ-029.
+
+Not first automation slice:
+
+- AI autonomous mutation.
+- Unreviewed recipe replay that mutates parameters, setup, devices, code
+  sources, or data-library state.
+- Device write-back before store/diff, readback, safety, and partial-failure
+  behavior are accepted by ADR.
+- Fully automatic calibration writeback before code provenance, parameter
+  proposals, calibration evidence, and rollback paths are durable.
+- A general optimizer that rewrites arbitrary imperative scan loops into
+  parallel device operations.
+- Generic workflow DAG engine as the normal way to run ordinary measurements.
+- Cloud-first dashboard, account, or team-permission system.
+
+## Future Epics
 
 FEPIC-001: Parameter System And Snapshot Binding.
 
@@ -50,6 +106,61 @@ FEPIC-001: Parameter System And Snapshot Binding.
   display hints, and UI affordances.
 - Table sections can expose user-defined row keys that later visualization
   tools can treat as target keys.
+
+FEPIC-002: Managed Code Source And Run Capture.
+
+- Users configure measurement code sources without copying folders by hand.
+- Users can mark importable Python entry points for opt-in Fricon management.
+- Fricon can capture code snapshot, SDK runner entry point, environment
+  summary, stdout/stderr, status, diagnostics, and produced artifacts.
+- Fricon can assemble a compact run manifest for compare, handoff, export, and
+  failure investigation.
+- Managed run improves provenance coverage; it does not by itself guarantee
+  scientific reproducibility without parameter, setup/device, environment, and
+  calibration coverage.
+- Ordinary interactive unmanaged Python remains possible, but shows lower
+  provenance coverage.
+
+FEPIC-003: Measurement History, Compare, And Handoff.
+
+- Measurement history is assembled from parameter snapshots, code snapshots,
+  setup summaries, lifecycle events, operator labels, and artifact links.
+- Users compare runs and see what changed since the last session.
+
+FEPIC-004: Setup And Calibration State Store/Diff.
+
+- Users record setup/device state and calibration-task evidence as structured
+  snapshots and ledgers.
+- Fricon can diff and bind state to runs without applying settings to devices.
+- Later, Fricon can separate desired setup/device state from observed
+  setup/device status so managed routines can compute reconciliation plans
+  before touching hardware.
+- Setup snapshots, device snapshots, calibration task records, and calibration
+  ledgers are related but distinct: setup records declared or passive context;
+  device snapshots record identity and observed/readback facts when available;
+  calibration task records preserve measurement evidence, fitted values,
+  diagnostics, and health decisions.
+- The first calibration-state value is not autonomous device control. It is
+  making calibration evidence, affected parameters, task health, retry/pause
+  decisions, and promoted parameter changes inspectable enough that users can
+  trust the next run.
+
+FEPIC-005: Calibration Chains And Reviewable Automation Workflow.
+
+- Users can preview automation actions before they mutate durable Fricon state,
+  device state, named parameter refs, or calibration records.
+- Automation proposals record intended inputs, expected mutations, affected
+  objects, actor, review outcome, and audit events.
+- Automation grows from parameter system and managed run records instead of
+  becoming an unrelated workflow engine.
+- Automation may eventually reconcile declared desired state against current
+  state, but only through plans that expose dependencies, parallelization,
+  settle/readback checks, and failure handling.
+- Automation records are distinct from managed measurement execution: reusable
+  recipes, previewable proposals, review decisions, and execution records each
+  own different facts.
+
+## Future User Stories
 
 FUS-001: Maintain named parameter profiles.
 
@@ -89,94 +200,6 @@ FUS-004: Promote a good run into a parameter proposal.
 - Success: this is a lightweight proposal flow, not a permissions or compliance
   system.
 
-FUS-008: Run like a previous measurement.
-
-- As an experimentalist, I want to start from a previous measurement's scan
-  schema, parameter snapshot, code source, sample/session context, and plot
-  layout so that repeat work is faster without hiding what changed.
-- Success: reused facts are copied by reference or snapshot, and changes are
-  shown before the new run starts.
-- Success: the new run starts from a draft with visible differences from the
-  source run; nothing starts or mutates until the user confirms.
-- Success: unmanaged source facts remain labeled unmanaged instead of being
-  promoted to managed provenance.
-- Success: calibration-derived parameters remain tied to their source evidence
-  instead of becoming anonymous copied values.
-
-FUS-015: Use parameter row keys as visual targets.
-
-- As an experimentalist, I want parameter table row keys to carry enough
-  user-defined target identity that a sample visualization can locate objects
-  without Fricon imposing a sample-component ontology.
-- Success: a row key can be matched to a user-authored sample-map config, DSL,
-  or lab script when such a view exists.
-- Success: color maps and numeric labels can be derived from parameter snapshot
-  queries, not from hardcoded sample object fields.
-- Success: a visualizer definition can be discoverable near the relevant sample
-  or session without making its shape model part of core sample identity.
-- Success: unmatched or ambiguous keys remain visible as data-quality issues,
-  not hidden failures.
-
-Parameter requirements:
-
-- FREQ-001: The parameter model is a hybrid structured tree. Flexible nodes are
-  valid by default, and selected nodes can carry typed definitions, units,
-  validation, display hints, and documentation.
-- FREQ-002: Named parameter refs resolve to immutable snapshots before a
-  managed or unmanaged measurement records data.
-- FREQ-003: Runtime parameter overrides are recorded separately from profile
-  snapshots, with actor, time, source, and optional reason.
-- FREQ-004: Parameter diffs are path-aware, unit-aware where units exist, and
-  can compare profile, proposal, effective run snapshot, and override layers.
-- FREQ-005: Parameter profile updates use lightweight proposals with source run
-  or source snapshot, changed fields, actor, reason, approval/rejection
-  outcome, and timestamp. They do not require a permissions system in the first
-  parameter workflow slice.
-- FREQ-023: Calibration-derived parameter changes must flow through parameter
-  proposals, calibration proposals, or chain-scoped calibration working refs.
-  Direct edits to durable named parameter refs should not be the normal
-  automation path.
-- FREQ-016: Parameter table rows can expose stable, user-defined target keys
-  for visualization and compare views. Fricon must not require those keys to
-  imply a first-class physical sample-component model.
-- FREQ-020: Sample visualizers, when introduced, should be modeled as views
-  over parameter snapshots and snapshot query results. Their storage location,
-  query language, and schema-evolution policy remain deferred until a dedicated
-  spec or ADR.
-
-Not first parameter slice:
-
-- Device write-back.
-- Strict global registry for every parameter.
-- Permissions, compliance, or multi-user approval system.
-- Automatic tracing of every parameter read without explicit design.
-- A mandatory field-level confidence taxonomy for every parameter value.
-- Heavyweight sample-component ontology.
-- Mandatory 2D sample-map authoring.
-- Visualizer schema migration or compatibility policy.
-
-## Priority 2: Managed Run
-
-FEPIC-002: Managed Code Source And Run Capture.
-
-- Users configure measurement code sources without copying folders by hand.
-- Users can mark importable Python entry points for opt-in Fricon management.
-- Fricon can capture code snapshot, SDK runner entry point, environment
-  summary, stdout/stderr, status, diagnostics, and produced artifacts.
-- Fricon can assemble a compact run manifest for compare, handoff, export, and
-  failure investigation.
-- Managed run improves provenance coverage; it does not by itself guarantee
-  scientific reproducibility without parameter, setup/device, environment, and
-  calibration coverage.
-- Ordinary interactive unmanaged Python remains possible, but shows lower
-  provenance coverage.
-
-FEPIC-003: Measurement History, Compare, And Handoff.
-
-- Measurement history is assembled from parameter snapshots, code snapshots,
-  setup summaries, lifecycle events, operator labels, and artifact links.
-- Users compare runs and see what changed since the last session.
-
 FUS-005: Configure a measurement code source.
 
 - As an experimentalist, I want to register a local or remote code source,
@@ -208,6 +231,20 @@ FUS-007: Run through an opt-in SDK runner.
 - Success: the first managed-runner slice does not need queues, resource
   scheduling, retries, or broad workflow DAG execution.
 
+FUS-008: Run like a previous measurement.
+
+- As an experimentalist, I want to start from a previous measurement's scan
+  schema, parameter snapshot, code source, sample/session context, and plot
+  layout so that repeat work is faster without hiding what changed.
+- Success: reused facts are copied by reference or snapshot, and changes are
+  shown before the new run starts.
+- Success: the new run starts from a draft with visible differences from the
+  source run; nothing starts or mutates until the user confirms.
+- Success: unmanaged source facts remain labeled unmanaged instead of being
+  promoted to managed provenance.
+- Success: calibration-derived parameters remain tied to their source evidence
+  instead of becoming anonymous copied values.
+
 FUS-009: Compare two measurements.
 
 - As an experimentalist, I want to compare runs by parameters, code, sample,
@@ -225,110 +262,6 @@ FUS-010: See operator handoff.
   calibration due/expired state, failed runs, imports, exports, and notes.
 - Success: handoff distinguishes facts, warnings, decisions, and missing
   provenance so the next operator knows what remains uncertain.
-
-FUS-016: Inspect a run manifest.
-
-- As an experimentalist, I want a run manifest that links the available
-  measurement, parameter snapshot, row/target keys, code/environment summary,
-  lifecycle, logs, artifacts, operator, and timestamps so that I can understand
-  a run without opening several unrelated stores.
-- Success: the manifest can be opened from Desktop, Python, and export bundles.
-- Success: the manifest states provenance coverage instead of implying that
-  unmanaged work was fully captured.
-- Success: the manifest is a composite view over recorded facts; it does not
-  own or duplicate parameter, code, setup, analysis, or artifact records.
-
-FUS-017: Investigate a failed fit or anomalous measurement.
-
-- As an experimentalist, I want to follow a suspicious result back to inputs,
-  parameter changes, code/environment state, setup labels, logs, and analysis
-  attempts so that tedious failure investigation is not a manual archaeology
-  task.
-- Success: failed or questionable analysis/fit attempts can be recorded with
-  input artifacts, method/code reference, quality metrics, failure reason, and
-  produced outputs when available.
-- Success: comparison to a previous-good run is generated from recorded facts.
-- Success: investigation can show whether code, parameter snapshot, generated
-  sidecars, or calibration evidence changed from the previous-good baseline.
-
-FUS-019: Record measurement intent and outcome.
-
-- As an experimentalist, I want to record the question, intent, outcome, and
-  trust decision for a measurement so that future compare, handoff, and repeat
-  work can use more than raw data and filenames.
-- Success: intent can be recorded before or during a run, and outcome can be
-  recorded after review.
-- Success: outcomes can link to datasets, analysis attempts, notes, and
-  lifecycle events.
-- Success: lightweight labels such as accepted, questionable, invalidated, or
-  repeat-needed can explain review state without becoming a full ELN.
-
-Managed-run requirements:
-
-- FREQ-006: Managed code provenance records source URI/path, selected revision,
-  dirty state, source hashes where practical, SDK runner entry point, runner
-  invocation, and environment summary.
-- FREQ-007: Fricon shows provenance level and coverage instead of claiming
-  reproducibility from Git metadata alone.
-- FREQ-008: The first managed-runner slice is SDK runner integration. It
-  captures stdout/stderr excerpts or logs, start/end timestamps, status,
-  abort/fail reason, produced artifacts, and diagnostic warnings.
-- FREQ-009: The first managed-runner slice is not a scheduler. Queues, resource
-  management, retries, and workflow DAG execution are later or ADR-gated.
-- FREQ-010: Run history and compare views are generated from recorded facts:
-  parameters, code, setup, lifecycle events, notes, operator labels, and
-  artifacts.
-- FREQ-017: A run manifest links the durable measurement identity to parameter
-  snapshot/ref facts, row/target keys when present, code/environment summary,
-  lifecycle/log events, artifacts, operator, timestamps, and provenance
-  coverage.
-- FREQ-018: Analysis or fit attempts can be represented as investigation
-  records with inputs, method/code reference, status, diagnostics, quality
-  metrics, failure reason, and outputs when available.
-- FREQ-021: Measurement intent and outcome records preserve question, decision,
-  linked evidence, actor, timestamp, and review state without turning Fricon
-  into a full ELN.
-Not first managed-run slice:
-
-- Scheduler, queues, resource leases, broad retry policy, or workflow DAG.
-- Resumable scan-point execution.
-- Making managed execution mandatory for ordinary exploratory scripts.
-- Treating shell-command wrapping as the primary runner UX.
-
-## Priority 3: Calibration Chains And Reviewable Automation
-
-FEPIC-004: Setup And Calibration State Store/Diff.
-
-- Users record setup/device state and calibration-task evidence as structured
-  snapshots and ledgers.
-- Fricon can diff and bind state to runs without applying settings to devices.
-- Later, Fricon can separate desired setup/device state from observed
-  setup/device status so managed routines can compute reconciliation plans
-  before touching hardware.
-- Setup snapshots, device snapshots, calibration task records, and calibration
-  ledgers are related but distinct: setup records declared or passive context;
-  device snapshots record identity and observed/readback facts when available;
-  calibration task records preserve measurement evidence, fitted values,
-  diagnostics, and health decisions.
-- The first calibration-state value is not autonomous device control. It is
-  making calibration evidence, affected parameters, task health, retry/pause
-  decisions, and promoted parameter changes inspectable enough that users can
-  trust the next run.
-
-FEPIC-005: Calibration Chains And Reviewable Automation Workflow.
-
-- Users can preview automation actions before they mutate durable Fricon state,
-  device state, named parameter refs, or calibration records.
-- Automation proposals record intended inputs, expected mutations, affected
-  objects, actor, review outcome, and audit events.
-- Automation grows from parameter system and managed run records instead of
-  becoming an unrelated workflow engine.
-- Automation may eventually reconcile declared desired state against current
-  state, but only through plans that expose dependencies, parallelization,
-  settle/readback checks, and failure handling.
-- Automation records are distinct from managed measurement execution: reusable
-  recipes, previewable proposals, review decisions, and execution records each
-  own different facts.
 
 FUS-011: Store and diff setup snapshots.
 
@@ -356,6 +289,91 @@ FUS-012: Track calibration state.
   assessment, and manual rationale can be preserved when they materially affect
   whether a calibration should be used.
 
+FUS-013: Preview an automation workflow.
+
+- As an experimentalist, I want a proposed automation workflow to show what it
+  will read, run, and mutate before execution so that hidden state changes do
+  not surprise me.
+- Success: preview separates parameter changes, setup/device changes, managed
+  runs, analysis steps, calibration proposals, and data-library mutations.
+- Success: preview identifies whether each action is read-only, produces a
+  durable record, mutates Fricon state, or reaches an ADR-gated device boundary.
+- Success: calibration automation previews generated artifacts, affected
+  parameter paths, task-chain health gates, before/after diffs for durable
+  promotion, and rollback targets before applying accepted durable changes.
+
+FUS-014: Review and apply automation proposals.
+
+- As a lab maintainer, I want automation proposals to require explicit review
+  before mutating durable lab state so that automation remains accountable.
+- Success: approval, rejection, actor, reason, timestamp, and affected objects
+  are recorded.
+
+FUS-015: Use parameter row keys as visual targets.
+
+- As an experimentalist, I want parameter table row keys to carry enough
+  user-defined target identity that a sample visualization can locate objects
+  without Fricon imposing a sample-component ontology.
+- Success: a row key can be matched to a user-authored sample-map config, DSL,
+  or lab script when such a view exists.
+- Success: color maps and numeric labels can be derived from parameter snapshot
+  queries, not from hardcoded sample object fields.
+- Success: a visualizer definition can be discoverable near the relevant sample
+  or session without making its shape model part of core sample identity.
+- Success: unmatched or ambiguous keys remain visible as data-quality issues,
+  not hidden failures.
+
+FUS-016: Inspect a run manifest.
+
+- As an experimentalist, I want a run manifest that links the available
+  measurement, parameter snapshot, row/target keys, code/environment summary,
+  lifecycle, logs, artifacts, operator, and timestamps so that I can understand
+  a run without opening several unrelated stores.
+- Success: the manifest can be opened from Desktop, Python, and export bundles.
+- Success: the manifest states provenance coverage instead of implying that
+  unmanaged work was fully captured.
+- Success: the manifest is a composite view over recorded facts; it does not
+  own or duplicate parameter, code, setup, analysis, or artifact records.
+
+FUS-017: Investigate a failed fit or anomalous measurement.
+
+- As an experimentalist, I want to follow a suspicious result back to inputs,
+  parameter changes, code/environment state, setup labels, logs, and analysis
+  attempts so that tedious failure investigation is not a manual archaeology
+  task.
+- Success: failed or questionable analysis/fit attempts can be recorded with
+  input artifacts, method/code reference, quality metrics, failure reason, and
+  produced outputs when available.
+- Success: comparison to a previous-good run is generated from recorded facts.
+- Success: investigation can show whether code, parameter snapshot, generated
+  sidecars, or calibration evidence changed from the previous-good baseline.
+
+FUS-018: Replay a routine recipe after review.
+
+- As an experimentalist, I want common compare, run, and analyze routines to be
+  captured as reviewable recipes so that repetitive work is faster without
+  hiding what will change.
+- Success: preview shows parameter refs or overrides, code entry point,
+  expected artifacts, analysis steps, and durable mutations before execution.
+- Success: replay states which routine/code version, parameter snapshot,
+  calibration evidence, generated sidecars, and safety envelope it depends on.
+- Success: read-only batch compare or triage can be useful before
+  mutation-capable automation exists.
+- Success: replay records recipe template, automation proposal, review
+  decision, execution status, produced records, and failure handling separately.
+
+FUS-019: Record measurement intent and outcome.
+
+- As an experimentalist, I want to record the question, intent, outcome, and
+  trust decision for a measurement so that future compare, handoff, and repeat
+  work can use more than raw data and filenames.
+- Success: intent can be recorded before or during a run, and outcome can be
+  recorded after review.
+- Success: outcomes can link to datasets, analysis attempts, notes, and
+  lifecycle events.
+- Success: lightweight labels such as accepted, questionable, invalidated, or
+  repeat-needed can explain review state without becoming a full ELN.
+
 FUS-020: Run a bootstrap calibration chain with health gates.
 
 - As an experimentalist, I want a calibration sequence made of smaller
@@ -375,19 +393,6 @@ FUS-020: Run a bootstrap calibration chain with health gates.
 - Success: rejection, retry, or deferral preserves evidence without mutating
   durable named parameter state.
 
-FUS-013: Preview an automation workflow.
-
-- As an experimentalist, I want a proposed automation workflow to show what it
-  will read, run, and mutate before execution so that hidden state changes do
-  not surprise me.
-- Success: preview separates parameter changes, setup/device changes, managed
-  runs, analysis steps, calibration proposals, and data-library mutations.
-- Success: preview identifies whether each action is read-only, produces a
-  durable record, mutates Fricon state, or reaches an ADR-gated device boundary.
-- Success: calibration automation previews generated artifacts, affected
-  parameter paths, task-chain health gates, before/after diffs for durable
-  promotion, and rollback targets before applying accepted durable changes.
-
 FUS-021: Declare expected setup/device state and reconcile it.
 
 - As an experimentalist, I want a managed routine to describe the expected
@@ -404,82 +409,119 @@ FUS-021: Declare expected setup/device state and reconcile it.
 - Success: imperative scripts remain supported for exploratory work and for
   devices whose side effects are not yet modeled safely.
 
-FUS-014: Review and apply automation proposals.
+## Future Requirements
 
-- As a lab maintainer, I want automation proposals to require explicit review
-  before mutating durable lab state so that automation remains accountable.
-- Success: approval, rejection, actor, reason, timestamp, and affected objects
-  are recorded.
+FREQ-001: The parameter model is a hybrid structured tree. Flexible nodes are
+valid by default, and selected nodes can carry typed definitions, units,
+validation, display hints, and documentation.
 
-FUS-018: Replay a routine recipe after review.
+FREQ-002: Named parameter refs resolve to immutable snapshots before a managed
+or unmanaged measurement records data.
 
-- As an experimentalist, I want common compare, run, and analyze routines to be
-  captured as reviewable recipes so that repetitive work is faster without
-  hiding what will change.
-- Success: preview shows parameter refs or overrides, code entry point,
-  expected artifacts, analysis steps, and durable mutations before execution.
-- Success: replay states which routine/code version, parameter snapshot,
-  calibration evidence, generated sidecars, and safety envelope it depends on.
-- Success: read-only batch compare or triage can be useful before
-  mutation-capable automation exists.
-- Success: replay records recipe template, automation proposal, review
-  decision, execution status, produced records, and failure handling separately.
+FREQ-003: Runtime parameter overrides are recorded separately from profile
+snapshots, with actor, time, source, and optional reason.
 
-Automation requirements:
+FREQ-004: Parameter diffs are path-aware, unit-aware where units exist, and can
+compare profile, proposal, effective run snapshot, and override layers.
 
-- FREQ-011: Setup/device/calibration state supports store, bind, search, and
-  diff before any device write-back is implemented.
-- FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
-  separate ADRs covering safety, readback, partial failure, and audit behavior.
-- FREQ-013: Post-MVP improvements remain local-first: no cloud account, hosted
-  dashboard, or central Fricon server is required for core parameter, run, or
-  automation workflows.
-- FREQ-014: Reviewable automation must produce a preview of intended reads,
-  writes, device interactions, generated records, and failure handling before
-  mutation starts.
-- FREQ-015: Automation records must preserve actor, trigger, reviewed plan,
-  accepted or rejected changes, execution status, produced artifacts, and audit
-  events.
-- FREQ-027: Desired-state routines distinguish desired state, observed/current
-  state, planned actions, attempted writes, readbacks, and final status.
-- FREQ-019: Routine recipes and reviewed replay use parameter snapshots and
-  run manifests as inputs. Read-only compare or triage may run first; mutation
-  requires preview, review, execution status, and audit records.
-- FREQ-022: AI may summarize, propose, or assist, but mutating actions enter as
-  ordinary reviewed proposals. Durable AI-created conclusions record model or
-  tool provenance and privacy-scoped inputs where practical.
-- FREQ-024: Calibration proposals preserve source measurements, analysis
-  attempts, fitted values, affected parameter paths, task health assessments,
-  before/after diffs for durable promotion, code context, review outcome, and
-  rollback target where practical.
-- FREQ-029: Bootstrap calibration chains preserve task order, dependencies,
-  chain-scoped working-ref revisions, health-gate decisions, retries,
-  pause/review reasons, and final promotion outcome.
-- FREQ-025: Automation previews classify intended effects at least as
-  read-only inspection, derived artifact creation, data-library mutation,
-  parameter/profile mutation, device/hardware mutation, or ADR-gated
-  OS/network mutation.
-- FREQ-026: Generated sidecars or derived config files that influence analysis,
-  calibration, or replay are recorded as artifacts with source inputs,
-  generator/code context, and links to the proposal or run that depends on
-  them.
-- FREQ-028: Reconciliation plans may parallelize device writes only when
-  dependency, safety, settle, readback, timeout, and abort semantics are
-  explicit enough for the affected devices and setup.
+FREQ-005: Parameter profile updates use lightweight proposals with source run
+or source snapshot, changed fields, actor, reason, approval/rejection outcome,
+and timestamp. They do not require a permissions system in the first parameter
+workflow slice.
 
-Not first automation slice:
+FREQ-006: Managed code provenance records source URI/path, selected revision,
+dirty state, source hashes where practical, SDK runner entry point, runner
+invocation, and environment summary.
 
-- AI autonomous mutation.
-- Unreviewed recipe replay that mutates parameters, setup, devices, code
-  sources, or data-library state.
-- Device write-back before store/diff, readback, safety, and partial-failure
-  behavior are accepted by ADR.
-- Fully automatic calibration writeback before code provenance, parameter
-  proposals, calibration evidence, and rollback paths are durable.
-- A general optimizer that rewrites arbitrary imperative scan loops into
-  parallel device operations.
-- Generic workflow DAG engine as the normal way to run ordinary measurements.
-- Cloud-first dashboard, account, or team-permission system.
+FREQ-007: Fricon shows provenance level and coverage instead of claiming
+reproducibility from Git metadata alone.
+
+FREQ-008: The first managed-runner slice is SDK runner integration. It captures
+stdout/stderr excerpts or logs, start/end timestamps, status, abort/fail
+reason, produced artifacts, and diagnostic warnings.
+
+FREQ-009: The first managed-runner slice is not a scheduler. Queues, resource
+management, retries, and workflow DAG execution are later or ADR-gated.
+
+FREQ-010: Run history and compare views are generated from recorded facts:
+parameters, code, setup, lifecycle events, notes, operator labels, and
+artifacts.
+
+FREQ-011: Setup/device/calibration state supports store, bind, search, and diff
+before any device write-back is implemented.
+
+FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
+separate ADRs covering safety, readback, partial failure, and audit behavior.
+
+FREQ-013: Post-MVP improvements remain local-first: no cloud account, hosted
+dashboard, or central Fricon server is required for core parameter, run, or
+automation workflows.
+
+FREQ-014: Reviewable automation must produce a preview of intended reads,
+writes, device interactions, generated records, and failure handling before
+mutation starts.
+
+FREQ-015: Automation records must preserve actor, trigger, reviewed plan,
+accepted or rejected changes, execution status, produced artifacts, and audit
+events.
+
+FREQ-016: Parameter table rows can expose stable, user-defined target keys for
+visualization and compare views. Fricon must not require those keys to imply a
+first-class physical sample-component model.
+
+FREQ-017: A run manifest links the durable measurement identity to parameter
+snapshot/ref facts, row/target keys when present, code/environment summary,
+lifecycle/log events, artifacts, operator, timestamps, and provenance coverage.
+
+FREQ-018: Analysis or fit attempts can be represented as investigation records
+with inputs, method/code reference, status, diagnostics, quality metrics,
+failure reason, and outputs when available.
+
+FREQ-019: Routine recipes and reviewed replay use parameter snapshots and run
+manifests as inputs. Read-only compare or triage may run first; mutation
+requires preview, review, execution status, and audit records.
+
+FREQ-020: Sample visualizers, when introduced, should be modeled as views over
+parameter snapshots and snapshot query results. Their storage location, query
+language, and schema-evolution policy remain deferred until a dedicated spec or
+ADR.
+
+FREQ-021: Measurement intent and outcome records preserve question, decision,
+linked evidence, actor, timestamp, and review state without turning Fricon into
+a full ELN.
+
+FREQ-022: AI may summarize, propose, or assist, but mutating actions enter as
+ordinary reviewed proposals. Durable AI-created conclusions record model or
+tool provenance and privacy-scoped inputs where practical.
+
+FREQ-023: Calibration-derived parameter changes must flow through parameter
+proposals, calibration proposals, or chain-scoped calibration working refs.
+Direct edits to durable named parameter refs should not be the normal
+automation path.
+
+FREQ-024: Calibration proposals preserve source measurements, analysis
+attempts, fitted values, affected parameter paths, task health assessments,
+before/after diffs for durable promotion, code context, review outcome, and
+rollback target where practical.
+
+FREQ-025: Automation previews classify intended effects at least as read-only
+inspection, derived artifact creation, data-library mutation, parameter/profile
+mutation, device/hardware mutation, or ADR-gated OS/network mutation.
+
+FREQ-026: Generated sidecars or derived config files that influence analysis,
+calibration, or replay are recorded as artifacts with source inputs,
+generator/code context, and links to the proposal or run that depends on them.
+
+FREQ-027: Desired-state routines distinguish desired state, observed/current
+state, planned actions, attempted writes, readbacks, and final status.
+
+FREQ-028: Reconciliation plans may parallelize device writes only when
+dependency, safety, settle, readback, timeout, and abort semantics are explicit
+enough for the affected devices and setup.
+
+FREQ-029: Bootstrap calibration chains preserve task order, dependencies,
+chain-scoped working-ref revisions, health-gate decisions, retries,
+pause/review reasons, and final promotion outcome.
 
 ## Supporting Candidates
 


### PR DESCRIPTION
## Summary
- Centralize docs-next authoring rules in `ai/documentation-update-policy.md` and keep the top-level README as a short pointer.
- Rework `capability-map.md`, `future-concepts.md`, and `future-stories-and-requirements.md` so stable IDs are defined in ascending order and priority/grouping is kept in separate index sections.
- Tighten the governance docs to reflect the new ID allocation workflow and avoid duplicating the same rules across multiple files.

## Testing
- Docs formatting and repository hygiene checks passed.
- Reviewed the reorganized ID sections to confirm the numbered definitions are now ordered and the duplicate rule blocks were removed.