### PR TITLE
docs: refine personas and role routing

### DIFF
--- a/docs/product/epics/EPIC-001-local-setup-data-library.md
+++ b/docs/product/epics/EPIC-001-local-setup-data-library.md
@@ -6,9 +6,9 @@ Accepted.
 
 ## Product Goal
 
-An experimentalist can install Fricon, create or open one local data library,
-and run Python scripts against it without assembling mismatched Desktop, CLI,
-Python SDK, and local runtime pieces.
+A Local Measurement System Maintainer can install Fricon, create or open one
+local data library, and keep Python scripts runnable against it without
+assembling mismatched Desktop, CLI, Python SDK, and local runtime pieces.
 
 ## MVP Scope
 

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -306,10 +306,17 @@ FUS-013: Preview an automation workflow.
 
 FUS-014: Review and apply automation proposals.
 
-- As a lab maintainer, I want automation proposals to require explicit review
-  before mutating durable lab state so that automation remains accountable.
+- As the accountable domain owner, I want mutation-capable automation proposals
+  to require explicit review before changing durable Fricon state so that
+  automation remains accountable.
 - Success: approval, rejection, actor, reason, timestamp, and affected objects
   are recorded.
+- Success: review routes to the role that owns the affected state: P-004 for
+  parameter or calibration proposals, P-005 for managed-routine or
+  measurement-code proposal shape, and P-003 for durable analysis or
+  interpretation records. P-002 supplies technical readiness checks when the
+  proposal depends on runtime, update, environment, or data-library safety, but
+  is not the default domain approver.
 
 FUS-015: Use parameter row keys as visual targets.
 

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -312,11 +312,14 @@ FUS-014: Review and apply automation proposals.
 - Success: approval, rejection, actor, reason, timestamp, and affected objects
   are recorded.
 - Success: review routes to the role that owns the affected state: P-004 for
-  parameter or calibration proposals, P-005 for managed-routine or
-  measurement-code proposal shape, and P-003 for durable analysis or
-  interpretation records. P-002 supplies technical readiness checks when the
-  proposal depends on runtime, update, environment, or data-library safety, but
-  is not the default domain approver.
+  parameter, effective-configuration, or calibration proposals, P-005 for
+  managed-routine or measurement-code proposal shape, and P-003 for durable
+  analysis or interpretation records. P-002 supplies technical readiness checks
+  when the proposal depends on runtime, update, environment, or data-library
+  safety, but is not the default domain approver.
+- Success: setup or device-state mutation stays ADR-gated and must name an
+  explicit accountable setup/device owner once that role is accepted; it is not
+  routed to P-002 merely because local system readiness is involved.
 
 FUS-015: Use parameter row keys as visual targets.
 

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -163,8 +163,9 @@ FEPIC-005: Calibration Chains And Reviewable Automation Workflow.
 
 FUS-001: Maintain named parameter profiles.
 
-- As an experimentalist, I want refs such as `main`, `latest-good`, or
-  `cooldown-2026-05` so that large parameter sets have memorable identities.
+- As an Effective Configuration & Calibration Steward, I want refs such as
+  `main`, `latest-good`, or `cooldown-2026-05` so that large parameter sets
+  have memorable identities.
 - Success: refs can move, but each run records the immutable snapshot revision
   actually used.
 - Success: ordinary parameters can remain flexible tree nodes; important
@@ -172,24 +173,25 @@ FUS-001: Maintain named parameter profiles.
 
 FUS-002: Bind effective parameters at run start.
 
-- As an experimentalist, I want a measurement to capture the resolved parameter
-  snapshot and runtime overrides so that later analysis can explain the exact
-  effective settings.
+- As an Effective Configuration & Calibration Steward, I want a measurement to
+  capture the resolved parameter snapshot and runtime overrides so that later
+  analysis can explain the exact effective settings.
 - Success: overrides are separate facts with actor, time, source, and optional
   reason.
 
 FUS-003: Compare parameters across runs and proposals.
 
-- As an experimentalist, I want to diff two runs, snapshots, or profiles so
-  that I can find parameter drift without reading JSON files by hand.
+- As an Effective Configuration & Calibration Steward, I want to diff two runs,
+  snapshots, or profiles so that I can find parameter drift without reading
+  JSON files by hand.
 - Success: diffs preserve path, value, unit, source profile, override status,
   actor, and linked run or proposal.
 
 FUS-004: Promote a good run into a parameter proposal.
 
-- As an experimentalist, I want to turn the effective settings from a successful
-  run into a reviewed proposal so that useful adjustments can become a named
-  profile intentionally.
+- As an Effective Configuration & Calibration Steward, I want to turn the
+  effective settings from a successful run into a reviewed proposal so that
+  useful adjustments can become a named profile intentionally.
 - Success: promotion records source run, changed fields, reviewer/actor, and
   approval or rejection outcome.
 - Success: promotion can cite analysis or calibration evidence when the source
@@ -201,9 +203,9 @@ FUS-004: Promote a good run into a parameter proposal.
 
 FUS-005: Configure a measurement code source.
 
-- As an experimentalist, I want to register a local or remote code source,
-  entry point, and environment hint so that Fricon can stop relying on copied
-  folders as the only code provenance story.
+- As a Local Measurement System Maintainer, I want to register a local or
+  remote code source, entry point, and environment hint so that Fricon can stop
+  relying on copied folders as the only code provenance story.
 - Success: source location, selected revision, environment file, and local
   checkout status are visible before a managed run.
 - Success: approved releases, setup profiles, scan-schema helpers,
@@ -214,8 +216,8 @@ FUS-005: Configure a measurement code source.
 
 FUS-006: Capture a managed code snapshot.
 
-- As an experimentalist, I want Fricon to capture Git commit, dirty state,
-  source hashes, dependency summary, SDK runner entry point, and runner
+- As a Measurement Method Author, I want Fricon to capture Git commit, dirty
+  state, source hashes, dependency summary, SDK runner entry point, and runner
   invocation when it starts a managed run so that measurement history is not
   hand-entered.
 - Success: provenance level is visible as unmanaged, observed, or managed
@@ -225,9 +227,10 @@ FUS-006: Capture a managed code snapshot.
 
 FUS-007: Run through an opt-in SDK runner.
 
-- As an experimentalist, I want selected scripts to integrate with a Fricon SDK
-  runner so that Fricon can capture parameters, code snapshot, stdout, stderr,
-  lifecycle, warnings, abort/fail reason, and produced artifacts.
+- As a Measurement Method Author, I want selected scripts to integrate with a
+  Fricon SDK runner so that Fricon can capture parameters, code snapshot,
+  stdout, stderr, lifecycle, warnings, abort/fail reason, and produced
+  artifacts.
 - Success: the unmanaged Python path still works; managed runner is opt-in
   until its safety model is accepted.
 - Success: the first managed-runner slice does not need queues, resource
@@ -235,9 +238,9 @@ FUS-007: Run through an opt-in SDK runner.
 
 FUS-008: Run like a previous measurement.
 
-- As an experimentalist, I want to start from a previous measurement's scan
-  schema, parameter snapshot, code source, sample/session context, and plot
-  layout so that repeat work is faster without hiding what changed.
+- As a Measurement Run Operator, I want to start from a previous measurement's
+  scan schema, parameter snapshot, code source, sample/session context, and
+  plot layout so that repeat work is faster without hiding what changed.
 - Success: reused facts are copied by reference or snapshot, and changes are
   shown before the new run starts.
 - Success: the new run starts from a draft with visible differences from the
@@ -249,17 +252,18 @@ FUS-008: Run like a previous measurement.
 
 FUS-009: Compare two measurements.
 
-- As an experimentalist, I want to compare runs by parameters, code, sample,
-  setup, calibration status, lifecycle, notes, and output artifacts so that I
-  can explain why results differ.
+- As an Experimental Data Analyst, I want to compare runs by parameters, code,
+  sample, setup, calibration status, lifecycle, notes, and output artifacts so
+  that I can explain why results differ.
 - Success: comparison is generated from recorded facts, not a manual report.
 - Success: a previous-good run can be selected as a baseline, and missing or
   incomplete facts are shown rather than hidden.
 
 FUS-010: See operator handoff.
 
-- As a shared-lab user, I want to see what changed since my last session so
-  that I can trust the lab computer state before starting work.
+- As a Measurement Run Operator on a shared lab computer, I want to see what
+  changed since my last session so that I can trust the lab computer state
+  before starting work.
 - Success: handoff includes parameter ref changes, setup snapshot changes,
   calibration due/expired state, failed runs, imports, exports, and notes.
 - Success: handoff distinguishes facts, warnings, decisions, and missing
@@ -267,8 +271,8 @@ FUS-010: See operator handoff.
 
 FUS-011: Store and diff setup snapshots.
 
-- As an experimentalist, I want structured setup snapshots for devices,
-  software, firmware, driver versions, connection labels, and readback
+- As an accountable setup/device owner, I want structured setup snapshots for
+  devices, software, firmware, driver versions, connection labels, and readback
   freshness so that setup drift is inspectable.
 - Success: Fricon can diff snapshots and bind a snapshot to a run without
   controlling devices.
@@ -277,9 +281,9 @@ FUS-011: Store and diff setup snapshots.
 
 FUS-012: Track calibration state.
 
-- As an experimentalist, I want calibration records with source measurements,
-  fitted values, diagnostics, health decisions, and affected-run links so that
-  questionable data can be reviewed.
+- As an Effective Configuration & Calibration Steward, I want calibration
+  records with source measurements, fitted values, diagnostics, health
+  decisions, and affected-run links so that questionable data can be reviewed.
 - Success: records can distinguish sample/control-parameter calibration from
   instrument/device calibration.
 - Success: unhealthy or out-of-family task results can pause a calibration
@@ -293,9 +297,9 @@ FUS-012: Track calibration state.
 
 FUS-013: Preview an automation workflow.
 
-- As an experimentalist, I want a proposed automation workflow to show what it
-  will read, run, and mutate before execution so that hidden state changes do
-  not surprise me.
+- As an accountable domain owner, I want a proposed automation workflow to show
+  what it will read, run, and mutate before execution so that hidden state
+  changes do not surprise me.
 - Success: preview separates parameter changes, setup/device changes, managed
   runs, analysis steps, calibration proposals, and data-library mutations.
 - Success: preview identifies whether each action is read-only, produces a
@@ -306,7 +310,7 @@ FUS-013: Preview an automation workflow.
 
 FUS-014: Review and apply automation proposals.
 
-- As the accountable domain owner, I want mutation-capable automation proposals
+- As an accountable domain owner, I want mutation-capable automation proposals
   to require explicit review before changing durable Fricon state so that
   automation remains accountable.
 - Success: approval, rejection, actor, reason, timestamp, and affected objects
@@ -318,14 +322,16 @@ FUS-014: Review and apply automation proposals.
   when the proposal depends on runtime, update, environment, or data-library
   safety, but is not the default domain approver.
 - Success: setup or device-state mutation stays ADR-gated and must name an
-  explicit accountable setup/device owner once that role is accepted; it is not
-  routed to P-002 merely because local system readiness is involved.
+  explicit accountable setup/device owner once setup/device mutation is in
+  scope; it is not routed to P-002 merely because local system readiness is
+  involved.
 
 FUS-015: Use parameter row keys as visual targets.
 
-- As an experimentalist, I want parameter table row keys to carry enough
-  user-defined target identity that a sample visualization can locate objects
-  without Fricon imposing a sample-component ontology.
+- As an Effective Configuration & Calibration Steward, I want parameter table
+  row keys to carry enough user-defined target identity that a sample
+  visualization can locate objects without Fricon imposing a sample-component
+  ontology.
 - Success: a row key can be matched to a user-authored sample-map config, DSL,
   or lab script when such a view exists.
 - Success: color maps and numeric labels can be derived from parameter snapshot
@@ -337,10 +343,10 @@ FUS-015: Use parameter row keys as visual targets.
 
 FUS-016: Inspect a run manifest.
 
-- As an experimentalist, I want a run manifest that links the available
-  measurement, parameter snapshot, row/target keys, code/environment summary,
-  lifecycle, logs, artifacts, operator, and timestamps so that I can understand
-  a run without opening several unrelated stores.
+- As an Experimental Data Analyst, I want a run manifest that links the
+  available measurement, parameter snapshot, row/target keys, code/environment
+  summary, lifecycle, logs, artifacts, operator, and timestamps so that I can
+  understand a run without opening several unrelated stores.
 - Success: the manifest can be opened from Desktop, Python, and export bundles.
 - Success: the manifest states provenance coverage instead of implying that
   unmanaged work was fully captured.
@@ -349,10 +355,10 @@ FUS-016: Inspect a run manifest.
 
 FUS-017: Investigate a failed fit or anomalous measurement.
 
