### PR TITLE
docs: reframe product analysis around initial adoption

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,10 @@ The reset keeps useful infrastructure where it fits, but it does not preserve
 workspace-first storage, API, IPC, or desktop navigation compatibility when
 that compatibility would keep the wrong product model alive.
 
-Product planning in this directory uses MVP, post-MVP priority, and ADR-gated
-labels. Do not treat post-MVP priorities as semantic-version labels; compatible
+Product planning in this directory uses initial adoption, strategic follow-on,
+and ADR-gated labels. Initial adoption is the first usable migration slice, not
+a statement that later product-core capabilities are less important. Do not
+treat strategic follow-on priorities as semantic-version labels; compatible
 features may still ship on the same compatible release line.
 
 ## Workflow Stance
@@ -82,8 +84,8 @@ docs/
 
 Keep each idea in the narrowest durable owner:
 
-- `product/vision.md` owns the current high-confidence product thesis, MVP
-  goal, user promise, and high-level product horizons.
+- `product/vision.md` owns the current high-confidence product thesis, initial
+  adoption goal, user promise, and high-level product horizons.
 - `product/personas.md` owns the current high-confidence product-role model.
 - `product/product-analysis-progress.md` owns product-analysis confidence,
   progress, and revalidation order.
@@ -92,7 +94,7 @@ Keep each idea in the narrowest durable owner:
   the current high-confidence product inputs.
 - `product/future-concepts.md` and
   `product/future-stories-and-requirements.md` are backlog material until the
-  MVP product baseline is revalidated.
+  initial adoption product baseline is revalidated.
 - `product/glossary.md` is a provisional terminology helper until capability
   and story revalidation settles the active product language.
 - `domain/README.md` owns the current domain-layer status.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,10 @@ features may still ship on the same compatible release line.
 ## Workflow Stance
 
 This directory is currently the primary work surface. The product baseline is
-being revalidated from the current greenfield direction. Keep discussion
-changes lightweight. Do not add implementation scaffolding, package locks,
-generated artifacts, or release automation until the accepted product baseline
-and required downstream architecture or ADR inputs call for them.
+being rebuilt from the current greenfield analysis. Keep discussion changes
+lightweight. Do not add implementation scaffolding, package locks, generated
+artifacts, or release automation until the accepted product baseline and
+required downstream architecture or ADR inputs call for them.
 
 ## Scale Classification
 
@@ -87,16 +87,16 @@ Keep each idea in the narrowest durable owner:
 - `product/vision.md` owns the current high-confidence product thesis, initial
   adoption goal, user promise, and high-level product horizons.
 - `product/personas.md` owns the current high-confidence product-role model.
-- `product/product-analysis-progress.md` owns product-analysis confidence,
-  progress, and revalidation order.
+- `product/product-analysis-progress.md` owns product-analysis progress,
+  document confidence, open questions, and the next analysis sequence.
 - `product/capability-map.md`, `product/story-map.md`, `product/epics/`, and
-  `product/user-stories/` are draft derived artifacts until revalidated from
-  the current high-confidence product inputs.
+  `product/user-stories/` are draft derived artifacts until they are rederived
+  or checked against the current greenfield analysis.
 - `product/future-concepts.md` and
   `product/future-stories-and-requirements.md` are backlog material until the
-  initial adoption product baseline is revalidated.
+  initial adoption product baseline is stable.
 - `product/glossary.md` is a provisional terminology helper until capability
-  and story revalidation settles the active product language.
+  and story analysis settles the active product language.
 - `domain/README.md` owns the current domain-layer status.
 - `architecture/README.md` owns accepted architecture constraints while the
   project is still in product analysis. Detailed API, storage, module,

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,13 @@
 
 ## Status
 
-Active v0.2+ documentation baseline.
+Active documentation workspace; product baseline under revalidation.
 
 ## Purpose
 
 `docs/` is the single documentation directory for the v0.2+ reset. It owns
-the active product, domain status, architecture, ADR, research,
-user-documentation planning, and AI-agent guidance baseline.
+the active product-analysis workspace, domain status, architecture constraints,
+ADR, research, user-documentation planning, and AI-agent guidance baseline.
 
 ## Design Stance
 
@@ -25,10 +25,11 @@ features may still ship on the same compatible release line.
 
 ## Workflow Stance
 
-This directory is currently the primary work surface. Keep discussion changes
-lightweight. Do not add implementation scaffolding, package locks, generated
-artifacts, or release automation until the accepted product baseline and
-required downstream architecture or ADR inputs call for them.
+This directory is currently the primary work surface. The product baseline is
+being revalidated from the current greenfield direction. Keep discussion
+changes lightweight. Do not add implementation scaffolding, package locks,
+generated artifacts, or release automation until the accepted product baseline
+and required downstream architecture or ADR inputs call for them.
 
 ## Scale Classification
 
@@ -45,14 +46,16 @@ Fricon is an S2 medium modular system:
 1. `postmortems/v0-lessons.md`
 2. `decisions/ADR-001-v02-clean-reset-boundary.md`
 3. `product/vision.md`
-4. `product/capability-map.md`
-5. `product/story-map.md`
-6. `product/python-sdk-ux.md` for the Python SDK usage guideline
-7. relevant `product/epics/` and `product/user-stories/`
-8. `domain/README.md`
-9. `architecture/README.md`
-10. `architecture/compatibility-policy.md`
-11. `ai/project-context.md`
+4. `product/personas.md`
+5. `product/product-analysis-progress.md`
+6. `product/capability-map.md`
+7. `product/story-map.md`
+8. `product/python-sdk-ux.md` for the Python SDK usage guideline
+9. relevant `product/epics/` and `product/user-stories/`
+10. `domain/README.md`
+11. `architecture/README.md`
+12. `architecture/compatibility-policy.md`
+13. `ai/project-context.md`
 
 `specs/` and `implementation-plans/` are currently sentinels only. Recreate
 downstream artifacts only when implementation planning is the task and the