-- As an experimentalist, I want to follow a suspicious result back to inputs,
-  parameter changes, code/environment state, setup labels, logs, and analysis
-  attempts so that tedious failure investigation is not a manual archaeology
-  task.
+- As an Experimental Data Analyst, I want to follow a suspicious result back to
+  inputs, parameter changes, code/environment state, setup labels, logs, and
+  analysis attempts so that tedious failure investigation is not a manual
+  archaeology task.
 - Success: failed or questionable analysis/fit attempts can be recorded with
   input artifacts, method/code reference, quality metrics, failure reason, and
   produced outputs when available.
@@ -362,9 +368,9 @@ FUS-017: Investigate a failed fit or anomalous measurement.
 
 FUS-018: Replay a routine recipe after review.
 
-- As an experimentalist, I want common compare, run, and analyze routines to be
-  captured as reviewable recipes so that repetitive work is faster without
-  hiding what will change.
+- As a Measurement Method Author, I want common compare, run, and analyze
+  routines to be captured as reviewable recipes so that repetitive work is
+  faster without hiding what will change.
 - Success: preview shows parameter refs or overrides, code entry point,
   expected artifacts, analysis steps, and durable mutations before execution.
 - Success: replay states which routine/code version, parameter snapshot,
@@ -376,9 +382,9 @@ FUS-018: Replay a routine recipe after review.
 
 FUS-019: Record measurement intent and outcome.
 
-- As an experimentalist, I want to record the question, intent, outcome, and
-  trust decision for a measurement so that future compare, handoff, and repeat
-  work can use more than raw data and filenames.
+- As an Experimental Data Analyst, I want to record the question, intent,
+  outcome, and trust decision for a measurement so that future compare,
+  handoff, and repeat work can use more than raw data and filenames.
 - Success: intent can be recorded before or during a run, and outcome can be
   recorded after review.
 - Success: outcomes can link to datasets, analysis attempts, notes, and
@@ -388,9 +394,10 @@ FUS-019: Record measurement intent and outcome.
 
 FUS-020: Run a bootstrap calibration chain with health gates.
 
-- As an experimentalist, I want a calibration sequence made of smaller
-  calibration tasks to continue automatically through healthy intermediate
-  results, but pause, retry, or ask for review when a task result looks wrong.
+- As an Effective Configuration & Calibration Steward, I want a calibration
+  sequence made of smaller calibration tasks to continue automatically through
+  healthy intermediate results, but pause, retry, or ask for review when a task
+  result looks wrong.
 - Success: each task records source measurements, analysis attempts, fitted
   values, generated sidecars or derived artifacts where relevant, affected
   parameter paths, code context, task status, and health assessment.
@@ -407,10 +414,10 @@ FUS-020: Run a bootstrap calibration chain with health gates.
 
 FUS-021: Declare expected setup/device state and reconcile it.
 
-- As an experimentalist, I want a managed routine to describe the expected
-  setup or device state derived from parameters so that Fricon can compute
-  what actually needs to change instead of every loop body manually writing
-  every device in sequence.
+- As an accountable setup/device owner, I want a managed routine to describe
+  the expected setup or device state derived from parameters so that Fricon can
+  compute what actually needs to change instead of every loop body manually
+  writing every device in sequence.
 - Success: the desired state is a durable plan input separate from observed
   device/readback status and from completed measurement facts.
 - Success: Fricon previews per-device diffs, skipped no-op writes, ordered

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -163,9 +163,9 @@ FEPIC-005: Calibration Chains And Reviewable Automation Workflow.
 
 FUS-001: Maintain named parameter profiles.
 
-- As an Effective Configuration & Calibration Steward, I want refs such as
-  `main`, `latest-good`, or `cooldown-2026-05` so that large parameter sets
-  have memorable identities.
+- As an Effective Configuration Steward, I want refs such as `main`,
+  `latest-good`, or `cooldown-2026-05` so that large parameter sets have
+  memorable identities.
 - Success: refs can move, but each run records the immutable snapshot revision
   actually used.
 - Success: ordinary parameters can remain flexible tree nodes; important
@@ -173,25 +173,25 @@ FUS-001: Maintain named parameter profiles.
 
 FUS-002: Bind effective parameters at run start.
 
-- As an Effective Configuration & Calibration Steward, I want a measurement to
-  capture the resolved parameter snapshot and runtime overrides so that later
-  analysis can explain the exact effective settings.
+- As an Effective Configuration Steward, I want a measurement to capture the
+  resolved parameter snapshot and runtime overrides so that later analysis can
+  explain the exact effective settings.
 - Success: overrides are separate facts with actor, time, source, and optional
   reason.
 
 FUS-003: Compare parameters across runs and proposals.
 
-- As an Effective Configuration & Calibration Steward, I want to diff two runs,
-  snapshots, or profiles so that I can find parameter drift without reading
-  JSON files by hand.
+- As an Effective Configuration Steward, I want to diff two runs, snapshots, or
+  profiles so that I can find parameter drift without reading JSON files by
+  hand.
 - Success: diffs preserve path, value, unit, source profile, override status,
   actor, and linked run or proposal.
 
 FUS-004: Promote a good run into a parameter proposal.
 
-- As an Effective Configuration & Calibration Steward, I want to turn the
-  effective settings from a successful run into a reviewed proposal so that
-  useful adjustments can become a named profile intentionally.
+- As an Effective Configuration Steward, I want to turn the effective settings
+  from a successful run into a reviewed proposal so that useful adjustments can
+  become a named profile intentionally.
 - Success: promotion records source run, changed fields, reviewer/actor, and
   approval or rejection outcome.
 - Success: promotion can cite analysis or calibration evidence when the source
@@ -281,9 +281,9 @@ FUS-011: Store and diff setup snapshots.
 
 FUS-012: Track calibration state.
 
-- As an Effective Configuration & Calibration Steward, I want calibration
-  records with source measurements, fitted values, diagnostics, health
-  decisions, and affected-run links so that questionable data can be reviewed.
+- As an Effective Configuration Steward, I want calibration records with source
+  measurements, fitted values, diagnostics, health decisions, and affected-run
+  links so that questionable data can be reviewed.
 - Success: records can distinguish sample/control-parameter calibration from
   instrument/device calibration.
 - Success: unhealthy or out-of-family task results can pause a calibration
@@ -328,10 +328,9 @@ FUS-014: Review and apply automation proposals.
 
 FUS-015: Use parameter row keys as visual targets.
 
-- As an Effective Configuration & Calibration Steward, I want parameter table
-  row keys to carry enough user-defined target identity that a sample
-  visualization can locate objects without Fricon imposing a sample-component
-  ontology.
+- As an Effective Configuration Steward, I want parameter table row keys to
+  carry enough user-defined target identity that a sample visualization can
+  locate objects without Fricon imposing a sample-component ontology.
 - Success: a row key can be matched to a user-authored sample-map config, DSL,
   or lab script when such a view exists.
 - Success: color maps and numeric labels can be derived from parameter snapshot
@@ -394,10 +393,10 @@ FUS-019: Record measurement intent and outcome.
 
 FUS-020: Run a bootstrap calibration chain with health gates.
 
-- As an Effective Configuration & Calibration Steward, I want a calibration
-  sequence made of smaller calibration tasks to continue automatically through
-  healthy intermediate results, but pause, retry, or ask for review when a task
-  result looks wrong.
+- As an Effective Configuration Steward, I want a calibration sequence made of
+  smaller calibration tasks to continue automatically through healthy
+  intermediate results, but pause, retry, or ask for review when a task result
+  looks wrong.
 - Success: each task records source measurements, analysis attempts, fitted
   values, generated sidecars or derived artifacts where relevant, affected
   parameter paths, code context, task status, and health assessment.

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -4,76 +4,60 @@
 
 Accepted.
 
+## Purpose
+
+These personas are lightweight product-role archetypes for Fricon planning.
+They are not fictional biographies, job titles, a permission model, or a
+replacement for user stories.
+
+Use this document to decide whose goal, risk, or decision a product slice
+serves. Put concrete capabilities, success criteria, and edge cases in user
+stories, future requirements, or domain documents.
+
 ## Grounding
 
-These personas were refined against a representative local lab workspace,
+These archetypes were refined against a representative local lab workspace,
 which shows current practice built around Windows lab folders, Jupyter
 notebooks, LabRAD Data Vault, mutable `parameters.json`/`registry.json` files,
 wiring spreadsheets, generated sidecars, calibration scripts, hardware
 bring-up helpers, backups, and report artifacts.
 
-The personas describe recurring product responsibilities, not fixed job titles.
-One person may move between roles during a single day. A workflow should still
-name the role whose decision, risk, or user outcome it primarily serves.
+They are responsibility views, not fixed people. One person may move between
+roles during a single day.
 
-## Story Role Routing
+## Writing Rules
 
-Existing user stories may use broad legacy wording such as "experimentalist".
-When stories are revised, choose the most specific primary persona from this
-file instead of preserving old role wording by default.
+- Keep each persona short, research-backed, and easy to remember.
+- Describe stable goals, behavior patterns, context, and decision pressure.
+- Do not repeat feature requirements that belong in user stories.
+- Use story modifiers for temporary contexts such as first-time use, offline
+  operation, locked-down machines, interrupted runs, or migration work.
+- Add a new persona only when research shows a durable product responsibility
+  that the existing roles cannot explain.
 
-When several roles participate, use the accountable role as the story's primary
-persona and mention supporting roles in notes or acceptance criteria. Do not
-hide a Fricon technical, analyst, calibration, or measurement-stack concern
-behind the generic experimentalist role.
+## Story Routing
 
-Use the personas this way:
+Choose the persona that owns the story's main outcome:
 
-- Use P-001 Experimentalist for ordinary measurement operation: running,
-  watching, annotating, recovering, reopening, or exporting new measurement
-  work.
-- Use P-002 Fricon Technical Maintainer for Fricon development, deployment,
-  installation, diagnostics, local runtime health, environment setup, migration
-  guidance, support bundles, and shared code setup.
-- Use P-003 Analyst for reopen, analysis, reports, derived artifacts,
-  downstream handoff, mapping/classification provenance, and interpretation
-  context.
-- Use P-004 Calibration and Parameter Steward for calibration evidence,
-  effective configuration selection, parameter diffs, fitted values,
-  accepted/rejected calibration outcomes, and hardware or instrument
-  calibration evidence.
-- Use P-005 Measurement Stack Author for SDK shape, script migration,
-  Data Vault-style helper translation, scan helpers, runner integrations,
-  pulse rules, plotting utilities, and report/export recipes.
+- P-001 Experimentalist: ordinary measurement operation and recovery.
+- P-002 Fricon Technical Maintainer: Fricon deployment, local runtime health,
+  diagnostics, migration support, and technical readiness.
+- P-003 Analyst: reopening, analysis, reports, derived artifacts, downstream
+  handoff, and interpretation provenance.
+- P-004 Calibration and Parameter Steward: calibration evidence, parameter
+  state, fitted values, effective configuration, and rollback decisions.
+- P-005 Measurement Stack Author: reusable measurement code, SDK shape, scan
+  helpers, runner integration, plotting utilities, and report/export recipes.
 
-Do not add a separate future-automation persona unless a future product slice
-uncovers a distinct person with needs that are not already covered by the
-Fricon technical maintainer, calibration steward, or measurement stack author
-roles.
+When several roles participate, use the accountable role as the story's
+primary persona and mention supporting roles in notes or acceptance criteria.
 
-## Role Boundary Principles
-
-- Roles are responsibility views. A person can switch roles, but each product
-  workflow should make the active responsibility explicit.
-- MVP stories should prefer the role that directly experiences the MVP problem.
-  Post-MVP stories should prefer the role that reviews or owns the durable
-  state change.
-- Legacy compatibility belongs at role boundaries as aliases, context,
-  attachments, summaries, or evidence. It should not create a new role unless
-  it creates a durable product responsibility.
-- If a story asks Fricon to mutate durable lab state, the responsible role is
-  never only P-001 Experimentalist. Use the domain owner for the decision:
-  P-004 for parameter or calibration proposals, P-005 for managed-routine or
-  measurement-code proposal shape, and P-003 for durable analysis or
-  interpretation records. P-002 contributes technical guardrails when a
-  proposal depends on Fricon runtime, update, library, or environment safety.
-- Prefer positive ownership over negative exclusions. The sections below state
-  what each role needs and does; avoid writing stories that define a persona
-  mainly by listing other roles' work.
-- Keep the key boundaries simple: P-001 operates measurement work, P-002 keeps
-  Fricon technically usable, P-003 owns analysis and report provenance, P-004
-  owns calibration and parameter-state decisions, and P-005 owns reusable
-  measurement-code and routine shape.
+If a story asks Fricon to mutate durable lab state, the accountable role is
+never only P-001. Route the decision to the state owner: P-004 for parameter
+or calibration proposals, P-005 for managed-routine or measurement-code
+proposal shape, and P-003 for durable analysis or interpretation records.
+P-002 contributes technical guardrails when runtime, update, library, or
+environment safety matters.
 
 ## P-001 Experimentalist
 
@@ -82,239 +66,117 @@ notebooks on lab computers. They may use routines written by a more advanced
 lab member and may only know enough Python to change a scan range, select
 qubits, rerun a cell, or add a note.
 
-Primary responsibilities:
+Goals:
 
-- start and run ordinary unmanaged measurements from Python scripts or
-  notebooks
-- watch live data and inspect recent measurement outputs
-- add lightweight notes, markers, sample/session context, and corrections
-- recover, reopen, and export their own measurements for later work
-- supply enough local context to explain the run without understanding every
-  implementation detail
+- start, watch, annotate, recover, reopen, and export measurement work
+- understand the active sample/session, measurement name, scan shape, units,
+  and selected local context without learning Fricon internals
+- preserve useful partial results when scripts interrupt or long saves fail
 
-Needs:
+Context and pressure:
 
-- low-boilerplate Python recording
-- live feedback while a measurement is running
-- the ability to monitor more than one live measurement or view without
-  disturbing acquisition
-- reliable recovery from interrupted runs
-- easy reopening and export for later analysis
-- visible active sample/session, measurement name, scan axes, units,
-  dependencies, and selected local configuration context
-- no requirement to understand Rust, IPC, storage layout, or database internals
-- no requirement to understand every copied script, generated sidecar,
-  parameter backup, or external runner detail before starting new work
+- often works on Windows, offline, locked-down, or slow-to-update lab machines
+- may depend on Jupyter, Conda or `uv`, LabRAD/Data Vault services, copied
+  folders, dated backups, and mutable local configuration during migration
+- needs Fricon to make ordinary measurement work safer without forcing managed
+  execution first
 
-Constraints:
+Common switches:
 
-- may use Windows lab computers
-- may work on locked-down or offline machines
-- may pin Python environments with `uv.lock`, virtual environments, or lab
-  setup scripts
-- may not update Desktop, local runtime, CLI, and Python SDK together
-- may need Fricon to fail safely during long-running measurements, exports, or
-  local maintenance work
-- may rely on Jupyter, Conda or `uv` environments, LabRAD/Data Vault services,
-  and local folders with dated copies or backups during migration
-
-Observed real-case pressures:
-
-- startup can be a manual sequence of local services and Jupyter
-- measurement data may be saved by dataset IDs and paths that are meaningful
-  locally but fragile for handoff
-- interrupted sweeps and long-running saves need readable partial state, not
-  only a final success/failure bit
-
-Common overlaps:
-
-- uses scripts, scan helpers, and report recipes maintained by P-005
-- asks P-002 for setup, launch, environment, or support-bundle help
-- hands completed or partial runs to P-003 for analysis and reporting
-- becomes P-004 only when evaluating calibration evidence or accepting
-  parameter changes
+- becomes P-004 when deciding whether calibration results should change working
+  parameter state
+- depends on P-005 for reusable routines and P-002 when setup or update
+  problems block measurement work
 
 ## P-002 Fricon Technical Maintainer
 
 The person who develops, deploys, updates, diagnoses, and supports Fricon for a
-lab's local computers and data libraries. This role focuses on Fricon technical
-readiness, local integration, diagnostics, and migration support for the lab
-environment.
+lab's local computers and data libraries.
 
-Primary responsibilities:
+Goals:
 
 - keep Fricon installation, local runtime components, data libraries, Python
-  environments, and update paths usable on lab computers
-- diagnose setup, compatibility, migration, and support problems before users
-  read raw logs
-- help labs migrate gradually from old LabRAD/Data Vault, folder, and parameter
-  file workflows into Fricon
-- define safe support and sharing practices for local code sources and
-  environment setup
-- provide technical guardrails for post-MVP proposals when Fricon runtime,
-  update, data-library, or environment safety matters
+  environments, and update paths technically usable
+- make setup, compatibility, migration, and support problems diagnosable
+  before users read raw logs
+- help labs adopt Fricon gradually while old LabRAD/Data Vault, folder, and
+  parameter-file history remains in place
 
-Needs:
+Context and pressure:
 
-- clear installation and diagnostics
-- explicit split between Fricon install, data-library location, Python
-  environment, and later measurement-code management
-- support for sharing approved measurement code without copying random folders
-- exportable support bundles that are local and redacted by default
-- setup/update guidance that works for offline, locked-down, or slow-to-update
-  lab computers
-- user-facing diagnostics before raw logs, especially for stopped runtime
-  components, locked libraries, stale SDKs, incompatible versions, and
-  migration-required states
-- effective-configuration diagnostics when several dated parameter files,
-  registry files, lock files, wiring sheets, generated line/chip summaries, or
-  local backups may all appear plausible
-- a way to explain which local services, data paths, setting paths, package
-  environments, and generated sidecars were expected during a run
-- migration guidance that lets old LabRAD/Data Vault history remain in place
-  while new work records honest Fricon context
-- technical readiness checks for proposals that depend on local runtime,
+- supports machines that may be offline, locked down, slow to update, or
+  pinned to lab-specific Python environments
+- must handle sensitive local paths, machine names, IP addresses, environment
+  details, and setup files carefully
+- contributes technical readiness checks when a proposal depends on runtime,
   update timing, data-library compatibility, or environment state
 
-Constraints:
+Common switches:
 
-- may support Windows, offline, locked-down, or slow-to-update lab computers
-- may not be the person who wrote the measurement script or understands the
-  scientific intent of a run
-- may need redacted support bundles because paths, IP addresses, machine names,
-  environment details, and setup files can be sensitive
-- may need Fricon to fail before mutation when components, SDKs, or libraries
-  are incompatible
-
-Common overlaps:
-
-- supports P-001 when setup or update problems block measurement work
-- supports P-005 by making shared code sources and environments usable
-- can block or flag proposals that are technically unsafe because of update
-  policy, runtime state, environment state, or data-library compatibility
-- relies on P-004 for calibration-specific acceptance, rejection, and rollback
-  decisions
+- works with P-005 when shared code sources or package environments become
+  lab-maintained assets
+- relies on P-004 or P-003 for scientific acceptance of calibration,
+  parameter, analysis, or interpretation outcomes
 
 ## P-003 Analyst
 
 The person who reopens completed measurements for notebooks, reports, or HPC
-analysis. In practice, this role often produces secondary artifacts such as fit
-results, plots, `.npy` or `.json` derived data, spreadsheets, and slide decks.
+analysis. This role often produces secondary artifacts such as fit results,
+plots, `.npy` or `.json` derived data, spreadsheets, and slide decks.
 
-Primary responsibilities:
+Goals:
 
-- reopen completed, interrupted, or exported measurements through stable
-  Fricon APIs and IDs
-- inspect datasets, scan schema, metadata, lifecycle, and selected provenance
-- produce analysis outputs, derived data, plots, reports, and presentation
-  artifacts
+- reopen completed, interrupted, or exported measurements through stable IDs
+  and APIs
 - preserve links from derived artifacts back to source measurements,
   parameters, code/procedure context, and manual judgment
-- validate supplied mapping, readout-classification, shot-group, or
-  detector/observable context for advanced workflows
-- review durable analysis, interpretation, or report records when they become
-  Fricon-managed evidence instead of notebook-local outputs
+- keep mapping, readout-classification, shot-group, detector, or observable
+  context aligned for advanced analysis workflows
 
-Needs:
+Context and pressure:
 
-- stable IDs and Python reopen snippets
-- direct read access to export bundles
-- simple manifest or index previews in exported bundles
-- metadata and units preserved well enough to understand the data away from the
-  acquisition computer
-- privacy-aware export choices for local paths, code provenance, environment
-  summaries, setup details, and sample context
-- enough lifecycle, parameter, code, and procedure context to tell whether an
-  analysis result came from a completed run, an interrupted run, a calibration
-  retry, or a manually edited notebook state
-- links from derived artifacts back to the measurement inputs they used, even
-  before analysis attempts become first-class post-MVP records
-- report handoff that does not depend on reconstructing local folder state or
-  remembering which notebook cell produced a plot
-- enough mapping, readout-classification, and artifact provenance to trust
-  advanced workflows where simulation qubits, physical qubits, shot groups,
-  detector events, and fitted metrics must stay aligned
-
-Constraints:
-
-- may work away from the acquisition computer or after the run has finished
-- may need export bundles that redact sensitive paths, setup details, code
-  summaries, environment data, or sample context
-- may need to distinguish raw measurement facts from notebook-local analysis
+- often works away from the acquisition computer or after the run has finished
+- needs privacy-aware handoff when exports contain local paths, setup details,
+  code summaries, environment data, or sample context
+- must distinguish recorded measurement facts from notebook-local analysis
   state and manually edited outputs
-- may need Fricon to preserve enough context even before analysis records are
-  first-class post-MVP objects
 
-Common overlaps:
+Common switches:
 
 - consumes measurements produced by P-001
-- may produce evidence that P-004 uses for parameter decisions
-- may use report/export recipes maintained by P-005
-- may ask P-002 for export privacy or support-bundle guidance
+- may provide evidence that P-004 uses for parameter or calibration decisions
+- uses report/export recipes maintained by P-005
 
 ## P-004 Calibration and Parameter Steward
 
-A current lab user who tunes readout, pulse, coupler, crosstalk, demodulation,
-feedback, or hardware bring-up parameters and decides whether fitted values
-should become the next working local configuration. This role may be the
-experimentalist on a small team, but the product pressure is distinct from
-ordinary data collection.
+A lab member who tunes readout, pulse, coupler, crosstalk, demodulation,
+feedback, hardware bring-up, or related parameters and decides whether fitted
+values should become the next working local configuration.
 
-Primary responsibilities:
+Goals:
 
-- run or supervise calibration work that produces evidence, fitted values, and
-  affected parameter paths
-- decide which effective configuration or prior-good state a calibration
+- decide which effective configuration or prior-good state calibration work
   depends on
-- evaluate calibration health, safety gates, fit quality, retry/pause needs,
+- evaluate calibration evidence, fit quality, health gates, retry/pause needs,
   and manual inspection flags
 - mark calibration results as exploratory, accepted, rejected, superseded, or
-  needing review
-- decide whether proposed parameter changes should become working state, and
-  preserve rollback evidence where practical
-- review parameter, calibration, and calibration-derived mutation proposals
-  before they change durable working state
+  needing review, with rollback context where practical
 
-Needs:
+Context and pressure:
 
-- clear links between calibration measurements, input parameter snapshots,
-  generated sidecars, fitted outputs, and any later parameter-file edits
-- safe capture of selected `parameters.json`, `registry.json`, wiring,
-  demodulation, readout, line/chip, and runner summaries at run time
-- diffs or summaries that explain what changed since a previous good
-  calibration or measurement
-- a way to mark calibration results as exploratory, accepted for current work,
-  rejected, superseded, or needing review
-- exported evidence that can explain why a parameter changed without exporting
-  sensitive local paths by default
-- prerequisite and safety checks before long calibration routines, including
-  missing registry values, invalid fitted inputs, alignment failures,
-  instrument output state, and known-good backup state
-- before/after records for hardware or instrument calibration work, including
-  offsets, powers, frequencies, timestamps, and cleanup/stop outcomes when
-  supplied by the unmanaged routine
-
-Constraints:
-
-- may work with mutable JSON files, lock files, dated backups, copied setting
-  folders, generated temporary files, and local database helpers
-- may need to compare or restore a previous parameter state after a failed
-  calibration
+- works with mutable JSON files, lock files, dated backups, copied setting
+  folders, generated temporary files, wiring sheets, and local database helpers
 - may run routines that update local parameters while also producing datasets,
   so mutation and measurement facts must stay distinguishable
-- may depend on physical instrument addresses, external device state, and
-  operational cleanup that Fricon can record but not control in the MVP
-- should not need Fricon to own device control before Fricon can record the
-  calibration evidence honestly
+- may depend on physical instrument addresses and external device state that
+  Fricon can record before it can control
 
-Common overlaps:
+Common switches:
 
 - may be the same person as P-001 during daily calibration work
-- depends on P-005 for calibration routines, scan helpers, and code provenance
-  integration
-- may use P-003 analysis outputs as calibration evidence
-- relies on P-002 for technical readiness checks when calibration proposals
-  affect runtime, update, environment, or data-library compatibility
+- depends on P-005 for calibration routines and code provenance
+- uses P-002 technical readiness checks when calibration proposals affect
+  runtime, update, environment, or data-library compatibility
 
 ## P-005 Measurement Stack Author
 