@@ -63,7 +66,7 @@ questions.
 
 ```text
 docs/
-  product/              User goals, capabilities, stories, future ledger, glossary
+  product/              Product analysis, user goals, capabilities, stories, glossary
   domain/               Current domain-layer status
   architecture/         Accepted constraints and deferred ADR questions
   decisions/            ADRs for durable decisions
@@ -79,17 +82,19 @@ docs/
 
 Keep each idea in the narrowest durable owner:
 
-- `product/vision.md` owns the accepted product thesis, MVP goal, user promise,
-  and high-level product horizons.
-- `product/future-concepts.md` owns the accepted post-MVP priority ledger and
-  promotion rule.
-- `product/future-stories-and-requirements.md` owns proposed future user stories
-  and requirements. It should reference the priority ledger instead of restating
-  its rationale.
-- `product/capability-map.md` owns stable capability IDs and compact scope
-  boundaries. Detailed acceptance notes belong in stories or ADRs; derived
-  specs may add implementation acceptance after upstream acceptance.
-- `product/glossary.md` owns public and future terminology.
+- `product/vision.md` owns the current high-confidence product thesis, MVP
+  goal, user promise, and high-level product horizons.
+- `product/personas.md` owns the current high-confidence product-role model.
+- `product/product-analysis-progress.md` owns product-analysis confidence,
+  progress, and revalidation order.
+- `product/capability-map.md`, `product/story-map.md`, `product/epics/`, and
+  `product/user-stories/` are draft derived artifacts until revalidated from
+  the current high-confidence product inputs.
+- `product/future-concepts.md` and
+  `product/future-stories-and-requirements.md` are backlog material until the
+  MVP product baseline is revalidated.
+- `product/glossary.md` is a provisional terminology helper until capability
+  and story revalidation settles the active product language.
 - `domain/README.md` owns the current domain-layer status.
 - `architecture/README.md` owns accepted architecture constraints while the
   project is still in product analysis. Detailed API, storage, module,

--- a/docs/ai/agent-steering.md
+++ b/docs/ai/agent-steering.md
@@ -8,12 +8,12 @@ Draft.
 
 | Task | Start With |
 | --- | --- |
-| Product direction | `product/vision.md`, `product/capability-map.md`, `product/story-map.md` |
-| Product term or concept question | `product/glossary.md`, then `product/capability-map.md` |
-| Architecture question | `architecture/README.md`, then accepted product docs |
+| Product direction | `product/product-analysis-progress.md`, then `product/vision.md` and `product/personas.md` |
+| Product term or concept question | `product/product-analysis-progress.md`, then draft `product/glossary.md` |
+| Architecture question | `architecture/README.md`, then revalidated product docs |
 | Storage/API/protocol decision | First confirm product inputs; use `architecture/README.md` and ADRs, and do not create detailed architecture files until architecture design starts |
 | Compatibility question | `architecture/compatibility-policy.md`, `decisions/ADR-001-v02-clean-reset-boundary.md` |
-| Implementation planning | First confirm accepted product/architecture/ADR inputs, then recreate or read derived `specs/` and `implementation-plans/`; they are sentinel-only right now |
+| Implementation planning | First confirm revalidated product inputs plus accepted architecture/ADR inputs, then recreate or read derived `specs/` and `implementation-plans/`; they are sentinel-only right now |
 
 ## When To Pause And Update Docs
 
@@ -31,6 +31,8 @@ Pause local implementation and update docs when:
   or pause/review behavior
 - a managed routine introduces desired-state setup/device reconciliation,
   parallel device apply, readback semantics, or partial-failure handling
+- draft capabilities, epics, or stories would be used as implementation input
+  before product-analysis revalidation
 - a spec or milestone draft introduces product scope, product terminology, or
   architecture decisions that are not already owned by upstream docs or ADRs
 - a spec contradicts an accepted ADR

--- a/docs/ai/project-context.md
+++ b/docs/ai/project-context.md
@@ -31,12 +31,14 @@ scientific measurement work. Treat `product/vision.md` and
 capabilities, stories, epics, and future backlog docs as draft derived material
 until `product/product-analysis-progress.md` says they have been revalidated.
 
-Product planning uses MVP, post-MVP priority, and ADR-gated labels. Do not
-interpret post-MVP priorities as semantic-version labels; compatible additions
-may remain on the same compatible release line.
+Product planning uses initial adoption, strategic follow-on, and ADR-gated
+labels. Initial adoption means the first usable migration slice, not the set of
+all important Fricon capabilities. Do not interpret strategic follow-on
+priorities as semantic-version labels; compatible additions may remain on the
+same compatible release line.
 
-Post-MVP priority order and rationale are draft backlog material until the MVP
-product baseline is revalidated.
+Strategic follow-on priority order and rationale are draft backlog material
+until the initial adoption product baseline is revalidated.
 
 Primary user model:
 
@@ -54,15 +56,15 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 - Do not make Desktop the durable data backend.
 - Do not bypass local runtime compatibility checks for mutating Python APIs.
 - Do not introduce SaaS, accounts, teams, roles, or distributed database
-  behavior for the MVP.
-- Do not implement post-MVP runner, device, calibration, or AI mutation systems
-  before their ADRs/specs exist.
+  behavior for the initial adoption slice.
+- Do not implement strategic follow-on runner, device, calibration, or AI
+  mutation systems before their ADRs/specs exist.
 
 ## Good Defaults
 
 - Prefer measurement-scoped dataset writers in public examples.
-- Use MVP/post-MVP/ADR-gated for product priority. Do not use `v0.3` or `v0.4`
-  as shorthand for feature horizons.
+- Use initial adoption, strategic follow-on, and ADR-gated for product
+  priority. Do not use `v0.3` or `v0.4` as shorthand for feature horizons.
 - Treat high-impact Python SDK ergonomics as product requirements, not only
   implementation details.
 - Keep product-level SDK docs focused on usage guidelines and non-binding
@@ -73,9 +75,10 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 - Keep sample/session context optional and correctable.
 - Do not turn sample target binding into a heavy physical-component ontology
   unless a later product decision requires it.
-- For post-MVP parameter, calibration, run-manifest, sample-visualizer, and
-  setup/device reconciliation details, read `product/future-concepts.md` and
-  `product/glossary.md` as draft backlog and terminology context.
+- For strategic follow-on parameter, calibration, run-manifest,
+  sample-visualizer, and setup/device reconciliation details, read
+  `product/future-concepts.md` and `product/glossary.md` as draft backlog and
+  terminology context.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
 - Use events for lifecycle, notes, corrections, and audit history.

--- a/docs/ai/project-context.md
+++ b/docs/ai/project-context.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted for v0.2+ planning.
+Draft pending product-analysis revalidation.
 
 ## Start Here
 
@@ -11,10 +11,12 @@ For v0.2+ work, read:
 1. `docs/README.md`
 2. `docs/decisions/ADR-001-v02-clean-reset-boundary.md`
 3. `docs/product/vision.md`
-4. `docs/product/python-sdk-ux.md` for the Python SDK usage guideline
-5. `docs/domain/README.md`
-6. `docs/architecture/README.md`
-7. `docs/architecture/compatibility-policy.md`
+4. `docs/product/personas.md`
+5. `docs/product/product-analysis-progress.md`
+6. `docs/product/python-sdk-ux.md` for the Python SDK usage guideline
+7. `docs/domain/README.md`
+8. `docs/architecture/README.md`
+9. `docs/architecture/compatibility-policy.md`
 
 `docs/specs/` and `docs/implementation-plans/` are sentinels only
 right now. Recreate or read downstream artifacts only when implementation
@@ -23,17 +25,18 @@ explicitly marked with open interview questions.
 
 ## Product Direction
 
-Fricon is a local lab data library for scientific measurement work.
-Its long-term motivation is unified parameter management, measurement-code
-management, SDK runner capture, dataset recording, and provenance in one
-local-first product experience.
+Fricon is currently being revalidated as a local lab data library for
+scientific measurement work. Treat `product/vision.md` and
+`product/personas.md` as the strongest current product inputs. Treat
+capabilities, stories, epics, and future backlog docs as draft derived material
+until `product/product-analysis-progress.md` says they have been revalidated.
 
 Product planning uses MVP, post-MVP priority, and ADR-gated labels. Do not
 interpret post-MVP priorities as semantic-version labels; compatible additions
 may remain on the same compatible release line.
 
-Post-MVP priority order and rationale are owned by
-`product/future-concepts.md`.
+Post-MVP priority order and rationale are draft backlog material until the MVP
+product baseline is revalidated.
 
 Primary user model:
 
@@ -72,7 +75,7 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   unless a later product decision requires it.
 - For post-MVP parameter, calibration, run-manifest, sample-visualizer, and
   setup/device reconciliation details, read `product/future-concepts.md` and
-  `product/glossary.md`.
+  `product/glossary.md` as draft backlog and terminology context.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
 - Use events for lifecycle, notes, corrections, and audit history.

--- a/docs/ai/project-context.md
+++ b/docs/ai/project-context.md
@@ -2,43 +2,22 @@
 
 ## Status
 
-Draft pending product-analysis revalidation.
+Draft pending greenfield product-analysis baseline.
 
-## Start Here
+## Assumption
 
-For v0.2+ work, read:
+Read `docs/README.md` first. It owns the documentation reading order,
+source-of-truth map, and current product-analysis status.
 
-1. `docs/README.md`
-2. `docs/decisions/ADR-001-v02-clean-reset-boundary.md`
-3. `docs/product/vision.md`
-4. `docs/product/personas.md`
-5. `docs/product/product-analysis-progress.md`
-6. `docs/product/python-sdk-ux.md` for the Python SDK usage guideline
-7. `docs/domain/README.md`
-8. `docs/architecture/README.md`
-9. `docs/architecture/compatibility-policy.md`
+This file is only an agent overlay: it records operating reminders that are
+easy to forget during AI-assisted work. Do not duplicate the README here.
 
-`docs/specs/` and `docs/implementation-plans/` are sentinels only
-right now. Recreate or read downstream artifacts only when implementation
-planning is the task and the relevant upstream baseline is accepted or
-explicitly marked with open interview questions.
+## Current Working Model
 
-## Product Direction
-
-Fricon is currently being revalidated as a local lab data library for
-scientific measurement work. Treat `product/vision.md` and
-`product/personas.md` as the strongest current product inputs. Treat
-capabilities, stories, epics, and future backlog docs as draft derived material
-until `product/product-analysis-progress.md` says they have been revalidated.
-
-Product planning uses initial adoption, strategic follow-on, and ADR-gated
-labels. Initial adoption means the first usable migration slice, not the set of
-all important Fricon capabilities. Do not interpret strategic follow-on
-priorities as semantic-version labels; compatible additions may remain on the
-same compatible release line.
-
-Strategic follow-on priority order and rationale are draft backlog material
-until the initial adoption product baseline is revalidated.
+The current high-confidence product inputs are `product/vision.md` and
+`product/personas.md`. Use `product/product-analysis-progress.md` to understand
+which greenfield analysis steps are complete before relying on derived
+capabilities, stories, epics, or strategic follow-on backlog material.
 
 Primary user model:
 
@@ -51,6 +30,8 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 ## Hard Boundaries
 
 - Do not preserve prior workspace/dataset compatibility by default.
+- Do not treat draft capabilities, stories, epics, or backlog items as
+  implementation-ready.
 - Do not make datasets own measurement, sample, parameter, code, or lifecycle
   meaning.
 - Do not make Desktop the durable data backend.
@@ -65,6 +46,8 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 - Prefer measurement-scoped dataset writers in public examples.
 - Use initial adoption, strategic follow-on, and ADR-gated for product
   priority. Do not use `v0.3` or `v0.4` as shorthand for feature horizons.
+- Start product analysis from user journeys and story backbone before deriving
+  capabilities.
 - Treat high-impact Python SDK ergonomics as product requirements, not only
   implementation details.
 - Keep product-level SDK docs focused on usage guidelines and non-binding

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -18,8 +18,9 @@ architecture unless an ADR accepts them.
 ## Accepted Constraints
 
 - v0.2 is a clean reset from the pre-v0.2 workspace/dataset-first model.
-- Fricon remains local-first for the MVP; hosted SaaS, accounts, teams,
-  permissions, and distributed database semantics are out of scope.
+- Fricon remains local-first for the initial adoption slice; hosted SaaS,
+  accounts, teams, permissions, and distributed database semantics are out of
+  scope.
 - Mutating clients must fail compatibility checks before writing to a data
   library.
 - Desktop UI state must not become the durable data backend.
@@ -28,8 +29,8 @@ architecture unless an ADR accepts them.
   searchable and directly openable.
 - Dataset artifacts must not own measurement, sample, lifecycle, parameter,
   code, or provenance meaning.
-- Post-MVP runner, device, calibration, and AI mutation systems require later
-  ADRs/specs before implementation.
+- Strategic follow-on runner, device, calibration, and AI mutation systems
+  require later ADRs/specs before implementation.
 
 ## Deferred Architecture Questions
 

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -19,7 +19,7 @@ an accepted conceptual model.
 During the current phase:
 
 - `docs/product/vision.md` owns the current high-confidence product thesis,
-  MVP goal, user promise, and high-level horizons.
+  initial adoption goal, user promise, and high-level horizons.
 - `docs/product/personas.md` owns the current high-confidence product-role
   model.
 - `docs/product/product-analysis-progress.md` owns product-analysis confidence,
@@ -31,12 +31,13 @@ During the current phase:
   revalidation.
 - `docs/product/future-concepts.md` and
   `docs/product/future-stories-and-requirements.md` are backlog context pending
-  MVP baseline revalidation.
+  initial adoption baseline revalidation.
 - `docs/architecture/README.md` owns only accepted architecture constraints and
   deferred architecture questions.
 
-If a topic is about what users need, product priority, MVP versus post-MVP
-scope, or acceptable user-facing promises, keep it in `docs/product/`.
+If a topic is about what users need, product priority, initial adoption versus
+strategic follow-on scope, or acceptable user-facing promises, keep it in
+`docs/product/`.
 
 If a topic is about transport, storage, process boundaries, API shape, module
 names, export format, or migration mechanics, keep it out of `docs/domain/`

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -18,14 +18,20 @@ an accepted conceptual model.
 
 During the current phase:
 
-- `docs/product/vision.md` owns the product thesis, MVP goal, user promise, and
-  high-level horizons.
-- `docs/product/capability-map.md` owns accepted capability IDs and compact
-  scope boundaries.
-- `docs/product/glossary.md` owns current public and future terminology.
-- `docs/product/future-concepts.md` owns post-MVP priority order and rationale.
-- `docs/product/future-stories-and-requirements.md` owns proposed future
-  stories and requirements.
+- `docs/product/vision.md` owns the current high-confidence product thesis,
+  MVP goal, user promise, and high-level horizons.
+- `docs/product/personas.md` owns the current high-confidence product-role
+  model.
+- `docs/product/product-analysis-progress.md` owns product-analysis confidence,
+  progress, and revalidation order.
+- `docs/product/capability-map.md`, `docs/product/story-map.md`,
+  `docs/product/epics/`, and `docs/product/user-stories/` are draft derived
+  material pending product-analysis revalidation.
+- `docs/product/glossary.md` is draft terminology context pending
+  revalidation.
+- `docs/product/future-concepts.md` and
+  `docs/product/future-stories-and-requirements.md` are backlog context pending
+  MVP baseline revalidation.
 - `docs/architecture/README.md` owns only accepted architecture constraints and
   deferred architecture questions.
 
@@ -39,7 +45,9 @@ until architecture or ADR work starts.
 ## Domain Rebuild Trigger
 
 Recreate detailed domain docs only after the relevant product inputs are
-accepted or explicitly marked with open questions.
+accepted or explicitly marked with open questions. During the current
+revalidation phase, use `docs/product/product-analysis-progress.md` to decide
+whether a product input is ready to support domain work.
 
 The first rebuilt domain baseline should be lean and should answer only:
 
@@ -58,4 +66,4 @@ Expected future files, when the phase starts:
 
 Do not restore the old migrated draft files as active sources of truth. Mine
 git history only when explicitly asked for historical reference, then rederive
-domain content from accepted product documents.
+domain content from revalidated product documents.

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -22,16 +22,16 @@ During the current phase:
   initial adoption goal, user promise, and high-level horizons.
 - `docs/product/personas.md` owns the current high-confidence product-role
   model.
-- `docs/product/product-analysis-progress.md` owns product-analysis confidence,
-  progress, and revalidation order.
+- `docs/product/product-analysis-progress.md` owns product-analysis progress,
+  document confidence, open questions, and the next analysis sequence.
 - `docs/product/capability-map.md`, `docs/product/story-map.md`,
   `docs/product/epics/`, and `docs/product/user-stories/` are draft derived
-  material pending product-analysis revalidation.
-- `docs/product/glossary.md` is draft terminology context pending
-  revalidation.
+  material pending greenfield analysis.
+- `docs/product/glossary.md` is draft terminology context pending product
+  analysis.
 - `docs/product/future-concepts.md` and
   `docs/product/future-stories-and-requirements.md` are backlog context pending
-  initial adoption baseline revalidation.
+  a stable initial adoption baseline.
 - `docs/architecture/README.md` owns only accepted architecture constraints and
   deferred architecture questions.
 
@@ -46,9 +46,9 @@ until architecture or ADR work starts.
 ## Domain Rebuild Trigger
 
 Recreate detailed domain docs only after the relevant product inputs are
-accepted or explicitly marked with open questions. During the current
-revalidation phase, use `docs/product/product-analysis-progress.md` to decide
-whether a product input is ready to support domain work.
+accepted or explicitly marked with open questions. During the current analysis
+phase, use `docs/product/product-analysis-progress.md` to decide whether a
+product input is ready to support domain work.
 
 The first rebuilt domain baseline should be lean and should answer only:
 
@@ -67,4 +67,4 @@ Expected future files, when the phase starts:
 
 Do not restore the old migrated draft files as active sources of truth. Mine
 git history only when explicitly asked for historical reference, then rederive
-domain content from revalidated product documents.
+domain content from accepted greenfield product documents.

--- a/docs/product/capability-map.md
+++ b/docs/product/capability-map.md
@@ -6,29 +6,33 @@ Draft pending product-analysis revalidation.
 
 ## Vision Alignment
 
-The capability baseline serves one MVP goal: replace the simple LabRAD Data
-Vault/Grapher loop for new measurements. Capabilities should support that loop
-without importing old history, emulating LabRAD, or pulling post-MVP parameter,
-code-management, runner, device, or automation systems into the MVP.
+The capability baseline should be revalidated against one initial adoption
+goal: replace the simple LabRAD Data Vault/Grapher loop for new measurements.
+Capabilities in the first adoption slice should support that loop without
+importing old history, emulating LabRAD, or pulling strategic follow-on
+parameter, code-management, runner, device, or automation systems into the
+first release path.
 
-Post-MVP capability ordering is owned by `product/future-concepts.md`. This map
-keeps stable IDs and compact scope boundaries only.
+Strategic follow-on capability ordering is draft backlog context in
+`product/future-concepts.md`. This map keeps stable IDs and compact scope
+boundaries only.
 
-Release versions are not product-horizon labels. Compatible post-MVP
-capabilities may still ship on the same compatible release line; use MVP,
-post-MVP priority, and ADR-gated labels for product planning.
+Release versions are not product-horizon labels. Compatible strategic
+follow-on capabilities may still ship on the same compatible release line; use
+initial adoption, strategic follow-on, and ADR-gated labels for product
+planning.
 
 ## Product Grouping
 
 Use these planning groups when routing product work:
 
 - Local adoption: CAP-001, CAP-002, CAP-012, CAP-013.
-- MVP measurement replacement: CAP-003, CAP-005, CAP-006, CAP-007, CAP-028,
-  CAP-030.
+- Initial adoption measurement replacement: CAP-003, CAP-005, CAP-006,
+  CAP-007, CAP-028, CAP-030.
 - Context and provenance: CAP-004, CAP-014, CAP-015, CAP-017, CAP-027,
   CAP-029, CAP-033.
 - Review and analysis: CAP-008, CAP-009, CAP-010, CAP-011, CAP-016, CAP-026.
-- Post-MVP foundation: CAP-018 through CAP-025, CAP-031, CAP-032.
+- Strategic follow-on foundation: CAP-018 through CAP-025, CAP-031, CAP-032.
 
 ## Capability Definitions
 
@@ -185,15 +189,16 @@ CAP-018: Read-only remote monitoring.
 
 - Intent: allow trusted users on the lab network to watch measurements without
   editing the data library.
-- Boundary: the MVP may keep APIs observable, but should not promise remote
-  access or shared editing.
+- Boundary: the initial adoption slice may keep APIs observable, but should not
+  promise remote access or shared editing.
 
 CAP-019: Rich sample maps and saved views.
 
 - Intent: support user-defined spatial sample maps, richer sample metadata, and
   saved comparison views after the local data-library loop works.
-- Boundary: the MVP only needs optional sample/session context and correction.
-  Post-MVP map details belong in a dedicated spec or ADR.
+- Boundary: initial adoption only needs optional sample/session context and
+  correction. Strategic follow-on map details belong in a dedicated spec or
+  ADR.
 
 CAP-020: Measurement-code source setup and approved code update flows.
 
@@ -205,16 +210,17 @@ CAP-020: Measurement-code source setup and approved code update flows.
   releases, setup profiles, environment lock files, scan-schema helpers,
   measurement templates, plot presets, export recipes, and maintainer handoff
   for local changes.
-- Boundary: the MVP records honest provenance but does not own code deployment.
-  Scheduler or managed-execution behavior belongs to later capabilities.
+- Boundary: initial adoption records honest provenance but does not own code
+  deployment. Scheduler or managed-execution behavior belongs to later
+  capabilities.
 
 CAP-021: Parameter profiles and proposals.
 
 - Intent: promote repeated parameter snapshots into reusable profiles and
   reviewed proposals, with diffs and source evidence that make calibration
   changes inspectable instead of anonymous config-file edits.
-- Boundary: the MVP keeps only light parameter context summaries without a
-  registry UI or effective-configuration model.
+- Boundary: initial adoption keeps only light parameter context summaries,
+  without a registry UI or effective-configuration model.
 
 CAP-022: Analysis, interpretation, and calibration records.
 
@@ -222,7 +228,7 @@ CAP-022: Analysis, interpretation, and calibration records.
   anomaly review, calibration, and derived-result activity as first-class
   records that can cite input measurements, code context, parameter snapshots,
   generated artifacts, fitted values, and affected parameter paths.
-- Boundary: the MVP may export analysis-ready data but does not manage
+- Boundary: initial adoption may export analysis-ready data but does not manage
   calibration promotion. Detailed calibration workflow semantics belong in the
   future backlog.
 
@@ -233,7 +239,7 @@ CAP-023: Managed code snapshots and execution.
 - Boundary: managed code starts from selected importable Python entry points or
   SDK-integrated wrappers, not a general scheduler, shell-command runner, or
   workflow DAG.
-- Boundary: the MVP records unmanaged execution context only.
+- Boundary: initial adoption records unmanaged execution context only.
 
 CAP-024: Device boundary and managed device communication.
 
@@ -241,17 +247,17 @@ CAP-024: Device boundary and managed device communication.
   boundaries when Fricon begins controlling instruments, including later
   desired-state planning, observed-state readback, reconciliation diffs, and
   reviewed apply plans.
-- Boundary: the MVP may record passive setup/device summaries but does not talk
-  to instruments. Device apply is ADR-gated.
+- Boundary: initial adoption may record passive setup/device summaries but does
+  not talk to instruments. Device apply is ADR-gated.
 
 CAP-025: AI-assisted reviewed automation.
 
 - Intent: let AI propose actions or analysis steps that are reviewed before
   mutating the data library.
-- Boundary: the MVP should preserve auditability, not implement mutating AI
-  automation. AI-created durable conclusions should record provenance, and
-  mutating AI actions should enter through the same reviewed proposal path as
-  non-AI automation.
+- Boundary: initial adoption should preserve auditability, not implement
+  mutating AI automation. AI-created durable conclusions should record
+  provenance, and mutating AI actions should enter through the same reviewed
+  proposal path as non-AI automation.
 
 CAP-026: Dataset artifact discovery and direct open.
 

--- a/docs/product/capability-map.md
+++ b/docs/product/capability-map.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Vision Alignment
 

--- a/docs/product/epics/EPIC-001-local-setup-data-library.md
+++ b/docs/product/epics/EPIC-001-local-setup-data-library.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Product Goal
 

--- a/docs/product/epics/EPIC-001-local-setup-data-library.md
+++ b/docs/product/epics/EPIC-001-local-setup-data-library.md
@@ -10,7 +10,7 @@ A Local Measurement System Maintainer can install Fricon, create or open one
 local data library, and keep Python scripts runnable against it without
 assembling mismatched Desktop, CLI, Python SDK, and local runtime pieces.
 
-## MVP Scope
+## Initial Adoption Scope
 
 - Coherent local Fricon release for Desktop, CLI, Python SDK, and required
   local runtime components.
@@ -21,7 +21,7 @@ assembling mismatched Desktop, CLI, Python SDK, and local runtime pieces.
   offline or locked-down environments, pinned Python environments, and
   slow-to-update setups.
 
-## Not MVP
+## Not Initial Adoption
 
 - Hosted service, multi-user administration, or direct shared-folder database
   access.

--- a/docs/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs/product/epics/EPIC-002-new-measurement-logging.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Product Goal
 

--- a/docs/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs/product/epics/EPIC-002-new-measurement-logging.md
@@ -10,10 +10,11 @@ Replace the simple LabRAD Data Vault/Grapher loop for new measurements:
 declare measured data, append values from Python, watch it live, and reopen it
 later without manual file/folder discipline.
 
-This is the center of the MVP. It should stay close to ordinary Python
-measurement scripts instead of becoming a managed automation framework.
+This is the center of the initial adoption slice. It should stay close to
+ordinary Python measurement scripts instead of becoming a managed automation
+framework.
 
-## MVP Scope
+## Initial Adoption Scope
 
 - Explicit but low-ceremony Python measurement creation.
 - Measurement-scoped dataset artifact writers.
@@ -22,7 +23,7 @@ measurement scripts instead of becoming a managed automation framework.
   with raw schema for advanced cases.
 - Explicit scan semantics for reliable live and historical plots.
 
-## Not MVP
+## Not Initial Adoption
 
 - LabRAD compatibility server or built-in Data Vault parser.
 - Visual sweep builder as the primary acquisition model.

--- a/docs/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs/product/epics/EPIC-003-measurement-console-inspection.md
@@ -10,7 +10,7 @@ Fricon Desktop opens to current lab work: active/recent measurements, live
 datasets, quick plots, notes, favorites, partial/failed runs, and direct reopen
 actions.
 
-## MVP Scope
+## Initial Adoption Scope
 
 - Measurement-first console.
 - Active and recent measurement list.
@@ -20,7 +20,7 @@ actions.
 - Dataset direct-open entry points.
 - Favorites, notes, lifecycle flags, and basic search shortcuts.
 
-## Not MVP
+## Not Initial Adoption
 
 - Publication plotting.
 - Generic dashboard builder.

--- a/docs/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs/product/epics/EPIC-003-measurement-console-inspection.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Product Goal
 

--- a/docs/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs/product/epics/EPIC-004-recovery-reopen-export.md
@@ -9,7 +9,7 @@ Draft pending product-analysis revalidation.
 Interrupted or completed measurements remain useful. Users can recover context,
 reopen data from Python, and export a measurement for offline analysis.
 
-## MVP Scope
+## Initial Adoption Scope
 
 - Readable partial data and visible lifecycle state.
 - Trash/recover instead of normal hard delete.
@@ -20,7 +20,7 @@ reopen data from Python, and export a measurement for offline analysis.
 - Human-readable export manifest or index preview.
 - Privacy preview for sensitive provenance in exports.
 
-## Not MVP
+## Not Initial Adoption
 
 - Resumable managed execution.
 - Full offline viewer polish before the write/reopen loop works.

--- a/docs/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs/product/epics/EPIC-004-recovery-reopen-export.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Product Goal
 

--- a/docs/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -7,10 +7,11 @@ Draft pending product-analysis revalidation.
 ## Product Goal
 
 Help labs adopt Fricon for new measurements while old loggers, copied folders,
-and historical data remain where they are. This epic protects the MVP from
-becoming a legacy import project or a full automation stack.
+and historical data remain where they are. This epic protects the initial
+adoption slice from becoming a legacy import project or a full automation
+stack.
 
-## MVP Scope
+## Initial Adoption Scope
 
 - Data Vault-style script migration guidance for new measurements.
 - Source aliases and old-system references as metadata, not primary identity.
@@ -20,9 +21,9 @@ becoming a legacy import project or a full automation stack.
   that old scripts currently leave in copied folders.
 - Optional sample/session context that can be corrected after a run.
 
-## Post-MVP Scope
+## Strategic Follow-On Scope
 
-Detailed post-MVP priority and acceptance details live in
+Detailed strategic follow-on priority and acceptance details live in
 `product/future-concepts.md` and
 `product/future-stories-and-requirements.md`.
 

--- a/docs/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Product Goal
 

--- a/docs/product/future-concepts.md
+++ b/docs/product/future-concepts.md
@@ -2,14 +2,14 @@
 
 ## Status
 
-Accepted post-MVP priority ledger.
+Draft pending post-MVP product revalidation.
 
 ## Purpose
 
-Preserve important post-MVP directions without letting future systems inflate
+Preserve candidate post-MVP directions without letting future systems inflate
 the MVP measurement loop.
 
-This file owns the accepted priority order for post-MVP concepts. Candidate
+This file records a prior priority order for post-MVP concepts. Candidate
 stories and requirement details live in
 `product/future-stories-and-requirements.md`.
 
@@ -17,10 +17,11 @@ These are product priority horizons, not semantic-version promises. Compatible
 capabilities may ship on the same release line as the MVP if the compatibility,
 storage, and API policies allow it.
 
-Post-MVP concepts should move Fricon toward local experiment memory and
-reviewed action. The point is to explain, compare, hand off, repeat, and safely
-automate work from recorded facts, not to imitate legacy acquisition tools or
-make device control, sample visualization, or AI the product center by itself.
+Post-MVP concepts should be revalidated after the MVP product baseline is
+settled. The intended direction is local experiment memory and reviewed action:
+explain, compare, hand off, repeat, and safely automate work from recorded
+facts, not imitate legacy acquisition tools or make device control, sample
+visualization, or AI the product center by itself.
 
 ## Promotion Rule
 

--- a/docs/product/future-concepts.md
+++ b/docs/product/future-concepts.md
@@ -2,26 +2,26 @@
 
 ## Status
 
-Draft pending post-MVP product revalidation.
+Draft pending strategic follow-on product revalidation.
 
 ## Purpose
 
-Preserve candidate post-MVP directions without letting future systems inflate
-the MVP measurement loop.
+Preserve candidate strategic follow-on directions without letting future
+systems inflate the initial adoption measurement loop.
 
-This file records a prior priority order for post-MVP concepts. Candidate
-stories and requirement details live in
+This file records a prior priority order for strategic follow-on concepts.
+Candidate stories and requirement details live in
 `product/future-stories-and-requirements.md`.
 
 These are product priority horizons, not semantic-version promises. Compatible
-capabilities may ship on the same release line as the MVP if the compatibility,
-storage, and API policies allow it.
+capabilities may ship on the same release line as the initial adoption slice
+when compatibility, storage, and API policies allow it.
 
-Post-MVP concepts should be revalidated after the MVP product baseline is
-settled. The intended direction is local experiment memory and reviewed action:
-explain, compare, hand off, repeat, and safely automate work from recorded
-facts, not imitate legacy acquisition tools or make device control, sample
-visualization, or AI the product center by itself.
+Strategic follow-on concepts should be revalidated after the initial adoption
+product baseline is settled. The intended direction is local experiment memory
+and reviewed action: explain, compare, hand off, repeat, and safely automate
+work from recorded facts, not imitate legacy acquisition tools or make device
+control, sample visualization, or AI the product center by itself.
 
 ## Promotion Rule
 
@@ -148,7 +148,7 @@ Boundary:
 
 Included concepts: FC-001, FC-002, FC-011, FC-012, FC-013, FC-016.
 
-Candidate post-MVP stories and requirements live in
+Candidate strategic follow-on stories and requirements live in
 `product/future-stories-and-requirements.md`.
 
 ## Future Concept Definitions
@@ -157,7 +157,7 @@ FC-001: Read-only LAN monitoring.
 
 - Intent: support viewing, browsing, and export from trusted local-network
   clients without remote writes.
-- Boundary: this remains outside the MVP data-writing loop.
+- Boundary: this remains outside the initial adoption data-writing loop.
 
 FC-002: Rich sample maps and saved views.
 
@@ -227,14 +227,15 @@ FC-010: AI-assisted automation.
 FC-011: Resumable execution checkpoints.
 
 - Intent: add resumable execution checkpoints with a managed runner.
-- Boundary: this is later or ADR-gated and should not complicate unmanaged MVP
-  recovery.
+- Boundary: this is later or ADR-gated and should not complicate unmanaged
+  initial adoption recovery.
 
 FC-012: External large asset references.
 
 - Intent: reference detector files, images, waveforms, and other large external
   assets.
-- Boundary: this avoids turning the MVP into a general media asset library.
+- Boundary: this avoids turning the initial adoption slice into a general media
+  asset library.
 
 FC-013: User-facing dataset streams.
 

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -2,15 +2,16 @@
 
 ## Status
 
-Proposed post-MVP planning backlog.
+Draft pending post-MVP product revalidation.
 
 ## Purpose
 
 Capture candidate post-MVP user stories and product requirements before they
 become accepted product scope.
 
-These items are intentionally outside the accepted MVP. They exist so MVP
-storage, product-model, and API choices do not block likely future needs.
+These items are intentionally outside the current MVP hypothesis. They exist so
+MVP storage, product-model, and API choices do not block likely future needs
+after the MVP baseline is revalidated.
 
 This file uses priority horizons, not semantic-version labels. A compatible
 feature can still ship on the same release line as the MVP if the relevant
@@ -18,9 +19,10 @@ compatibility, storage, and API policies allow it.
 
 ## Planning Stance
 
-`product/future-concepts.md` owns the accepted post-MVP priority ledger and
+`product/future-concepts.md` records a prior post-MVP priority ledger and
 rationale. This backlog expands that ledger into candidate future epics,
-stories, and requirements.
+stories, and requirements. Treat both files as backlog context until the MVP
+product baseline is revalidated.
 
 Post-MVP work should prioritize:
 

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -2,29 +2,29 @@
 
 ## Status
 
-Draft pending post-MVP product revalidation.
+Draft pending strategic follow-on product revalidation.
 
 ## Purpose
 
-Capture candidate post-MVP user stories and product requirements before they
-become accepted product scope.
+Capture candidate strategic follow-on user stories and product requirements
+before they become accepted product scope.
 
-These items are intentionally outside the current MVP hypothesis. They exist so
-MVP storage, product-model, and API choices do not block likely future needs
-after the MVP baseline is revalidated.
+These items are intentionally outside the current initial adoption hypothesis.
+They exist so initial adoption storage, product-model, and API choices do not
+block likely future needs after the initial adoption baseline is revalidated.
 
 This file uses priority horizons, not semantic-version labels. A compatible
-feature can still ship on the same release line as the MVP if the relevant
-compatibility, storage, and API policies allow it.
+feature can still ship on the same release line as the initial adoption slice
+when compatibility, storage, and API policies allow it.
 
 ## Planning Stance
 
-`product/future-concepts.md` records a prior post-MVP priority ledger and
-rationale. This backlog expands that ledger into candidate future epics,
-stories, and requirements. Treat both files as backlog context until the MVP
-product baseline is revalidated.
+`product/future-concepts.md` records a prior strategic follow-on priority
+ledger and rationale. This backlog expands that ledger into candidate future
+epics, stories, and requirements. Treat both files as backlog context until the
+initial adoption product baseline is revalidated.
 
-Post-MVP work should prioritize:
+Strategic follow-on work should prioritize:
 
 - parameter system first
 - managed run second
@@ -473,7 +473,7 @@ before any device write-back is implemented.
 FREQ-012: Device apply, resumable execution, and AI-assisted mutation require
 separate ADRs covering safety, readback, partial failure, and audit behavior.
 
-FREQ-013: Post-MVP improvements remain local-first: no cloud account, hosted
+FREQ-013: Strategic follow-on improvements remain local-first: no cloud account, hosted
 dashboard, or central Fricon server is required for core parameter, run, or
 automation workflows.
 

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending terminology revalidation.
 
 ## Public MVP Terms
 

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -4,7 +4,7 @@
 
 Draft pending terminology revalidation.
 
-## Public MVP Terms
+## Public Initial Adoption Terms
 
 - Data Library: local Fricon root and catalog for measurements, samples,
   artifacts, and provenance.
@@ -23,20 +23,21 @@ Draft pending terminology revalidation.
   summary for selected local files and settings such as parameters, registries,
   wiring references, line/chip info, demod settings, or external runner config.
   It is not a global parameter profile or device inventory.
-- Code Provenance Summary: MVP record of what Fricon can honestly know about
-  measurement code, such as unmanaged label, optional script/notebook path, Git
-  summary, dirty-state signal, copied-folder/source-root label, or
-  user-supplied explanation. It is not a managed code snapshot or approval
-  record.
+- Code Provenance Summary: initial adoption record of what Fricon can honestly
+  know about measurement code, such as unmanaged label, optional
+  script/notebook path, Git summary, dirty-state signal,
+  copied-folder/source-root label, or user-supplied explanation. It is not a
+  managed code snapshot or approval record.
 - Setup Summary: optional passive setup, device, driver, environment, clock, or
   method context; describes, does not control.
 - Procedure Summary: optional passive procedure context such as unmanaged
   script, external runner, or declared plan; does not imply managed execution.
 - Measurement Code: user-authored Python that creates, runs, analyzes, or helps
-  explain a measurement. In the MVP this usually means an ordinary script,
-  notebook cell flow, Data Vault-style translated script, or copied lab folder.
-  Fricon records honest provenance for it; it does not package, approve,
-  deploy, snapshot, or execute the code unless later managed-run features exist.
+  explain a measurement. In the initial adoption slice this usually means an
+  ordinary script, notebook cell flow, Data Vault-style translated script, or
+  copied lab folder. Fricon records honest provenance for it; it does not
+  package, approve, deploy, snapshot, or execute the code unless later
+  managed-run features exist.
 - Operator Profile: lightweight local actor label for mutating actions on a
   shared lab computer.
 - Event/Audit Record: timeline record for lifecycle, note, correction, system
@@ -80,8 +81,9 @@ Draft pending terminology revalidation.
   snapshot to drive labels, color maps, comparisons, or visualizer state.
 - Measurement Code Source: configured upstream source for lab measurement code,
   such as a Git/Gitea repository, package, mirror, or maintained local folder.
-  Post-MVP, this should replace copied working folders as the normal code
-  provenance story for managed measurement, analysis, and calibration work.
+  In strategic follow-on slices, this should replace copied working folders as
+  the normal code provenance story for managed measurement, analysis, and
+  calibration work.
 - Managed Run Entry Point: importable Python function, module entry point, or
   small SDK-integrated wrapper selected for opt-in Fricon-managed execution. It
   is not a scheduler job, visual workflow, shell-command launcher, or generic
@@ -141,11 +143,11 @@ Draft pending terminology revalidation.
 - Automation Execution: status record for a reviewed action, including produced
   records and failure handling.
 
-## Avoid As Primary MVP User Terms
+## Avoid As Primary Initial Adoption User Terms
 
 - ActivityRun: internal shared pattern for measurement, analysis, import,
   simulation, and calibration work.
 - Stream: internal or advanced substructure for grouped payloads such as
-  primary/baseline data. Not an MVP user-facing concept.
+  primary/baseline data. Not user-facing initial adoption terminology.
 - Experiment: informal scientific wording or possible future grouping/template,
   not the first public acquisition record.

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -63,10 +63,10 @@ interpretation records. P-002 contributes technical guardrails when runtime,
 update, library, or environment safety matters.
 
 Physical setup, instrument, wiring, and device-state ownership is a distinct
-future boundary. MVP stories record those facts as passive setup context or
-run-bound local configuration. If later workflows review or mutate setup or
-device state, route that decision to an explicit setup/device owner rather than
-to P-002 by default; P-002 owns software-system readiness.
+future boundary. Initial adoption stories record those facts as passive setup
+context or run-bound local configuration. If later workflows review or mutate
+setup or device state, route that decision to an explicit setup/device owner
+rather than to P-002 by default; P-002 owns software-system readiness.
 
 ## P-001 Measurement Run Operator
 
@@ -230,8 +230,8 @@ Context and pressure:
 - may rely on P-002 for runtime, package, deployment, or diagnostic support
 - needs migration ergonomics that do not require rewriting the whole
   measurement stack at once
-- creates post-MVP pressure for approved code sources, managed entry points,
-  templates, and reviewed updates
+- creates strategic follow-on pressure for approved code sources, managed
+  entry points, templates, and reviewed updates
 
 Common switches:
 

--- a/docs/product/product-analysis-progress.md
+++ b/docs/product/product-analysis-progress.md
@@ -7,10 +7,11 @@ Accepted as the product-analysis progress tracker.
 ## Purpose
 
 Track how far the greenfield product analysis has actually progressed, and
-which product documents are trusted inputs versus provisional material.
+which analysis questions still need work before downstream domain,
+architecture, spec, or implementation planning starts.
 
-This file does not define product scope. It records confidence, open work, and
-the order in which product documents should be revalidated.
+This file does not define product scope. It records analysis progress,
+confidence, open questions, and the next analysis sequence.
 
 ## Current Situation
 
@@ -27,9 +28,9 @@ The most carefully reviewed current inputs are:
   product-role thinking.
 
 Other product documents should be treated as draft derived material until they
-are revalidated from those two inputs and the current greenfield questions.
+are rederived or checked against the current greenfield analysis.
 
-## Confidence Levels
+## Document Confidence
 
 High-confidence product inputs:
 
@@ -41,14 +42,14 @@ Provisional product helpers:
 - `product/glossary.md`
 - `product/python-sdk-ux.md`
 
-Draft derived product artifacts pending revalidation:
+Draft derived product artifacts:
 
 - `product/capability-map.md`
 - `product/story-map.md`
 - `product/epics/`
 - `product/user-stories/`
 
-Backlog material only:
+Strategic follow-on backlog material:
 
 - `product/future-concepts.md`
 - `product/future-stories-and-requirements.md`
@@ -63,38 +64,44 @@ Downstream material not ready for implementation use:
 
 ## Greenfield Analysis Progress
 
-| Step | Current State | Next Action |
+| Step | Current State | Next Analysis Action |
 | --- | --- | --- |
 | Problem framing | Strong but should be summarized more sharply | Add a concise problem hypothesis if needed. |
 | User and role analysis | Strong current baseline | Keep refining only when new case evidence appears. |
-| Use case discovery | Draft, mostly derived from older docs | Rebuild through capability and story-map review. |
+| Use case discovery | Partial | Reconstruct the initial adoption journey from `vision.md`, `personas.md`, and case evidence. |
 | Alternatives and market analysis | Draft research synthesis exists | Use only for focused pressure, not product authority. |
 | Value proposition | Clear internally | Write a short external-facing value statement later. |
-| Scope definition | Draft despite detailed text | Revalidate initial adoption, strategic follow-on, and rejected scope from current inputs. |
-| Core workflow | Draft | Rebuild after capability revalidation. |
-| Capability map | Next critical target | Review each capability as keep, revise, defer, or reject. |
-| Initial adoption definition | Draft | Accept only after capability and story map are rederived. |
+| Core workflow | Partial | Define the initial adoption story backbone before editing capabilities. |
+| Story map | Draft, mostly derived from older docs | Rebuild from the story backbone and role goals. |
+| Capability map | Draft, mostly derived from older docs | Derive capabilities from accepted journeys and stories, then cross-check for gaps. |
+| Scope definition | Draft despite detailed text | Separate initial adoption, strategic follow-on, ADR-gated, and rejected scope after story/capability analysis. |
+| Initial adoption definition | Draft | Accept only after the journey, story map, and supporting capabilities cohere. |
 | Success metrics | Missing | Define measurable product and validation signals. |
 | Risks and assumptions | Partial | Add an explicit assumption and validation register. |
 | Validation plan | Missing | Define interviews, prototype checks, and migration-script trials. |
-| Product requirements | Not implementation-ready | Derive later from revalidated capabilities and stories. |
-| Domain analysis | Deferred | Start only after product revalidation. |
+| Product requirements | Not implementation-ready | Derive later from accepted journeys, stories, capabilities, and validation results. |
+| Domain analysis | Deferred | Start only after the product analysis baseline is stable. |
 | Architecture inputs | Deferred | Start only after product and domain baselines are stable. |
 
-## Current Revalidation Rule
+## Next Analysis Sequence
 
-Do not use draft product documents to start domain modeling, architecture, specs,
-or implementation planning.
+Use the current product documents as input evidence, not as the analysis order.
+The next work should proceed from user work to product capabilities:
 
-The next product-analysis task should be a systematic review of
-`product/capability-map.md`. For each capability, decide:
+1. Write or confirm the concise problem hypothesis.
+2. Define the initial adoption journey and story backbone.
+3. Rebuild `product/story-map.md` from that backbone.
+4. Recheck epics and user stories against the rebuilt story map.
+5. Derive `product/capability-map.md` from the accepted stories.
+6. Add success signals, assumptions, and validation tasks.
 
-- Keep: directly supported by `vision.md`, `personas.md`, and current case
-  evidence.
-- Revise: direction is useful but wording, scope, or boundary is stale.
-- Defer: plausible future direction, but not part of the initial adoption
-  product baseline.
-- Reject: old planning residue or inconsistent with the current direction.
+Capability review should follow story analysis. A capability without story or
+journey support should be deferred, rewritten as a backlog hypothesis, or
+rejected as old planning residue.
 
-After that review, rebuild `product/story-map.md`, then revalidate epics and
-user stories from the revalidated capability set.
+## Downstream Guardrail
+
+Do not use draft product documents to start domain modeling, architecture,
+specs, or implementation planning. Downstream work should wait until the
+greenfield analysis has accepted the relevant journeys, stories, capabilities,
+scope boundaries, and validation posture.

--- a/docs/product/product-analysis-progress.md
+++ b/docs/product/product-analysis-progress.md
@@ -1,0 +1,99 @@
+# Product Analysis Progress
+
+## Status
+
+Accepted as the product-analysis progress tracker.
+
+## Purpose
+
+Track how far the greenfield product analysis has actually progressed, and
+which product documents are trusted inputs versus provisional material.
+
+This file does not define product scope. It records confidence, open work, and
+the order in which product documents should be revalidated.
+
+## Current Situation
+
+Fricon restarted product analysis after earlier planning became difficult to
+continue from. Some current product documents were extracted from older
+planning material. They may contain useful lessons, but they were not all
+derived systematically from the current greenfield direction.
+
+The most carefully reviewed current inputs are:
+
+- `product/vision.md`, refined from the current clean-reset direction and the
+  user-supplied sample codebase review.
+- `product/personas.md`, refined from the same case-study pressure and current
+  product-role thinking.
+
+Other product documents should be treated as draft derived material until they
+are revalidated from those two inputs and the current greenfield questions.
+
+## Confidence Levels
+
+High-confidence product inputs:
+
+- `product/vision.md`
+- `product/personas.md`
+
+Provisional product helpers:
+
+- `product/glossary.md`
+- `product/python-sdk-ux.md`
+
+Draft derived product artifacts pending revalidation:
+
+- `product/capability-map.md`
+- `product/story-map.md`
+- `product/epics/`
+- `product/user-stories/`
+
+Backlog material only:
+
+- `product/future-concepts.md`
+- `product/future-stories-and-requirements.md`
+
+Downstream material not ready for implementation use:
+
+- `domain/`
+- `architecture/`, except the accepted reset constraints and compatibility
+  policy
+- `specs/`
+- `implementation-plans/`
+
+## Greenfield Analysis Progress
+
+| Step | Current State | Next Action |
+| --- | --- | --- |
+| Problem framing | Strong but should be summarized more sharply | Add a concise problem hypothesis if needed. |
+| User and role analysis | Strong current baseline | Keep refining only when new case evidence appears. |
+| Use case discovery | Draft, mostly derived from older docs | Rebuild through capability and story-map review. |
+| Alternatives and market analysis | Draft research synthesis exists | Use only for focused pressure, not product authority. |
+| Value proposition | Clear internally | Write a short external-facing value statement later. |
+| Scope definition | Draft despite detailed text | Revalidate MVP, post-MVP, and rejected scope from current inputs. |
+| Core workflow | Draft | Rebuild after capability revalidation. |
+| Capability map | Next critical target | Review each capability as keep, revise, defer, or reject. |
+| MVP definition | Draft | Accept only after capability and story map are rederived. |
+| Success metrics | Missing | Define measurable product and validation signals. |
+| Risks and assumptions | Partial | Add an explicit assumption and validation register. |
+| Validation plan | Missing | Define interviews, prototype checks, and migration-script trials. |
+| Product requirements | Not implementation-ready | Derive later from revalidated capabilities and stories. |
+| Domain analysis | Deferred | Start only after product revalidation. |
+| Architecture inputs | Deferred | Start only after product and domain baselines are stable. |
+
+## Current Revalidation Rule
+
+Do not use draft product documents to start domain modeling, architecture, specs,
+or implementation planning.
+
+The next product-analysis task should be a systematic review of
+`product/capability-map.md`. For each capability, decide:
+
+- Keep: directly supported by `vision.md`, `personas.md`, and current case
+  evidence.
+- Revise: direction is useful but wording, scope, or boundary is stale.
+- Defer: plausible future direction, but not MVP product baseline.
+- Reject: old planning residue or inconsistent with the current direction.
+
+After that review, rebuild `product/story-map.md`, then revalidate epics and
+user stories from the revalidated capability set.

--- a/docs/product/product-analysis-progress.md
+++ b/docs/product/product-analysis-progress.md
@@ -70,10 +70,10 @@ Downstream material not ready for implementation use:
 | Use case discovery | Draft, mostly derived from older docs | Rebuild through capability and story-map review. |
 | Alternatives and market analysis | Draft research synthesis exists | Use only for focused pressure, not product authority. |
 | Value proposition | Clear internally | Write a short external-facing value statement later. |
-| Scope definition | Draft despite detailed text | Revalidate MVP, post-MVP, and rejected scope from current inputs. |
+| Scope definition | Draft despite detailed text | Revalidate initial adoption, strategic follow-on, and rejected scope from current inputs. |
 | Core workflow | Draft | Rebuild after capability revalidation. |
 | Capability map | Next critical target | Review each capability as keep, revise, defer, or reject. |
-| MVP definition | Draft | Accept only after capability and story map are rederived. |
+| Initial adoption definition | Draft | Accept only after capability and story map are rederived. |
 | Success metrics | Missing | Define measurable product and validation signals. |
 | Risks and assumptions | Partial | Add an explicit assumption and validation register. |
 | Validation plan | Missing | Define interviews, prototype checks, and migration-script trials. |
@@ -92,7 +92,8 @@ The next product-analysis task should be a systematic review of
 - Keep: directly supported by `vision.md`, `personas.md`, and current case
   evidence.
 - Revise: direction is useful but wording, scope, or boundary is stale.
-- Defer: plausible future direction, but not MVP product baseline.
+- Defer: plausible future direction, but not part of the initial adoption
+  product baseline.
 - Reject: old planning residue or inconsistent with the current direction.
 
 After that review, rebuild `product/story-map.md`, then revalidate epics and

--- a/docs/product/python-sdk-ux.md
+++ b/docs/product/python-sdk-ux.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed product-level SDK usage guideline.
+Draft pending SDK experience revalidation.
 
 ## Purpose
 

--- a/docs/product/python-sdk-ux.md
+++ b/docs/product/python-sdk-ux.md
@@ -43,10 +43,10 @@ the run, what scan shape should be plotted, and how results are reopened later.
 
 In this guideline, measurement code remains ordinary Python first: notebooks,
 scripts, translated Data Vault-style scripts, importable functions, and local
-lab folders are all plausible shapes. The MVP should record honest provenance
-for those shapes. Managed-run entry points, code snapshots, approved code
-sources, and update flows are post-MVP product directions, not accepted SDK API
-mechanics.
+lab folders are all plausible shapes. The initial adoption slice should record
+honest provenance for those shapes. Managed-run entry points, code snapshots,
+approved code sources, and update flows are strategic follow-on product
+directions, not accepted SDK API mechanics.
 
 For common workflows, Fricon should provide appropriate simplification without
 pretending the right simplification is known before use. The exact API shape

--- a/docs/product/story-map.md
+++ b/docs/product/story-map.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Purpose
 

--- a/docs/product/story-map.md
+++ b/docs/product/story-map.md
@@ -7,8 +7,8 @@ Draft pending product-analysis revalidation.
 ## Purpose
 
 Keep the product route readable for future AI sessions. This file is a compact
-map from the product vision to MVP stories, not the place for full acceptance
-details.
+map from the product vision to initial adoption stories, not the place for full
+acceptance details.
 
 ## Backbone
 
@@ -25,12 +25,12 @@ Install and set up
   -> export
 ```
 