@@ -322,46 +184,26 @@ An advanced Python user who writes or maintains reusable measurement scripts,
 scan helpers, pulse-generation rules, runner integrations, plotting utilities,
 or export/report recipes used by other lab members.
 
-Primary responsibilities:
+Goals:
 
-- write and maintain user-authored Python code that creates, explains, or
-  post-processes measurement work
 - integrate Fricon recording into existing scripts, notebooks, Data
   Vault-style helpers, runners, and scan utilities
 - declare scan axes, dependencies, trace shapes, repeated shots, validity
   masks, runner identifiers, and procedure summaries from code
-- provide reusable plot, report, export, or generated-artifact recipes that
-  other roles can run
 - preserve honest code provenance without claiming Fricon managed execution
-- review managed-routine, measurement-code source, SDK integration, and
-  generated-artifact recipe proposals for technical shape and provenance
+  guarantees it does not yet provide
 
-Needs:
+Context and pressure:
 
-- SDK patterns that fit ordinary Python modules, scripts, and notebooks without
-  requiring Fricon-managed execution
-- a way to declare scan axes, dependencies, trace shapes, repeated shots,
-  validity masks, runner identifiers, and procedure summaries from code
-- honest code provenance for copied folders, local changes, Git state,
-  packaged helpers, generated circuits, and imported utility modules
-- failure and cleanup semantics that keep instruments, local runtime state, and
-  partially recorded datasets understandable after errors or interrupts
-- migration ergonomics for translating Data Vault-style helpers into Fricon
-  recording without rewriting the whole measurement stack at once
+- writes routines that other users may run without understanding every
+  dependency
+- needs migration ergonomics that do not require rewriting the whole
+  measurement stack at once
+- creates post-MVP pressure for approved code sources, managed entry points,
+  templates, and reviewed updates
 
-Constraints:
-
-- may be responsible for scripts that other users run without understanding
-  every internal dependency
-- may need Fricon to record context without claiming reproducibility it cannot
-  guarantee for unmanaged execution
-- may create post-MVP pressure for approved code sources, managed entry points,
-  templates, and reviewed updates, but those are not MVP promises
-
-Common overlaps:
+Common switches:
 
 - enables P-001 by making scripts and helpers easier to run and record
 - helps P-003 produce traceable analysis and report artifacts
 - helps P-004 produce calibration evidence and parameter-change proposals
-- works with P-002 when shared code sources, package environments, or managed
-  entry points become lab-maintained assets

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -48,9 +48,9 @@ Choose the persona that owns the story's main outcome:
   artifacts, downstream handoff, and interpretation provenance.
 - P-004 Effective Configuration Steward: effective configuration, calibration
   evidence, parameter state, fitted values, and rollback decisions.
-- P-005 Measurement Method Author: reusable measurement methods, script and
-  routine shape, SDK usage, scan helpers, runner integration, plotting
-  utilities, and report/export recipes.
+- P-005 Measurement Method Author: measurement-method code, script and routine
+  shape, SDK usage, scan helpers, runner integration, plotting utilities, and
+  report/export recipes.
 
 When several roles participate, use the accountable role as the story's
 primary persona and mention supporting roles in notes or acceptance criteria.
@@ -78,8 +78,10 @@ run, not every decision in the experiment.
 Goals:
 
 - start, watch, annotate, recover, and hand off measurement runs
-- understand the active sample/session, measurement name, scan shape, units,
-  and selected local context without learning Fricon internals
+- choose or adjust run-specific inputs such as scan ranges, selected targets,
+  and context labels
+- understand the active measurement name, scan shape, units, and selected local
+  context without learning Fricon internals
 - preserve useful partial results when scripts interrupt or long saves fail
 
 Context and pressure:
@@ -96,8 +98,9 @@ Common switches:
   for working effective configuration or parameter state
 - switches to P-003 when the main work is analysis, reporting, or interpreting
   derived artifacts after acquisition
-- depends on P-005 for reusable routines and P-002 when setup or update
-  problems block measurement work
+- switches to P-005 when changing measurement-method code, scan-helper
+  semantics, procedure summaries, or dataset schema
+- depends on P-002 when setup or update problems block measurement work
 
 ## P-002 Local Measurement System Maintainer
 
@@ -204,16 +207,17 @@ Common switches:
 
 ## P-005 Measurement Method Author
 
-The lab user who writes or maintains reusable measurement methods that other
-lab members run: scripts, scan helpers, pulse-generation rules, runner
-integrations, plotting utilities, or export/report recipes. This role
-understands how the experiment should be expressed in code, but may rely on
-P-002 for packaging, environments, deployment, and local system diagnostics.
+The role active when a lab user writes or maintains code that expresses a
+measurement method, from exploratory script blocks to reusable routines:
+scripts, scan helpers, pulse-generation rules, runner integrations, plotting
+utilities, or export/report recipes. This role understands how the experiment
+should be expressed in code, but may rely on P-002 for packaging,
+environments, deployment, and local system diagnostics.
 
 Goals:
 
-- integrate Fricon recording into existing scripts, notebooks, Data
-  Vault-style helpers, runners, and scan utilities
+- integrate Fricon recording into exploratory scripts, notebooks, Data
+  Vault-style helpers, reusable routines, runners, and scan utilities
 - declare scan axes, dependencies, trace shapes, repeated shots, validity
   masks, runner identifiers, and procedure summaries from code
 - preserve honest code provenance without claiming Fricon managed execution
@@ -221,8 +225,8 @@ Goals:
 
 Context and pressure:
 
-- writes routines that other users may run without understanding every
-  dependency
+- may write quick internal script blocks or routines that other users later run
+  without understanding every dependency
 - may rely on P-002 for runtime, package, deployment, or diagnostic support
 - needs migration ergonomics that do not require rewriting the whole
   measurement stack at once

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -77,7 +77,7 @@ run, not every decision in the experiment.
 
 Goals:
 
-- start, watch, annotate, recover, reopen, and export measurement runs
+- start, watch, annotate, recover, and hand off measurement runs
 - understand the active sample/session, measurement name, scan shape, units,
   and selected local context without learning Fricon internals
 - preserve useful partial results when scripts interrupt or long saves fail

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -4,10 +4,23 @@
 
 Accepted.
 
+## Grounding
+
+These personas were refined against a representative local lab workspace,
+which shows current practice built around Windows lab folders, Jupyter
+notebooks, LabRAD Data Vault, mutable `parameters.json`/`registry.json` files,
+wiring spreadsheets, generated sidecars, calibration scripts, hardware
+bring-up helpers, backups, and report artifacts.
+
+The personas describe recurring product roles. One person may move between
+roles during a single day.
+
 ## P-001 Experimentalist
 
 Researchers with entry-level Python ability who run measurement scripts or
-notebooks on lab computers.
+notebooks on lab computers. They may use routines written by a more advanced
+lab member and may only know enough Python to change a scan range, select
+qubits, rerun a cell, or add a note.
 
 Needs:
 
@@ -17,7 +30,11 @@ Needs:
   disturbing acquisition
 - reliable recovery from interrupted runs
 - easy reopening and export for later analysis
+- visible active sample/session, measurement name, scan axes, units,
+  dependencies, and selected local configuration context
 - no requirement to understand Rust, IPC, storage layout, or database internals
+- no requirement to understand every copied script, generated sidecar,
+  parameter backup, or external runner detail before starting new work
 
 Constraints:
 
@@ -28,6 +45,16 @@ Constraints:
 - may not update Desktop, local runtime, CLI, and Python SDK together
 - may need Fricon to fail safely during long-running measurements, exports, or
   local maintenance work
+- may rely on Jupyter, Conda or `uv` environments, LabRAD/Data Vault services,
+  and local folders with dated copies or backups during migration
+
+Observed real-case pressures:
+
+- startup can be a manual sequence of local services and Jupyter
+- measurement data may be saved by dataset IDs and paths that are meaningful
+  locally but fragile for handoff
+- interrupted sweeps and long-running saves need readable partial state, not
+  only a final success/failure bit
 
 ## P-002 Lab Maintainer
 
@@ -46,11 +73,19 @@ Needs:
 - user-facing diagnostics before raw logs, especially for stopped runtime
   components, locked libraries, stale SDKs, incompatible versions, and
   migration-required states
+- effective-configuration diagnostics when several dated parameter files,
+  registry files, lock files, wiring sheets, generated line/chip summaries, or
+  local backups may all appear plausible
+- a way to explain which local services, data paths, setting paths, package
+  environments, and generated sidecars were expected during a run
+- migration guidance that lets old LabRAD/Data Vault history remain in place
+  while new work records honest Fricon context
 
 ## P-003 Analyst
 
 The person who reopens completed measurements for notebooks, reports, or HPC
-analysis.
+analysis. In practice, this role often produces secondary artifacts such as fit
+results, plots, `.npy` or `.json` derived data, spreadsheets, and slide decks.
 
 Needs:
 
@@ -61,6 +96,16 @@ Needs:
   acquisition computer
 - privacy-aware export choices for local paths, code provenance, environment
   summaries, setup details, and sample context
+- enough lifecycle, parameter, code, and procedure context to tell whether an
+  analysis result came from a completed run, an interrupted run, a calibration
+  retry, or a manually edited notebook state
+- links from derived artifacts back to the measurement inputs they used, even
+  before analysis attempts become first-class post-MVP records
+- report handoff that does not depend on reconstructing local folder state or
+  remembering which notebook cell produced a plot
+- enough mapping, readout-classification, and artifact provenance to trust
+  advanced workflows where simulation qubits, physical qubits, shot groups,
+  detector events, and fitted metrics must stay aligned
 
 ## P-004 Future Automation Author
 
@@ -74,3 +119,71 @@ Needs:
 - no hidden mutation of completed dataset facts
 - enough local actor attribution to explain who or what changed durable lab
   state before any future permissions model exists
+
+## P-005 Calibration and Parameter Steward
+
+A current lab user who tunes readout, pulse, coupler, crosstalk, demodulation,
+feedback, or hardware bring-up parameters and decides whether fitted values
+should become the next working local configuration. This role may be the
+experimentalist on a small team, but the product pressure is distinct from
+ordinary data collection.
+
+Needs:
+
+- clear links between calibration measurements, input parameter snapshots,
+  generated sidecars, fitted outputs, and any later parameter-file edits
+- safe capture of selected `parameters.json`, `registry.json`, wiring,
+  demodulation, readout, line/chip, and runner summaries at run time
+- diffs or summaries that explain what changed since a previous good
+  calibration or measurement
+- a way to mark calibration results as exploratory, accepted for current work,
+  rejected, superseded, or needing review
+- exported evidence that can explain why a parameter changed without exporting
+  sensitive local paths by default
+- prerequisite and safety checks before long calibration routines, including
+  missing registry values, invalid fitted inputs, alignment failures,
+  instrument output state, and known-good backup state
+- before/after records for hardware or instrument calibration work, including
+  offsets, powers, frequencies, timestamps, and cleanup/stop outcomes when
+  supplied by the unmanaged routine
+
+Constraints:
+
+- may work with mutable JSON files, lock files, dated backups, copied setting
+  folders, generated temporary files, and local database helpers
+- may need to compare or restore a previous parameter state after a failed
+  calibration
+- may run routines that update local parameters while also producing datasets,
+  so mutation and measurement facts must stay distinguishable
+- may depend on physical instrument addresses, external device state, and
+  operational cleanup that Fricon can record but not control in the MVP
+- should not need Fricon to own device control before Fricon can record the
+  calibration evidence honestly
+
+## P-006 Measurement Stack Author
+
+An advanced Python user who writes or maintains reusable measurement scripts,
+scan helpers, pulse-generation rules, runner integrations, plotting utilities,
+or export/report recipes used by other lab members.
+
+Needs:
+
+- SDK patterns that fit ordinary Python modules, scripts, and notebooks without
+  requiring Fricon-managed execution
+- a way to declare scan axes, dependencies, trace shapes, repeated shots,
+  validity masks, runner identifiers, and procedure summaries from code
+- honest code provenance for copied folders, local changes, Git state,
+  packaged helpers, generated circuits, and imported utility modules
+- failure and cleanup semantics that keep instruments, local runtime state, and
+  partially recorded datasets understandable after errors or interrupts
+- migration ergonomics for translating Data Vault-style helpers into Fricon
+  recording without rewriting the whole measurement stack at once
+
+Constraints:
+
+- may be responsible for scripts that other users run without understanding
+  every internal dependency
+- may need Fricon to record context without claiming reproducibility it cannot
+  guarantee for unmanaged execution
+- may create post-MVP pressure for approved code sources, managed entry points,
+  templates, and reviewed updates, but those are not MVP promises

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -63,19 +63,18 @@ measurement-code proposal shape, and P-003 for durable analysis or
 interpretation records. P-002 contributes technical guardrails when runtime,
 update, library, or environment safety matters.
 