-## MVP Product Epics
+## Initial Adoption Product Epics
 
-The MVP route is the LabRAD Data Vault/Grapher replacement loop for new
-measurements: write from Python, watch live, recover partial data, reopen, and
-export. The epics below divide that route without making legacy import or
-managed automation part of the MVP.
+The initial adoption route is the LabRAD Data Vault/Grapher replacement loop
+for new measurements: write from Python, watch live, recover partial data,
+reopen, and export. The epics below divide that route without making legacy
+import or managed automation part of the first adoption slice.
 
 - EPIC-001: Local setup and data-library adoption.
 - EPIC-002: New measurement logging replacement.
@@ -40,7 +40,7 @@ managed automation part of the MVP.
 
 Detailed epic notes live under `product/epics/`.
 
-## MVP Story Index
+## Initial Adoption Story Index
 
 Ownership rules:
 
@@ -94,8 +94,9 @@ Migration ownership:
 - US-018 is owned by EPIC-005. EPIC-004 owns reopen/export for Fricon data, not
   the product migration posture.
 
-Each MVP story has an expanded file under `product/user-stories/`. Keep those
-files concise: they own story-level success criteria, not implementation tasks.
+Each initial adoption story has an expanded file under `product/user-stories/`.
+Keep those files concise: they own story-level success criteria, not
+implementation tasks.
 
 ## Sequencing
 