-Physical setup, instrument, wiring, and device-state stewardship is a deferred
-role pressure, not an accepted core persona yet. MVP stories should record it
-as passive setup context or run-bound local configuration. Post-MVP stories may
-need a separate Setup / Instrument Steward if setup or device state becomes an
-independent reviewed mutation boundary. Do not silently route physical
-setup/device ownership to P-002; P-002 owns software-system readiness.
+Physical setup, instrument, wiring, and device-state ownership is a distinct
+future boundary. MVP stories record those facts as passive setup context or
+run-bound local configuration. If later workflows review or mutate setup or
+device state, route that decision to an explicit setup/device owner rather than
+to P-002 by default; P-002 owns software-system readiness.
 
 ## P-001 Measurement Run Operator
 
 The role active when a lab user runs a measurement script or notebook on a lab
 computer. The person may be an experimentalist, student, or senior researcher,
-but this product role is limited to operating and understanding a measurement
-run.
+but the product responsibility is operating and understanding a measurement
+run, not every decision in the experiment.
 
 Goals:
 
@@ -126,7 +125,7 @@ Context and pressure:
 - must handle sensitive local paths, machine names, IP addresses, environment
   details, and setup files carefully
 - may diagnose OS, package, service, import, driver-path, and runner-launch
-  problems without knowing the scientific purpose of the routine
+  problems from a software-system perspective
 - contributes technical readiness checks when a proposal depends on runtime,
   update timing, data-library compatibility, or environment state
 
@@ -223,10 +222,9 @@ Goals:
 
 Context and pressure:
 
-- may be comfortable editing Python without owning the whole local runtime,
-  package, deployment, or diagnostic environment
 - writes routines that other users may run without understanding every
   dependency
+- may rely on P-002 for runtime, package, deployment, or diagnostic support
 - needs migration ergonomics that do not require rewriting the whole
   measurement stack at once
 - creates post-MVP pressure for approved code sources, managed entry points,

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -39,7 +39,7 @@ roles during a single day.
 
 Choose the persona that owns the story's main outcome:
 
-- P-001 Experimentalist: ordinary measurement operation and recovery.
+- P-001 Measurement Operator: ordinary measurement-run operation and recovery.
 - P-002 Fricon Technical Maintainer: Fricon deployment, local runtime health,
   diagnostics, migration support, and technical readiness.
 - P-003 Analyst: reopening, analysis, reports, derived artifacts, downstream
@@ -59,16 +59,16 @@ proposal shape, and P-003 for durable analysis or interpretation records.
 P-002 contributes technical guardrails when runtime, update, library, or
 environment safety matters.
 
-## P-001 Experimentalist
+## P-001 Measurement Operator
 
-Researchers with entry-level Python ability who run measurement scripts or
-notebooks on lab computers. They may use routines written by a more advanced
-lab member and may only know enough Python to change a scan range, select
-qubits, rerun a cell, or add a note.
+The role active when a lab user runs a measurement script or notebook on a lab
+computer. The person may be an experimentalist, student, or senior researcher,
+but this product role is limited to operating and understanding a measurement
+run.
 
 Goals:
 
-- start, watch, annotate, recover, reopen, and export measurement work
+- start, watch, annotate, recover, reopen, and export measurement runs
 - understand the active sample/session, measurement name, scan shape, units,
   and selected local context without learning Fricon internals
 - preserve useful partial results when scripts interrupt or long saves fail
@@ -83,8 +83,10 @@ Context and pressure:
 
 Common switches:
 
-- becomes P-004 when deciding whether calibration results should change working
-  parameter state
+- switches to P-004 when calibration evidence or fitted values are being judged
+  for working parameter state
+- switches to P-003 when the main work is analysis, reporting, or interpreting
+  derived artifacts after acquisition
 - depends on P-005 for reusable routines and P-002 when setup or update
   problems block measurement work
 
@@ -144,21 +146,23 @@ Context and pressure:
 Common switches:
 
 - consumes measurements produced by P-001
-- may provide evidence that P-004 uses for parameter or calibration decisions
+- switches to P-004 when analysis output becomes evidence for accepting,
+  rejecting, or rolling back calibration-derived parameter state
 - uses report/export recipes maintained by P-005
 
 ## P-004 Calibration and Parameter Steward
 
-A lab member who tunes readout, pulse, coupler, crosstalk, demodulation,
-feedback, hardware bring-up, or related parameters and decides whether fitted
-values should become the next working local configuration.
+The role active when measurement evidence and analysis outputs are evaluated
+as calibration evidence for working parameter state. This may happen before,
+during, or after calibration measurements, and the same person may also be the
+measurement operator or analyst.
 
 Goals:
 
 - decide which effective configuration or prior-good state calibration work
   depends on
-- evaluate calibration evidence, fit quality, health gates, retry/pause needs,
-  and manual inspection flags
+- evaluate calibration evidence, fitted values, health gates, retry/pause
+  needs, and manual inspection flags
 - mark calibration results as exploratory, accepted, rejected, superseded, or
   needing review, with rollback context where practical
 
@@ -173,7 +177,9 @@ Context and pressure:
 
 Common switches:
 
-- may be the same person as P-001 during daily calibration work
+- uses P-001 for the run-operation part of calibration work
+- uses P-003 when fitted outputs, plots, or derived artifacts need analysis
+  provenance before a calibration decision
 - depends on P-005 for calibration routines and code provenance
 - uses P-002 technical readiness checks when calibration proposals affect
   runtime, update, environment, or data-library compatibility

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -12,8 +12,9 @@ notebooks, LabRAD Data Vault, mutable `parameters.json`/`registry.json` files,
 wiring spreadsheets, generated sidecars, calibration scripts, hardware
 bring-up helpers, backups, and report artifacts.
 
-The personas describe recurring product roles. One person may move between
-roles during a single day.
+The personas describe recurring product responsibilities, not fixed job titles.
+One person may move between roles during a single day. A workflow should still
+name the role whose decision, risk, or user outcome it primarily serves.
 
 ## Story Role Routing
 
@@ -21,14 +22,19 @@ Existing user stories may use broad legacy wording such as "experimentalist".
 When stories are revised, choose the most specific primary persona from this
 file instead of preserving old role wording by default.
 
+When several roles participate, use the accountable role as the story's primary
+persona and mention supporting roles in notes or acceptance criteria. Do not
+hide a Fricon technical, analyst, calibration, or measurement-stack concern
+behind the generic experimentalist role.
+
 Use the personas this way:
 
 - Use P-001 Experimentalist for ordinary measurement operation: running,
   watching, annotating, recovering, reopening, or exporting new measurement
   work.
-- Use P-002 Lab Maintainer for installation, diagnostics, local runtime
-  health, environment setup, migration guidance, support bundles, shared code
-  setup, and post-MVP review of proposals that mutate durable lab state.
+- Use P-002 Fricon Technical Maintainer for Fricon development, deployment,
+  installation, diagnostics, local runtime health, environment setup, migration
+  guidance, support bundles, and shared code setup.
 - Use P-003 Analyst for reopen, analysis, reports, derived artifacts,
   downstream handoff, mapping/classification provenance, and interpretation
   context.
@@ -41,8 +47,26 @@ Use the personas this way:
   pulse rules, plotting utilities, and report/export recipes.
 
 Do not add a separate future-automation persona unless a future product slice
-uncovers a distinct person with needs that are not already covered by the lab
-maintainer, calibration steward, or measurement stack author roles.
+uncovers a distinct person with needs that are not already covered by the
+Fricon technical maintainer, calibration steward, or measurement stack author
+roles.
+
+## Role Boundary Principles
+
+- Roles are responsibility views. A person can switch roles, but each product
+  workflow should make the active responsibility explicit.
+- MVP stories should prefer the role that directly experiences the MVP problem.
+  Post-MVP stories should prefer the role that reviews or owns the durable
+  state change.
+- Legacy compatibility belongs at role boundaries as aliases, context,
+  attachments, summaries, or evidence. It should not create a new role unless
+  it creates a durable product responsibility.
+- If a story asks Fricon to mutate durable lab state, the responsible role is
+  never only P-001 Experimentalist. Use the domain owner for the decision:
+  P-004 for parameter or calibration proposals, P-005 for managed-routine or
+  measurement-code proposal shape, and P-003 for durable analysis or
+  interpretation records. P-002 contributes technical guardrails when a
+  proposal depends on Fricon runtime, update, library, or environment safety.
 
 ## P-001 Experimentalist
 
@@ -50,6 +74,16 @@ Researchers with entry-level Python ability who run measurement scripts or
 notebooks on lab computers. They may use routines written by a more advanced
 lab member and may only know enough Python to change a scan range, select
 qubits, rerun a cell, or add a note.
+
+Primary responsibilities:
+
+- start and run ordinary unmanaged measurements from Python scripts or
+  notebooks
+- watch live data and inspect recent measurement outputs
+- add lightweight notes, markers, sample/session context, and corrections
+- recover, reopen, and export their own measurements for later work
+- supply enough local context to explain the run without understanding every
+  implementation detail
 
 Needs:
 
@@ -85,10 +119,43 @@ Observed real-case pressures:
 - interrupted sweeps and long-running saves need readable partial state, not
   only a final success/failure bit
 
-## P-002 Lab Maintainer
+Not responsible for:
 
-The person who helps keep lab measurement code, setup context, and computers
-usable.
+- maintaining shared measurement-code sources, runner integrations, or lab
+  package environments
+- choosing whether calibration-derived values become accepted working
+  parameters
+- diagnosing every stopped local service, stale SDK, locked library, or
+  generated sidecar problem
+- making Fricon-managed execution or automation review decisions
+
+Common overlaps:
+
+- uses scripts, scan helpers, and report recipes maintained by P-005
+- asks P-002 for setup, launch, environment, or support-bundle help
+- hands completed or partial runs to P-003 for analysis and reporting
+- becomes P-004 only when evaluating calibration evidence or accepting
+  parameter changes
+
+## P-002 Fricon Technical Maintainer
+
+The person who develops, deploys, updates, diagnoses, and supports Fricon for a
+lab's local computers and data libraries. This role owns Fricon technical
+readiness and integration support, not scientific measurement logic,
+calibration decisions, or analysis conclusions.
+
+Primary responsibilities:
+
+- keep Fricon installation, local runtime components, data libraries, Python
+  environments, and update paths usable on lab computers
+- diagnose setup, compatibility, migration, and support problems before users
+  read raw logs
+- help labs migrate gradually from old LabRAD/Data Vault, folder, and parameter
+  file workflows into Fricon
+- define safe support and sharing practices for local code sources and
+  environment setup
+- provide technical guardrails for post-MVP proposals when Fricon runtime,
+  update, data-library, or environment safety matters
 
 Needs:
 
@@ -109,14 +176,59 @@ Needs:
   environments, and generated sidecars were expected during a run
 - migration guidance that lets old LabRAD/Data Vault history remain in place
   while new work records honest Fricon context
-- post-MVP review responsibility for parameter, calibration, managed-routine,
-  or automation proposals before they mutate durable lab state
+- technical readiness checks for proposals that depend on local runtime,
+  update timing, data-library compatibility, or environment state
+
+Constraints:
+
+- may support Windows, offline, locked-down, or slow-to-update lab computers
+- may not be the person who wrote the measurement script or understands the
+  scientific intent of a run
+- may need redacted support bundles because paths, IP addresses, machine names,
+  environment details, and setup files can be sensitive
+- may need Fricon to fail before mutation when components, SDKs, or libraries
+  are incompatible
+
+Not responsible for:
+
+- operating every measurement run
+- writing the measurement stack, pulse rules, runner integrations, or analysis
+  code as a product responsibility
+- deciding scientific interpretation or whether a fitted value is physically
+  trustworthy
+- approving parameter, calibration, managed-routine, or analysis proposals as
+  the domain owner
+- turning mutable local parameter files into accepted calibration outcomes
+  without P-004 ownership
+
+Common overlaps:
+
+- supports P-001 when setup or update problems block measurement work
+- supports P-005 by making shared code sources and environments usable
+- can block or flag proposals that are technically unsafe because of update
+  policy, runtime state, environment state, or data-library compatibility
+- relies on P-004 for calibration-specific acceptance, rejection, and rollback
+  decisions
 
 ## P-003 Analyst
 
 The person who reopens completed measurements for notebooks, reports, or HPC
 analysis. In practice, this role often produces secondary artifacts such as fit
 results, plots, `.npy` or `.json` derived data, spreadsheets, and slide decks.
+
+Primary responsibilities:
+
+- reopen completed, interrupted, or exported measurements through stable
+  Fricon APIs and IDs
+- inspect datasets, scan schema, metadata, lifecycle, and selected provenance
+- produce analysis outputs, derived data, plots, reports, and presentation
+  artifacts
+- preserve links from derived artifacts back to source measurements,
+  parameters, code/procedure context, and manual judgment
+- validate supplied mapping, readout-classification, shot-group, or
+  detector/observable context for advanced workflows
+- review durable analysis, interpretation, or report records when they become
+  Fricon-managed evidence instead of notebook-local outputs
 
 Needs:
 
@@ -138,6 +250,32 @@ Needs:
   advanced workflows where simulation qubits, physical qubits, shot groups,
   detector events, and fitted metrics must stay aligned
 
+Constraints:
+
+- may work away from the acquisition computer or after the run has finished
+- may need export bundles that redact sensitive paths, setup details, code
+  summaries, environment data, or sample context
+- may need to distinguish raw measurement facts from notebook-local analysis
+  state and manually edited outputs
+- may need Fricon to preserve enough context even before analysis records are
+  first-class post-MVP objects
+
+Not responsible for:
+
+- operating acquisition or keeping live instruments safe
+- maintaining lab runtime, SDK, or package environments
+- accepting calibration-derived values into the working parameter state
+- approving managed routine or measurement-code changes
+- writing or deploying the shared measurement stack, even if analysis code
+  uses it
+
+Common overlaps:
+
+- consumes measurements produced by P-001
+- may produce evidence that P-004 uses for parameter decisions
+- may use report/export recipes maintained by P-005
+- may ask P-002 for export privacy or support-bundle guidance
+
 ## P-004 Calibration and Parameter Steward
 
 A current lab user who tunes readout, pulse, coupler, crosstalk, demodulation,
@@ -145,6 +283,21 @@ feedback, or hardware bring-up parameters and decides whether fitted values
 should become the next working local configuration. This role may be the
 experimentalist on a small team, but the product pressure is distinct from
 ordinary data collection.
+
+Primary responsibilities:
+
+- run or supervise calibration work that produces evidence, fitted values, and
+  affected parameter paths
+- decide which effective configuration or prior-good state a calibration
+  depends on
+- evaluate calibration health, safety gates, fit quality, retry/pause needs,
+  and manual inspection flags
+- mark calibration results as exploratory, accepted, rejected, superseded, or
+  needing review
+- decide whether proposed parameter changes should become working state, and
+  preserve rollback evidence where practical
+- review parameter, calibration, and calibration-derived mutation proposals
+  before they change durable working state
 
 Needs:
 
@@ -178,11 +331,44 @@ Constraints:
 - should not need Fricon to own device control before Fricon can record the
   calibration evidence honestly
 
+Not responsible for:
+
+- keeping Fricon installed, updated, and diagnosable across lab computers
+- writing every measurement helper, runner integration, or report generator
+  used by calibration routines
+- making generic automation architecture decisions outside calibration and
+  parameter review boundaries
+- treating mutable JSON files or generated sidecars as the long-term source of
+  truth once Fricon has parameter snapshots and proposals
+
+Common overlaps:
+
+- may be the same person as P-001 during daily calibration work
+- depends on P-005 for calibration routines, scan helpers, and code provenance
+  integration
+- may use P-003 analysis outputs as calibration evidence
+- relies on P-002 for technical readiness checks when calibration proposals
+  affect runtime, update, environment, or data-library compatibility
+
 ## P-005 Measurement Stack Author
 
 An advanced Python user who writes or maintains reusable measurement scripts,
 scan helpers, pulse-generation rules, runner integrations, plotting utilities,
 or export/report recipes used by other lab members.
+
+Primary responsibilities:
+
+- write and maintain user-authored Python code that creates, explains, or
+  post-processes measurement work
+- integrate Fricon recording into existing scripts, notebooks, Data
+  Vault-style helpers, runners, and scan utilities
+- declare scan axes, dependencies, trace shapes, repeated shots, validity
+  masks, runner identifiers, and procedure summaries from code
+- provide reusable plot, report, export, or generated-artifact recipes that
+  other roles can run
+- preserve honest code provenance without claiming Fricon managed execution
+- review managed-routine, measurement-code source, SDK integration, and
+  generated-artifact recipe proposals for technical shape and provenance
 
 Needs:
 
@@ -205,3 +391,22 @@ Constraints:
   guarantee for unmanaged execution
 - may create post-MVP pressure for approved code sources, managed entry points,
   templates, and reviewed updates, but those are not MVP promises
+
+Not responsible for:
+
+- routine operation of every measurement that uses their code
+- maintaining Fricon installation, runtime health, or lab update policy as a
+  product responsibility
+- deciding whether calibration-derived values become accepted working
+  parameters
+- approving scientific analysis conclusions or calibration health decisions
+- making notebooks, copied folders, generated circuits, or report decks the
+  canonical system of record
+
+Common overlaps:
+
+- enables P-001 by making scripts and helpers easier to run and record
+- helps P-003 produce traceable analysis and report artifacts
+- helps P-004 produce calibration evidence and parameter-change proposals
+- works with P-002 when shared code sources, package environments, or managed
+  entry points become lab-maintained assets

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -39,27 +39,38 @@ roles during a single day.
 
 Choose the persona that owns the story's main outcome:
 
-- P-001 Measurement Operator: ordinary measurement-run operation and recovery.
-- P-002 Fricon Technical Maintainer: Fricon deployment, local runtime health,
+- P-001 Measurement Run Operator: ordinary measurement-run operation and
+  recovery.
+- P-002 Local Measurement System Maintainer: Fricon deployment, local runtime
+  health, data libraries, Python/package environments, code-source setup,
   diagnostics, migration support, and technical readiness.
-- P-003 Analyst: reopening, analysis, reports, derived artifacts, downstream
-  handoff, and interpretation provenance.
-- P-004 Calibration and Parameter Steward: calibration evidence, parameter
-  state, fitted values, effective configuration, and rollback decisions.
-- P-005 Measurement Stack Author: reusable measurement code, SDK shape, scan
-  helpers, runner integration, plotting utilities, and report/export recipes.
+- P-003 Experimental Data Analyst: reopening, analysis, reports, derived
+  artifacts, downstream handoff, and interpretation provenance.
+- P-004 Effective Configuration & Calibration Steward: effective
+  configuration, calibration evidence, parameter state, fitted values, and
+  rollback decisions.
+- P-005 Measurement Method Author: reusable measurement methods, script and
+  routine shape, SDK usage, scan helpers, runner integration, plotting
+  utilities, and report/export recipes.
 
 When several roles participate, use the accountable role as the story's
 primary persona and mention supporting roles in notes or acceptance criteria.
 
 If a story asks Fricon to mutate durable lab state, the accountable role is
 never only P-001. Route the decision to the state owner: P-004 for parameter
-or calibration proposals, P-005 for managed-routine or measurement-code
-proposal shape, and P-003 for durable analysis or interpretation records.
-P-002 contributes technical guardrails when runtime, update, library, or
-environment safety matters.
+or effective-configuration proposals, P-005 for managed-routine or
+measurement-code proposal shape, and P-003 for durable analysis or
+interpretation records. P-002 contributes technical guardrails when runtime,
+update, library, or environment safety matters.
 
-## P-001 Measurement Operator
+Physical setup, instrument, wiring, and device-state stewardship is a deferred
+role pressure, not an accepted core persona yet. MVP stories should record it
+as passive setup context or run-bound local configuration. Post-MVP stories may
+need a separate Setup / Instrument Steward if setup or device state becomes an
+independent reviewed mutation boundary. Do not silently route physical
+setup/device ownership to P-002; P-002 owns software-system readiness.
+
+## P-001 Measurement Run Operator
 
 The role active when a lab user runs a measurement script or notebook on a lab
 computer. The person may be an experimentalist, student, or senior researcher,
@@ -84,21 +95,25 @@ Context and pressure:
 Common switches:
 
 - switches to P-004 when calibration evidence or fitted values are being judged
-  for working parameter state
+  for working effective configuration or parameter state
 - switches to P-003 when the main work is analysis, reporting, or interpreting
   derived artifacts after acquisition
 - depends on P-005 for reusable routines and P-002 when setup or update
   problems block measurement work
 
-## P-002 Fricon Technical Maintainer
+## P-002 Local Measurement System Maintainer
 
-The person who develops, deploys, updates, diagnoses, and supports Fricon for a
-lab's local computers and data libraries.
+The role active when someone makes the local Fricon-backed measurement software
+system runnable on lab computers. This includes Fricon, local runtime
+components, data libraries, Python/package environments, configured code
+sources, update paths, diagnostics, and migration support. Its expertise is
+system readiness, not experiment design.
 
 Goals:
 
-- keep Fricon installation, local runtime components, data libraries, Python
-  environments, and update paths technically usable
+- keep the local measurement software system runnable, including Fricon,
+  runtime components, data libraries, Python/package environments, configured
+  code sources, and update paths
 - make setup, compatibility, migration, and support problems diagnosable
   before users read raw logs
 - help labs adopt Fricon gradually while old LabRAD/Data Vault, folder, and
@@ -110,17 +125,19 @@ Context and pressure:
   pinned to lab-specific Python environments
 - must handle sensitive local paths, machine names, IP addresses, environment
   details, and setup files carefully
+- may diagnose OS, package, service, import, driver-path, and runner-launch
+  problems without knowing the scientific purpose of the routine
 - contributes technical readiness checks when a proposal depends on runtime,
   update timing, data-library compatibility, or environment state
 
 Common switches:
 
-- works with P-005 when shared code sources or package environments become
-  lab-maintained assets
+- works with P-005 to make authored methods runnable through maintained local
+  code sources, package environments, and setup profiles
 - relies on P-004 or P-003 for scientific acceptance of calibration,
   parameter, analysis, or interpretation outcomes
 
-## P-003 Analyst
+## P-003 Experimental Data Analyst
 
 The person who reopens completed measurements for notebooks, reports, or HPC
 analysis. This role often produces secondary artifacts such as fit results,
@@ -147,15 +164,16 @@ Common switches:
 
 - consumes measurements produced by P-001
 - switches to P-004 when analysis output becomes evidence for accepting,
-  rejecting, or rolling back calibration-derived parameter state
+  rejecting, or rolling back calibration-derived effective configuration or
+  parameter state
 - uses report/export recipes maintained by P-005
 
-## P-004 Calibration and Parameter Steward
+## P-004 Effective Configuration & Calibration Steward
 
 The role active when measurement evidence and analysis outputs are evaluated
-as calibration evidence for working parameter state. This may happen before,
-during, or after calibration measurements, and the same person may also be the
-measurement operator or analyst.
+as calibration evidence for working effective configuration or parameter state.
+This may happen before, during, or after calibration measurements, and the same
+person may also be the measurement run operator or experimental data analyst.
 
 Goals:
 
@@ -165,6 +183,8 @@ Goals:
   needs, and manual inspection flags
 - mark calibration results as exploratory, accepted, rejected, superseded, or
   needing review, with rollback context where practical
+- preserve the distinction between parameter/configuration decisions and
+  physical setup or device-state ownership
 
 Context and pressure:
 
@@ -184,11 +204,13 @@ Common switches:
 - uses P-002 technical readiness checks when calibration proposals affect
   runtime, update, environment, or data-library compatibility
 
-## P-005 Measurement Stack Author
+## P-005 Measurement Method Author
 
-An advanced Python user who writes or maintains reusable measurement scripts,
-scan helpers, pulse-generation rules, runner integrations, plotting utilities,
-or export/report recipes used by other lab members.
+The lab user who writes or maintains reusable measurement methods that other
+lab members run: scripts, scan helpers, pulse-generation rules, runner
+integrations, plotting utilities, or export/report recipes. This role
+understands how the experiment should be expressed in code, but may rely on
+P-002 for packaging, environments, deployment, and local system diagnostics.
 
 Goals:
 
@@ -201,6 +223,8 @@ Goals:
 
 Context and pressure:
 
+- may be comfortable editing Python without owning the whole local runtime,
+  package, deployment, or diagnostic environment
 - writes routines that other users may run without understanding every
   dependency
 - needs migration ergonomics that do not require rewriting the whole
@@ -213,3 +237,5 @@ Common switches:
 - enables P-001 by making scripts and helpers easier to run and record
 - helps P-003 produce traceable analysis and report artifacts
 - helps P-004 produce calibration evidence and parameter-change proposals
+- works with P-002 when methods need maintained code sources, package
+  environments, setup profiles, or managed entry points

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -67,6 +67,13 @@ roles.
   measurement-code proposal shape, and P-003 for durable analysis or
   interpretation records. P-002 contributes technical guardrails when a
   proposal depends on Fricon runtime, update, library, or environment safety.
+- Prefer positive ownership over negative exclusions. The sections below state
+  what each role needs and does; avoid writing stories that define a persona
+  mainly by listing other roles' work.
+- Keep the key boundaries simple: P-001 operates measurement work, P-002 keeps
+  Fricon technically usable, P-003 owns analysis and report provenance, P-004
+  owns calibration and parameter-state decisions, and P-005 owns reusable
+  measurement-code and routine shape.
 
 ## P-001 Experimentalist
 