@@ -104,20 +105,21 @@ and US-015 to record, inspect, recover, and reopen a Python measurement while
 preserving first-class dataset discovery. The milestone plan should be derived
 after the product baseline and required architecture or ADR inputs are accepted.
 
-The full MVP also needs US-009 for export, US-017/US-018 to validate the
-incremental adoption posture, and US-019 to make copied local configuration
-visible: users can translate new Data Vault-style scripts, keep old history in
-the old system, and bind the run-relevant files or summaries that old scripts
-currently leave in folders and operator memory.
+The full initial adoption slice also needs US-009 for export, US-017/US-018 to
+validate the incremental adoption posture, and US-019 to make copied local
+configuration visible. Users should be able to translate new Data Vault-style
+scripts, keep old history in the old system, and bind the run-relevant files or
+summaries that old scripts currently leave in folders and operator memory.
 
 Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;
 detailed API signatures and capture mechanics belong in later ADRs/specs.
 
-Post-MVP work should turn the MVP facts into local experiment memory and
-reviewed action. Those priorities are outside the MVP story index and are owned
-by `product/future-concepts.md`.
+Strategic follow-on work should turn initial adoption facts into local
+experiment memory and reviewed action. Those priorities are outside the initial
+adoption story index and live as draft backlog context in
+`product/future-concepts.md`.
 