@@ -119,16 +126,6 @@ Observed real-case pressures:
 - interrupted sweeps and long-running saves need readable partial state, not
   only a final success/failure bit
 
-Not responsible for:
-
-- maintaining shared measurement-code sources, runner integrations, or lab
-  package environments
-- choosing whether calibration-derived values become accepted working
-  parameters
-- diagnosing every stopped local service, stale SDK, locked library, or
-  generated sidecar problem
-- making Fricon-managed execution or automation review decisions
-
 Common overlaps:
 
 - uses scripts, scan helpers, and report recipes maintained by P-005
@@ -140,9 +137,9 @@ Common overlaps:
 ## P-002 Fricon Technical Maintainer
 
 The person who develops, deploys, updates, diagnoses, and supports Fricon for a
-lab's local computers and data libraries. This role owns Fricon technical
-readiness and integration support, not scientific measurement logic,
-calibration decisions, or analysis conclusions.
+lab's local computers and data libraries. This role focuses on Fricon technical
+readiness, local integration, diagnostics, and migration support for the lab
+environment.
 
 Primary responsibilities:
 
@@ -188,18 +185,6 @@ Constraints:
   environment details, and setup files can be sensitive
 - may need Fricon to fail before mutation when components, SDKs, or libraries
   are incompatible
-
-Not responsible for:
-
-- operating every measurement run
-- writing the measurement stack, pulse rules, runner integrations, or analysis
-  code as a product responsibility
-- deciding scientific interpretation or whether a fitted value is physically
-  trustworthy
-- approving parameter, calibration, managed-routine, or analysis proposals as
-  the domain owner
-- turning mutable local parameter files into accepted calibration outcomes
-  without P-004 ownership
 
 Common overlaps:
 
@@ -259,15 +244,6 @@ Constraints:
   state and manually edited outputs
 - may need Fricon to preserve enough context even before analysis records are
   first-class post-MVP objects
-
-Not responsible for:
-
-- operating acquisition or keeping live instruments safe
-- maintaining lab runtime, SDK, or package environments
-- accepting calibration-derived values into the working parameter state
-- approving managed routine or measurement-code changes
-- writing or deploying the shared measurement stack, even if analysis code
-  uses it
 
 Common overlaps:
 
@@ -331,16 +307,6 @@ Constraints:
 - should not need Fricon to own device control before Fricon can record the
   calibration evidence honestly
 
-Not responsible for:
-
-- keeping Fricon installed, updated, and diagnosable across lab computers
-- writing every measurement helper, runner integration, or report generator
-  used by calibration routines
-- making generic automation architecture decisions outside calibration and
-  parameter review boundaries
-- treating mutable JSON files or generated sidecars as the long-term source of
-  truth once Fricon has parameter snapshots and proposals
-
 Common overlaps:
 
 - may be the same person as P-001 during daily calibration work
@@ -391,17 +357,6 @@ Constraints:
   guarantee for unmanaged execution
 - may create post-MVP pressure for approved code sources, managed entry points,
   templates, and reviewed updates, but those are not MVP promises
-
-Not responsible for:
-
-- routine operation of every measurement that uses their code
-- maintaining Fricon installation, runtime health, or lab update policy as a
-  product responsibility
-- deciding whether calibration-derived values become accepted working
-  parameters
-- approving scientific analysis conclusions or calibration health decisions
-- making notebooks, copied folders, generated circuits, or report decks the
-  canonical system of record
 
 Common overlaps:
 

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -15,6 +15,35 @@ bring-up helpers, backups, and report artifacts.
 The personas describe recurring product roles. One person may move between
 roles during a single day.
 
+## Story Role Routing
+
+Existing user stories may use broad legacy wording such as "experimentalist".
+When stories are revised, choose the most specific primary persona from this
+file instead of preserving old role wording by default.
+
+Use the personas this way:
+
+- Use P-001 Experimentalist for ordinary measurement operation: running,
+  watching, annotating, recovering, reopening, or exporting new measurement
+  work.
+- Use P-002 Lab Maintainer for installation, diagnostics, local runtime
+  health, environment setup, migration guidance, support bundles, shared code
+  setup, and post-MVP review of proposals that mutate durable lab state.
+- Use P-003 Analyst for reopen, analysis, reports, derived artifacts,
+  downstream handoff, mapping/classification provenance, and interpretation
+  context.
+- Use P-004 Calibration and Parameter Steward for calibration evidence,
+  effective configuration selection, parameter diffs, fitted values,
+  accepted/rejected calibration outcomes, and hardware or instrument
+  calibration evidence.
+- Use P-005 Measurement Stack Author for SDK shape, script migration,
+  Data Vault-style helper translation, scan helpers, runner integrations,
+  pulse rules, plotting utilities, and report/export recipes.
+
+Do not add a separate future-automation persona unless a future product slice
+uncovers a distinct person with needs that are not already covered by the lab
+maintainer, calibration steward, or measurement stack author roles.
+
 ## P-001 Experimentalist
 
 Researchers with entry-level Python ability who run measurement scripts or
@@ -80,6 +109,8 @@ Needs:
   environments, and generated sidecars were expected during a run
 - migration guidance that lets old LabRAD/Data Vault history remain in place
   while new work records honest Fricon context
+- post-MVP review responsibility for parameter, calibration, managed-routine,
+  or automation proposals before they mutate durable lab state
 
 ## P-003 Analyst
 
@@ -107,20 +138,7 @@ Needs:
   advanced workflows where simulation qubits, physical qubits, shot groups,
   detector events, and fitted metrics must stay aligned
 
-## P-004 Future Automation Author
-
-A later user or maintainer who builds calibration, managed execution, or
-AI-assisted workflows.
-
-Needs:
-
-- explicit measurement, artifact, parameter, code, and event boundaries
-- audit records for accepted/rejected mutating actions
-- no hidden mutation of completed dataset facts
-- enough local actor attribution to explain who or what changed durable lab
-  state before any future permissions model exists
-
-## P-005 Calibration and Parameter Steward
+## P-004 Calibration and Parameter Steward
 
 A current lab user who tunes readout, pulse, coupler, crosstalk, demodulation,
 feedback, or hardware bring-up parameters and decides whether fitted values
@@ -160,7 +178,7 @@ Constraints:
 - should not need Fricon to own device control before Fricon can record the
   calibration evidence honestly
 
-## P-006 Measurement Stack Author
+## P-005 Measurement Stack Author
 
 An advanced Python user who writes or maintains reusable measurement scripts,
 scan helpers, pulse-generation rules, runner integrations, plotting utilities,

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -46,9 +46,8 @@ Choose the persona that owns the story's main outcome:
   diagnostics, migration support, and technical readiness.
 - P-003 Experimental Data Analyst: reopening, analysis, reports, derived
   artifacts, downstream handoff, and interpretation provenance.
-- P-004 Effective Configuration & Calibration Steward: effective
-  configuration, calibration evidence, parameter state, fitted values, and
-  rollback decisions.
+- P-004 Effective Configuration Steward: effective configuration, calibration
+  evidence, parameter state, fitted values, and rollback decisions.
 - P-005 Measurement Method Author: reusable measurement methods, script and
   routine shape, SDK usage, scan helpers, runner integration, plotting
   utilities, and report/export recipes.
@@ -167,10 +166,10 @@ Common switches:
   parameter state
 - uses report/export recipes maintained by P-005
 
-## P-004 Effective Configuration & Calibration Steward
+## P-004 Effective Configuration Steward
 
-The role active when measurement evidence and analysis outputs are evaluated
-as calibration evidence for working effective configuration or parameter state.
+The role active when measurement evidence, analysis outputs, and calibration
+results are evaluated for working effective configuration or parameter state.
 This may happen before, during, or after calibration measurements, and the same
 person may also be the measurement run operator or experimental data analyst.
 

--- a/docs/product/story-map.md
+++ b/docs/product/story-map.md
@@ -46,6 +46,8 @@ Ownership rules:
 
 - Epics own outcomes. A story may affect another epic, but it should have only
   one primary owner.
+- Story persona wording follows `product/personas.md`; use the role that owns
+  the outcome instead of a broad lab identity.
 - Keep this index compact. Story-level success criteria live under
   `product/user-stories/`.
 - Each expanded story file names its primary epic.

--- a/docs/product/user-stories/US-001-install-and-launch.md
+++ b/docs/product/user-stories/US-001-install-and-launch.md
@@ -10,9 +10,10 @@ EPIC-001: Local setup and data-library adoption.
 
 ## Story
 
-As an experimentalist, I want one clear way to install and launch Fricon on a
-lab computer so that I can open Fricon Desktop and use the Python SDK against a
-local data library without assembling incompatible pieces by hand.
+As a Local Measurement System Maintainer, I want one clear way to install and
+launch Fricon on a lab computer so that measurement users can open Fricon
+Desktop and use the Python SDK against a local data library without assembling
+incompatible pieces by hand.
 
 ## Success Criteria
 
@@ -25,7 +26,7 @@ local data library without assembling incompatible pieces by hand.
 - Diagnostics explain stopped local runtime components, wrong library, locked
   library, old SDK, incompatible components, or migration-required states.
 - Local support information can be exported in a redacted, user-approved form
-  when a maintainer needs to debug setup problems.
+  when a Local Measurement System Maintainer needs to debug setup problems.
 
 ## Not In Scope
 

--- a/docs/product/user-stories/US-002-create-open-data-library.md
+++ b/docs/product/user-stories/US-002-create-open-data-library.md
@@ -10,9 +10,9 @@ EPIC-001: Local setup and data-library adoption.
 
 ## Story
 
-As an experimentalist, I want to create or open one local Fricon data library
-for my lab computer so that measurements, datasets, notes, and context have a
-durable home.
+As a Local Measurement System Maintainer, I want to create or open one local
+Fricon data library for a lab computer so that measurements, datasets, notes,
+and context have a durable home.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-003-run-exploratory-measurement.md
+++ b/docs/product/user-stories/US-003-run-exploratory-measurement.md
@@ -10,9 +10,10 @@ EPIC-002: New measurement logging replacement.
 
 ## Story
 
-As an experimentalist, I want to run an interactive unmanaged measurement from
-ordinary Python with minimal boilerplate so that Fricon records the measurement,
-produced datasets, optional sample/session context, and honest provenance.
+As a Measurement Run Operator, I want to run an interactive unmanaged
+measurement from ordinary Python with minimal boilerplate so that Fricon records
+the measurement, produced datasets, optional sample/session context, and honest
+provenance.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-004-produce-dataset-artifacts.md
+++ b/docs/product/user-stories/US-004-produce-dataset-artifacts.md
@@ -10,9 +10,9 @@ EPIC-002: New measurement logging replacement.
 
 ## Story
 
-As an experimentalist, I want one measurement to produce one or more dataset
-artifacts so that related tables, scans, or traces stay connected without
-losing direct dataset access.
+As a Measurement Run Operator, I want one measurement to produce one or more
+dataset artifacts so that related tables, scans, or traces stay connected
+without losing direct dataset access.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs/product/user-stories/US-005-watch-and-inspect.md
@@ -10,8 +10,8 @@ EPIC-003: Measurement console and inspection.
 
 ## Story
 
-As an experimentalist, I want local live and historical table/chart views so
-that I can decide whether a measurement is working.
+As a Measurement Run Operator, I want local live and historical table/chart
+views so that I can decide whether a measurement is working.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-006-recover-partial-measurement.md
+++ b/docs/product/user-stories/US-006-recover-partial-measurement.md
@@ -10,9 +10,9 @@ EPIC-004: Recovery, annotation, reopen, and export.
 
 ## Story
 
-As an experimentalist, I want interrupted or failed measurements to remain
-readable so that a crash does not turn useful partial data into an opaque
-folder cleanup problem.
+As a Measurement Run Operator, I want interrupted or failed measurements to
+remain readable so that a crash does not turn useful partial data into an
+opaque folder cleanup problem.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-007-annotate-right-level.md
+++ b/docs/product/user-stories/US-007-annotate-right-level.md
@@ -10,9 +10,9 @@ EPIC-003: Measurement console and inspection.
 
 ## Story
 
-As an experimentalist, I want to add notes, markers, favorites, pins, and small
-corrections at the measurement or dataset level so that important lab context
-does not stay only in memory.
+As a Measurement Run Operator, I want to add notes, markers, favorites, pins,
+and small corrections at the measurement or dataset level so that important lab
+context does not stay only in memory.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-008-reopen-measurement-outputs.md
+++ b/docs/product/user-stories/US-008-reopen-measurement-outputs.md
@@ -10,9 +10,9 @@ EPIC-004: Recovery, annotation, reopen, and export.
 
 ## Story
 