-Export remains an MVP product promise. Detailed export/offline-analysis
-requirements should be derived in a later spec after the product, architecture,
-and ADR boundaries are accepted.
+Export remains an initial adoption product promise. Detailed
+export/offline-analysis requirements should be derived in a later spec after
+the product, architecture, and ADR boundaries are accepted.

--- a/docs/product/story-module-matrix.md
+++ b/docs/product/story-module-matrix.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Deferred.
+Deferred pending product-analysis revalidation.
 
 ## Purpose
 

--- a/docs/product/user-stories/US-001-install-and-launch.md
+++ b/docs/product/user-stories/US-001-install-and-launch.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-001-install-and-launch.md
+++ b/docs/product/user-stories/US-001-install-and-launch.md
@@ -33,7 +33,7 @@ incompatible pieces by hand.
 - Hosted service, multi-user administration, or direct shared-folder database
   editing.
 - Enterprise deployment polish before the local loop works.
-- Full source-code or Python-environment management during the MVP.
+- Full source-code or Python-environment management during initial adoption.
 
 ## Related Capabilities
 

--- a/docs/product/user-stories/US-002-create-open-data-library.md
+++ b/docs/product/user-stories/US-002-create-open-data-library.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-003-run-exploratory-measurement.md
+++ b/docs/product/user-stories/US-003-run-exploratory-measurement.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-004-produce-dataset-artifacts.md
+++ b/docs/product/user-stories/US-004-produce-dataset-artifacts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs/product/user-stories/US-005-watch-and-inspect.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-006-recover-partial-measurement.md
+++ b/docs/product/user-stories/US-006-recover-partial-measurement.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-007-annotate-right-level.md
+++ b/docs/product/user-stories/US-007-annotate-right-level.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-008-reopen-measurement-outputs.md
+++ b/docs/product/user-stories/US-008-reopen-measurement-outputs.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-009-export-measurement.md
+++ b/docs/product/user-stories/US-009-export-measurement.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-010-update-without-corrupting-work.md
+++ b/docs/product/user-stories/US-010-update-without-corrupting-work.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-010-update-without-corrupting-work.md
+++ b/docs/product/user-stories/US-010-update-without-corrupting-work.md
@@ -27,11 +27,11 @@ Desktop, local runtime, CLI, Python SDK, or library versions.
   imports, exports, or repair work without explicit user intent.
 - Users can defer update work until the local measurement environment is idle.
 - Locked-down lab-computer needs such as offline installers, rollback, or