-As an experimentalist, I want to reopen a measurement or one of its dataset
-artifacts from Python by stable ID so that later analysis does not depend on
-remembering storage paths.
+As an Experimental Data Analyst, I want to reopen a measurement or one of its
+dataset artifacts from Python by stable ID so that later analysis does not
+depend on remembering storage paths.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-009-export-measurement.md
+++ b/docs/product/user-stories/US-009-export-measurement.md
@@ -10,9 +10,9 @@ EPIC-004: Recovery, annotation, reopen, and export.
 
 ## Story
 
-As an experimentalist, I want to export a complete measurement bundle so that I
-can analyze it on another computer without setting up a Fricon data library or
-importing the data first.
+As an Experimental Data Analyst, I want to export a complete measurement bundle
+so that I can analyze it on another computer without setting up a Fricon data
+library or importing the data first.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-010-update-without-corrupting-work.md
+++ b/docs/product/user-stories/US-010-update-without-corrupting-work.md
@@ -10,9 +10,9 @@ EPIC-001: Local setup and data-library adoption.
 
 ## Story
 
-As an experimentalist, I want Fricon updates and format changes to fail safely
-so that measurement work is not corrupted by mismatched Desktop, local runtime,
-CLI, Python SDK, or library versions.
+As a Local Measurement System Maintainer, I want Fricon updates and format
+changes to fail safely so that measurement work is not corrupted by mismatched
+Desktop, local runtime, CLI, Python SDK, or library versions.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-011-record-code-provenance.md
+++ b/docs/product/user-stories/US-011-record-code-provenance.md
@@ -10,9 +10,9 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want Fricon to record what it can honestly know about
-the code that produced a measurement so that later analysis can judge
-trustworthiness without pretending Fricon managed execution.
+As a Measurement Method Author, I want Fricon to record what it can honestly
+know about the code that produced a measurement so that later analysis can
+judge trustworthiness without pretending Fricon managed execution.
 
 ## Success Criteria
 
@@ -28,7 +28,8 @@ trustworthiness without pretending Fricon managed execution.
   explains selected files or settings that were active.
 - The product model leaves room for approved code releases, setup profiles,
   environment lock files, scan helpers, plot presets, export recipes, and
-  maintainer handoff without making them MVP code-management features.
+  handoff to a Local Measurement System Maintainer without making them MVP
+  code-management features.
 - Provenance can be previewed or omitted during export when it contains
   sensitive local details.
 - Corrections to provenance are visible as events.

--- a/docs/product/user-stories/US-012-register-sample-session.md
+++ b/docs/product/user-stories/US-012-register-sample-session.md
@@ -10,9 +10,9 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want to attach optional sample or sample-session
-context to a measurement so that data is easier to interpret when sample
-identity matters, without blocking exploratory measurements.
+As a Measurement Run Operator, I want to attach optional sample or
+sample-session context to a measurement so that data is easier to interpret
+when sample identity matters, without blocking exploratory measurements.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-013-find-open-dataset-artifact.md
+++ b/docs/product/user-stories/US-013-find-open-dataset-artifact.md
@@ -10,9 +10,9 @@ EPIC-003: Measurement console and inspection.
 
 ## Story
 
-As an experimentalist, I want to find and open a produced dataset artifact
-directly so that measurement-first navigation does not hide the actual data I
-need to inspect or analyze.
+As an Experimental Data Analyst, I want to find and open a produced dataset
+artifact directly so that measurement-first navigation does not hide the actual
+data I need to inspect or analyze.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-014-record-passive-setup-context.md
+++ b/docs/product/user-stories/US-014-record-passive-setup-context.md
@@ -10,9 +10,9 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want to record light setup, device, method, software,
-or environment summaries for a measurement so that future analysis has
-practical context without requiring Fricon to control instruments.
+As a Measurement Run Operator, I want to record light setup, device, method,
+software, or environment summaries for a measurement so that future analysis
+has practical context without requiring Fricon to control instruments.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-015-declare-common-scan-shapes.md
+++ b/docs/product/user-stories/US-015-declare-common-scan-shapes.md
@@ -10,9 +10,9 @@ EPIC-002: New measurement logging replacement.
 
 ## Story
 
-As an experimentalist, I want concise Python-native scan plans or helpers for
-common scan and trace shapes so that Fricon data has reliable plotting
-semantics without making every script write raw schema by hand.
+As a Measurement Method Author, I want concise Python-native scan plans or
+helpers for common scan and trace shapes so that Fricon data has reliable
+plotting semantics without making every script write raw schema by hand.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-016-record-passive-procedure-context.md
+++ b/docs/product/user-stories/US-016-record-passive-procedure-context.md
@@ -10,9 +10,9 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want to record an unmanaged script, external runner,
-or declared procedure summary so that the measurement has procedural context
-even before Fricon manages execution.
+As a Measurement Method Author, I want to record an unmanaged script, external
+runner, or declared procedure summary so that the measurement has procedural
+context even before Fricon manages execution.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -10,9 +10,10 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As a lab user, I want to translate a new Data Vault-style measurement script
-into Fricon with minimal conceptual change so that I can stop using the old
-logger for new measurements without rewriting the whole experiment stack.
+As a Measurement Method Author, I want to translate a new Data Vault-style
+measurement script into Fricon with minimal conceptual change so that the lab
+can stop using the old logger for new measurements without rewriting the whole
+experiment stack.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -10,9 +10,9 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want to start recording new measurements in Fricon
-while old LabRAD, QCoDeS, Labber, or folder-based history remains where it is
-so that migration does not block new data collection.
+As a Measurement Run Operator, I want to start recording new measurements in
+Fricon while old LabRAD, QCoDeS, Labber, or folder-based history remains where
+it is so that migration does not block new data collection.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
+++ b/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
@@ -10,10 +10,10 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an Effective Configuration & Calibration Steward, I want to bind selected
-local configuration files, references, hashes, or summaries to a measurement so
-that later analysis can explain which lab-local state was active without
-reading copied folders by hand.
+As an Effective Configuration Steward, I want to bind selected local
+configuration files, references, hashes, or summaries to a measurement so that
+later analysis can explain which lab-local state was active without reading
+copied folders by hand.
 
 ## Success Criteria
 

--- a/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
+++ b/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
@@ -10,9 +10,10 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an experimentalist, I want to bind selected local configuration files,
-references, hashes, or summaries to a measurement so that later analysis can
-explain which lab-local state was active without reading copied folders by hand.
+As an Effective Configuration & Calibration Steward, I want to bind selected
+local configuration files, references, hashes, or summaries to a measurement so
+that later analysis can explain which lab-local state was active without
+reading copied folders by hand.
 
 ## Success Criteria
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -60,6 +60,35 @@ Staying close to current practice does not mean freezing current practice as
 the ideal model. Post-MVP Fricon can introduce higher-provenance workflows, but
 only after the relevant facts, review boundaries, and safety model are explicit.
 
+## Adoption Strategy
+
+Fricon is intended for gradual lab adoption. A lab should be able to keep old
+runners, notebooks, LabRAD/Data Vault history, local parameter files, generated
+sidecars, and folder-based workflows while new measurement work moves into
+Fricon.
+
+This does not mean Fricon should preserve every legacy mechanism as a
+first-class product model. Legacy paths, numeric IDs, copied folders, mutable
+configuration files, generated sidecars, and notebook-local analysis should
+enter Fricon as aliases, context, attachments, summaries, or evidence. The
+canonical product model should stay centered on measurements, dataset
+artifacts, lifecycle, scan schema, provenance, selected configuration context,
+exports, and later reviewed parameter and calibration workflows.
+
+Transition features should point toward the full Fricon workflow:
+
+- legacy aliases become stable Fricon IDs
+- mutable configuration files become effective snapshots, profiles, and
+  reviewed proposals
+- copied folders become code provenance or configured measurement-code sources
+- unmanaged calibration scripts become calibration evidence and reviewed
+  parameter changes
+- notebooks, spreadsheets, and presentation decks become traceable analysis or
+  handoff artifacts rather than the system of record
+
+If a legacy need cannot fit one of these bridge forms, it should not become an
+MVP product concept without explicit product and architecture review.
+
 ## MVP Goal
 
 The MVP goal is practical: replace the simple LabRAD Data Vault/Grapher loop

--- a/docs/research/legacy-measurement-sample-lessons.md
+++ b/docs/research/legacy-measurement-sample-lessons.md
@@ -6,7 +6,7 @@ Draft research synthesis.
 
 ## Review Date
 
-2026-05-07.
+2026-05-08.
 
 ## Sources
 
@@ -37,8 +37,44 @@ The samples show a working but fragile legacy LabRAD-era pattern:
   regenerate settings. The problem is that those outputs are mixed with copied
   code folders, mutable parameter files, generated sidecars, and operator
   judgment rather than becoming a reviewed calibration-to-parameter workflow.
+- Hardware bring-up and instrument calibration are part of the same local
+  evidence problem: routines may depend on physical addresses, live output
+  state, stop/clear commands, offsets, powers, frequencies, timestamps, and
+  later conversion into setting files.
+- Analysis handoff is not only Python reopen. The samples also produce
+  spreadsheet summaries, presentation decks, plot images, derived arrays, and
+  JSON outputs that need traceable links back to input measurements and fitted
+  values.
+- Advanced feedback and error-correction analysis depends on fragile mappings:
+  simulation qubits to physical qubits, readout order, shot groups, IQ
+  classification centers, detector events, and observable outputs.
 - Partial or interrupted acquisition is treated as a cleanup/debugging problem,
   not as a first-class readable lifecycle state.
+
+## Follow-Up Persona Pressures
+
+A later review of the same sample set clarified several user roles behind the
+general migration pressure:
+
+- Calibration and parameter stewardship is current daily work, not only future
+  automation. Single-qubit calibration, two-qubit gate calibration, readout
+  optimization, feedback tuning, crosstalk work, and hardware bring-up all need
+  evidence capture before Fricon owns execution.
+- Effective configuration selection is a user problem. When dated parameter
+  files, registry backups, lock files, wiring sheets, generated line/chip
+  summaries, and temporary sidecars coexist, Fricon should help record which
+  state was selected and warn when the context is ambiguous or stale.
+- Analysis and reporting users need provenance for secondary artifacts. Fit
+  results, plots, spreadsheet rows, presentation slides, and derived data files
+  should cite the measurement, selected parameters, code/procedure context, and
+  any manual judgment they depend on.
+- Advanced experiment analysts need mapping and classification provenance.
+  Feedback or error-correction workflows should preserve supplied
+  sim-to-physical mappings, readout classification inputs, retraining notes,
+  shot grouping, detector/observable formatting, and manual inspection flags.
+- Measurement stack authors are a distinct current role. They maintain scan
+  helpers, pulse rules, runner integrations, plotting utilities, and report
+  generators that other users run without understanding every dependency.
 
 ## Lessons For Fricon
 
@@ -57,6 +93,13 @@ Fricon should make the following facts first-class for new work:
 - Passive setup and procedure summaries.
 - Run-bound local configuration snapshots or summaries for selected parameter,
   registry, wiring, line/chip, demod/readout, and runner configuration.
+- Effective-configuration selection notes and ambiguity/staleness warnings when
+  several local files or generated sidecars could plausibly explain a run.
+- Optional procedure context for hardware bring-up, instrument calibration,
+  readout classification, sim-to-physical mapping, and other unmanaged routine
+  facts supplied by the user or integration.
+- Links from derived artifacts and reports back to the measurements,
+  parameters, code/procedure context, and fitted values they used.
 - Measurement-centered export that carries semantic context, not just bytes.
 
 The MVP should still avoid LabRAD emulation, old-history import, broad device
@@ -81,6 +124,9 @@ The samples also point beyond the MVP replacement loop:
   review, with before/after diffs and rollback targets where practical.
 - Analysis and calibration records should provide evidence for trust decisions
   and proposed parameter changes before they become automation inputs.
+- Report and derived-artifact records should preserve both visual outputs and
+  numeric rationale, including anomaly/status labels when supplied by analysis
+  tools.
 - Calibration automation should use chain-scoped working refs or staged
   proposals instead of directly rewriting durable named parameter refs or
   generated config files.


### PR DESCRIPTION
## Summary
- Reworked `personas.md` into five lightweight product-role slices that distinguish measurement operation, system maintenance, analysis, effective configuration, and measurement-method authorship.
- Reassigned MVP and future stories to the most accountable role instead of a broad experimentalist label.
- Added guidance in the story map, vision, and legacy research notes to support gradual Fricon adoption without over-modeling transitional workflows.
- Updated the EPIC-001 framing and future story backlog to match the revised role boundaries and provenance model.

## Validation
- Reviewed the documentation set for internal consistency across personas, story routing, epics, vision, and future requirements.
- Ran `git diff --check` to confirm the edited docs are clean.