-  side-by-side installs remain product pressure, not MVP polish.
+  side-by-side installs remain product pressure, not initial adoption polish.
 
 ## Not In Scope
 
-- Stable third-party protocol commitments before the MVP is proven.
+- Stable third-party protocol commitments before initial adoption is proven.
 - Automatic migration of old v0.1 workspaces or legacy systems.
 - Silent auto-update while measurement work is active.
 

--- a/docs/product/user-stories/US-011-record-code-provenance.md
+++ b/docs/product/user-stories/US-011-record-code-provenance.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-011-record-code-provenance.md
+++ b/docs/product/user-stories/US-011-record-code-provenance.md
@@ -28,8 +28,8 @@ judge trustworthiness without pretending Fricon managed execution.
   explains selected files or settings that were active.
 - The product model leaves room for approved code releases, setup profiles,
   environment lock files, scan helpers, plot presets, export recipes, and
-  handoff to a Local Measurement System Maintainer without making them MVP
-  code-management features.
+  handoff to a Local Measurement System Maintainer without making them initial
+  adoption code-management features.
 - Provenance can be previewed or omitted during export when it contains
   sensitive local details.
 - Corrections to provenance are visible as events.

--- a/docs/product/user-stories/US-012-register-sample-session.md
+++ b/docs/product/user-stories/US-012-register-sample-session.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-013-find-open-dataset-artifact.md
+++ b/docs/product/user-stories/US-013-find-open-dataset-artifact.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-014-record-passive-setup-context.md
+++ b/docs/product/user-stories/US-014-record-passive-setup-context.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-015-declare-common-scan-shapes.md
+++ b/docs/product/user-stories/US-015-declare-common-scan-shapes.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-016-record-passive-procedure-context.md
+++ b/docs/product/user-stories/US-016-record-passive-procedure-context.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -32,7 +32,8 @@ experiment stack.
   references that the old script relied on.
 - The writer model does not block later user-written import scripts, but old
   data import is not part of the migration path for starting new work.
-- The MVP does not ship a built-in Data Vault parser or legacy browser.
+- The initial adoption slice does not ship a built-in Data Vault parser or
+  legacy browser.
 
 ## Not In Scope
 

--- a/docs/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -16,7 +16,7 @@ it is so that migration does not block new data collection.
 
 ## Success Criteria
 
-- The MVP communicates that old history can stay in the old system.
+- Initial adoption communicates that old history can stay in the old system.
 - New Fricon measurements may record source aliases or legacy references.
 - Later user-written import scripts can use generic APIs when old data needs to
   move forward.
@@ -24,7 +24,7 @@ it is so that migration does not block new data collection.
 
 ## Not In Scope
 
-- Built-in legacy import as an MVP adoption prerequisite.
+- Built-in legacy import as a prerequisite for initial adoption.
 - Making reopen/export own old-system history migration.
 
 ## Related Capabilities

--- a/docs/product/user-stories/US-018-start-new-work-keep-old-history.md
+++ b/docs/product/user-stories/US-018-start-new-work-keep-old-history.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
+++ b/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Draft pending product-analysis revalidation.
 
 ## Primary Epic
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted clean-reset product baseline.
+High-confidence product input; derived scope pending revalidation.
 
 ## Thesis
 
@@ -17,10 +17,24 @@ trust decisions, handoff, and reviewed replay.
 
 ## Planning Language
 
-This document uses MVP, post-MVP, and ADR-gated as product priority labels.
-They are not semantic-version labels. Compatible improvements can still ship on
-the same compatible release line when the storage, API, and compatibility
-policies allow it.
+This document uses planning horizons, not semantic-version labels.
+
+Initial Adoption Slice means the first practical Fricon release path that lets
+a lab start new measurement work with a useful write, watch, recover, reopen,
+and export loop. It is not a claim that other capabilities are less important.
+It comes first because it can provide standalone value while generating real
+Fricon records and usage feedback.
+
+Strategic Follow-On means product-core capabilities that remain central to
+Fricon's thesis, but are sequenced after the initial adoption slice because
+they depend on accepted product evidence, domain semantics, architecture
+decisions, or safety and review boundaries. Parameter management, managed run,
+calibration evidence, and reviewed automation belong here by dependency, not by
+importance.
+
+ADR-gated means a direction may be valuable, but should not become durable
+product scope before its compatibility, safety, data semantics, or architecture
+decision is recorded.
 
 ## Long-Term Motivation
 
@@ -39,7 +53,7 @@ aim is not only to store results, but to make the relationship between a
 measurement, its datasets, its Python code, its context, and its later
 interpretation explicit enough for humans and future automation to trust.
 
-The highest-value post-MVP lesson from legacy workflows is the code-and-parameter
+The highest-value later lesson from legacy workflows is the code-and-parameter
 management loop: copied code, mutable local configuration, generated sidecars,
 and notebook-local analysis make calibration hard to trust. Fricon should first
 make the recorded facts durable enough to explain, compare, hand off, repeat,
@@ -47,8 +61,8 @@ and then safely automate work.
 
 The long-term center is not device control, sample visualization, or AI by
 itself. Those capabilities matter when they serve trustworthy experiment
-memory, reviewable changes, and safer reuse. Detailed post-MVP ordering lives
-in `product/future-concepts.md`; future terminology is owned by
+memory, reviewable changes, and safer reuse. Strategic follow-on ordering is a
+draft hypothesis in `product/future-concepts.md`; future terminology lives in
 `product/glossary.md`.
 
 The product should stay close to how experimentalists already work: Python
@@ -57,8 +71,9 @@ without a server account model, and higher-provenance workflows grow from the
 same core experience instead of becoming a separate system.
 
 Staying close to current practice does not mean freezing current practice as
-the ideal model. Post-MVP Fricon can introduce higher-provenance workflows, but
-only after the relevant facts, review boundaries, and safety model are explicit.
+the ideal model. Later Fricon slices can introduce higher-provenance workflows,
+but only after the relevant facts, review boundaries, and safety model are
+explicit.
 
 ## Adoption Strategy
 
@@ -87,19 +102,19 @@ Transition features should point toward the full Fricon workflow:
   handoff artifacts rather than the system of record
 
 If a legacy need cannot fit one of these bridge forms, it should not become an
-MVP product concept without explicit product and architecture review.
+initial adoption concept without explicit product and architecture review.
 
-## MVP Goal
+## Initial Adoption Goal
 
-The MVP goal is practical: replace the simple LabRAD Data Vault/Grapher loop
-for new measurements.
+The initial adoption goal is practical: replace the simple LabRAD Data
+Vault/Grapher loop for new measurements.
 
 Success means a user can start new measurement work in Fricon, write data from
 Python, watch it live, recover partial results, reopen it later, and export it
-without depending on old storage paths or notebook-only reconstruction. The MVP
-does not need to import old history or emulate LabRAD; old LabRAD, QCoDeS,
-Labber, or folder-based history can remain where it is while new work moves to
-Fricon.
+without depending on old storage paths or notebook-only reconstruction. The
+initial adoption slice does not need to import old history or emulate LabRAD;
+old LabRAD, QCoDeS, Labber, or folder-based history can remain where it is
+while new work moves to Fricon.
 
 ## User Promise
 
@@ -113,7 +128,7 @@ Fricon should help a researcher answer:
 - Which selected local configuration files or summaries were bound to it?
 - How do I inspect it live, reopen it from Python, export it, or recover it?
 
-After the MVP, Fricon should also help answer:
+Strategic follow-on slices should also help answer:
 
 - What changed since the previous good run?
 - Why did this run succeed, fail, or become questionable?
@@ -136,7 +151,7 @@ It produced datasets.
 Fricon helps me inspect, annotate, recover, reopen, and export them.
 ```
 
-Post-MVP, the product should extend that model:
+Strategic follow-on slices should extend that model:
 
 ```text
 I can choose a previous-good run or routine.
@@ -168,24 +183,24 @@ accepts exact API syntax.
 ## Measurement Code Shape
 
 At product level, measurement code means the user-authored Python that creates
-or explains measurement work. In the MVP, this mainly includes ordinary Python
-scripts, notebook cell flows, Data Vault-style translated scripts, and copied
-lab working folders. Fricon should record honest context for these forms
-without pretending it owns their execution.
+or explains measurement work. In the initial adoption slice, this mainly
+includes ordinary Python scripts, notebook cell flows, Data Vault-style
+translated scripts, and copied lab working folders. Fricon should record honest
+context for these forms without pretending it owns their execution.
 
-The MVP code promise is provenance, not code management. Fricon may record an
-unmanaged label, optional script or notebook path, Git summary, dirty-state
-signal, copied-folder/source-root label, user summary, and export privacy
-choice. It should not claim automatic notebook capture, approved code releases,
-deployment, immutable code snapshots, or managed execution.
+The initial adoption code promise is provenance, not code management. Fricon
+may record an unmanaged label, optional script or notebook path, Git summary,
+dirty-state signal, copied-folder/source-root label, user summary, and export
+privacy choice. It should not claim automatic notebook capture, approved code
+releases, deployment, immutable code snapshots, or managed execution.
 
-Post-MVP code management should grow toward configured measurement code
-sources, approved update flows, importable managed-run entry points, and code
-snapshots only after the product facts and review boundaries are clear.
+Strategic follow-on code management should grow toward configured measurement
+code sources, approved update flows, importable managed-run entry points, and
+code snapshots only after the product facts and review boundaries are clear.
 
-## MVP Scope
+## Initial Adoption Scope
 
-To meet the MVP goal, the MVP should include:
+To meet the initial adoption goal, the first adoption slice should include:
 
 - one local data library per normal lab computer
 - explicit measurements
@@ -205,7 +220,8 @@ To meet the MVP goal, the MVP should include:
   environment, and unmanaged procedure context
 - selected run-bound local configuration snapshots or summaries, such as
   parameter files, registry files, wiring references, line/chip info, or
-  demod/readout settings, without turning MVP into a full parameter registry
+  demod/readout settings, without turning initial adoption into a full
+  parameter registry
 - Python reopen snippets through public APIs
 - a near-term measurement export spec for portable bundles and common analysis
   formats
@@ -236,16 +252,16 @@ work starts:
   multiple measurements or views at once while acquisition keeps running.
 - Measurement-code and run-configuration ideas should stay focused on the user
   pain of copied folders, mutable local files, setup sidecars, scan helpers,
-  plot presets, and export recipes. The MVP records honest context; approved
-  code update and managed execution remain post-MVP.
+  plot presets, and export recipes. Initial adoption records honest context;
+  approved code update and managed execution remain strategic follow-on.
 - Mutating actions should be attributable enough for local lab history, but the
-  MVP must not turn this into accounts, roles, permissions, or remote
-  collaboration.
+  first adoption slice must not turn this into accounts, roles, permissions, or
+  remote collaboration.
 
-## Post-MVP Direction
+## Strategic Follow-On Direction
 
-At the vision level, post-MVP work should extend the MVP facts into three user
-loops:
+At the vision level, strategic follow-on work should extend the facts recorded
+during initial adoption into three user loops:
 
 - Explain: run manifests, parameter/code/setup provenance, lifecycle evidence,
   analysis attempts, and failure or anomaly investigation.
@@ -254,8 +270,9 @@ loops:
 - Repeat: run-like-previous drafts, reviewed parameter proposals, routine
   recipes, and audited automation after the facts are trustworthy.
 
-Implementation should not treat post-MVP ordering as accepted until the product
-baseline is revalidated. The current post-MVP priority hypothesis is:
+Implementation should not treat strategic follow-on ordering as accepted until
+the product baseline is revalidated. The current strategic follow-on priority
+hypothesis is:
 
 - parameter system first
 - managed run second
@@ -273,7 +290,7 @@ sample-map authoring, device communication, resumable execution, user-facing
 stream concepts, and AI-assisted automation. Mutation-capable calibration or
 device apply remains ADR-gated.
 
-## Non-Goals For MVP
+## Non-Goals For Initial Adoption
 
 - hosted SaaS
 - account/team administration

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -254,7 +254,8 @@ loops:
 - Repeat: run-like-previous drafts, reviewed parameter proposals, routine
   recipes, and audited automation after the facts are trustworthy.
 
-Implementation should follow the accepted priority ledger:
+Implementation should not treat post-MVP ordering as accepted until the product
+baseline is revalidated. The current post-MVP priority hypothesis is:
 
 - parameter system first
 - managed run second

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -35,6 +35,7 @@ Covered:
 - EPICS Archiver, Olog, eLabFTW, LabKey, openBIS, and calibration-ledger tools
 
 Accepted synthesis lives in `lessons-for-fricon.md`. The broader source list
-and post-MVP planning synthesis live in `post-mvp-future-systems.md`.
+and strategic follow-on planning synthesis live in
+`strategic-follow-on-future-systems.md`.
 Concrete migration pressure from local legacy measurement sample work
 directories lives in `legacy-measurement-sample-lessons.md`.

--- a/docs/research/legacy-measurement-sample-lessons.md
+++ b/docs/research/legacy-measurement-sample-lessons.md
@@ -102,22 +102,22 @@ Fricon should make the following facts first-class for new work:
   parameters, code/procedure context, and fitted values they used.
 - Measurement-centered export that carries semantic context, not just bytes.
 
-The MVP should still avoid LabRAD emulation, old-history import, broad device
-control, a full parameter registry, and automatic tracing of every file an
-unmanaged script reads.
+The initial adoption slice should still avoid LabRAD emulation, old-history
+import, broad device control, a full parameter registry, and automatic tracing
+of every file an unmanaged script reads.
 
-## Post-MVP Product Pressure
+## Strategic Follow-On Product Pressure
 
-The samples also point beyond the MVP replacement loop:
+The samples also point beyond the initial adoption replacement loop:
 
 - Legacy folders are not just storage debt; they are missing experiment memory.
 - Repetition currently depends on copied code, mutable config, and operator
   recall.
-- The most valuable post-MVP improvement is to make code provenance,
+- The most valuable strategic follow-on improvement is to make code provenance,
   effective parameter snapshots, generated sidecars, calibration evidence, and
   accepted parameter changes inspectable together.
-- Fricon's post-MVP advantage should be reviewed reuse of recorded facts, not
-  emulation of legacy paths.
+- Fricon's strategic follow-on advantage should be reviewed reuse of recorded
+  facts, not emulation of legacy paths.
 - Read-only compare, handoff, run-like-previous drafts, and failure
   investigation should arrive before mutation-capable automation.
 - Parameter proposals should promote effective or fitted settings only after

--- a/docs/research/strategic-follow-on-future-systems.md
+++ b/docs/research/strategic-follow-on-future-systems.md
@@ -1,4 +1,4 @@
-# Post-MVP Future Systems Research
+# Strategic Follow-On Future Systems Research
 
 ## Status
 
@@ -10,12 +10,12 @@ Draft research synthesis.
 
 ## Purpose
 
-Capture background lessons for post-MVP parameter systems, managed code
-snapshots, runner capture, setup state, calibration history, and generated run
-history.
+Capture background lessons for strategic follow-on parameter systems, managed
+code snapshots, runner capture, setup state, calibration history, and generated
+run history.
 
 This research informs `product/future-stories-and-requirements.md`; it does
-not change accepted MVP scope.
+not change initial adoption scope.
 
 ## Sources
 
@@ -95,9 +95,9 @@ Modern desired-state and reviewable-apply references:
 
 ## Product Lessons
 
-- Parameter drift is a standalone product problem. Post-MVP parameter work
-  should treat named parameter profiles, immutable snapshots, proposals,
-  overrides, and diffs as first-class concepts.
+- Parameter drift is a standalone product problem. Strategic follow-on
+  parameter work should treat named parameter profiles, immutable snapshots,
+  proposals, overrides, and diffs as first-class concepts.
 - Code and parameter drift are coupled in practice. Calibration cannot be
   reliably automated while fitted values depend on copied measurement folders,
   mutable config files, notebook-local analysis, or generated sidecars that are


### PR DESCRIPTION
## Summary
- Reframed the v0.2 docs around an initial adoption slice instead of MVP/post-MVP language.
- Added a product analysis progress tracker to separate greenfield analysis progress from downstream revalidation.
- Reworked the product guidance, story map, capability map, glossary, research notes, and related routing docs so later work stays sequenced behind the current analysis baseline.

## Testing
- Not run (docs-only changes)