### PR TITLE
docs: sharpen product framing for initial adoption

### DIFF
--- a/docs/ai/project-context.md
+++ b/docs/ai/project-context.md
@@ -22,9 +22,9 @@ capabilities, stories, epics, or strategic follow-on backlog material.
 Primary user model:
 
 ```text
-I ran a measurement.
+I ran an interactive measurement from Python.
 It produced datasets.
-Fricon helps me inspect, annotate, recover, reopen, and export them.
+Fricon helps me monitor, recover, reopen, and export them.
 ```
 
 ## Hard Boundaries
@@ -38,6 +38,11 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
 - Do not bypass local runtime compatibility checks for mutating Python APIs.
 - Do not introduce SaaS, accounts, teams, roles, or distributed database
   behavior for the initial adoption slice.
+- Do not add LabRAD-dependent compatibility helpers, Data Vault parsers, or
+  unit-system adapters to the initial adoption slice.
+- Do not make first-slice adoption depend on report generation, user plotting
+  code execution, code deployment, Conda environment management, or calibration
+  automation.
 - Do not implement strategic follow-on runner, device, calibration, or AI
   mutation systems before their ADRs/specs exist.
 
@@ -64,6 +69,8 @@ Fricon helps me inspect, annotate, recover, reopen, and export them.
   terminology context.
 - Make live views noncritical consumers.
 - Keep code provenance honest: unmanaged means unmanaged.
+- Treat Git metadata as optional context for initial adoption, not a
+  reproducibility promise or a required provenance source.
 - Use events for lifecycle, notes, corrections, and audit history.
 - Use ADRs for storage, local runtime/API, export format, and compatibility
   decisions before durable implementation.

--- a/docs/product/capability-map.md
+++ b/docs/product/capability-map.md
@@ -87,23 +87,21 @@ CAP-005: Dataset artifact recording.
 
 CAP-006: Dataset scan semantics.
 
-- Promise: plotted datasets carry explicit scan or trace meaning instead of
-  relying on column-position guesses.
-- Includes: variable roles, labels, units, dependencies, axis structure,
-  partial grids, irregular/adaptive points, logical step records, per-step
-  parameters, selectable log or trace collections, fixed-shape traces, and
-  variable-length traces.
-- Excludes: requiring every advanced acquisition to fit a regular grid or
-  requiring optional units and labels when the schema remains interpretable.
+- Promise: plotted datasets carry enough schema for slicing and plotting
+  without relying on column-position guesses.
+- Includes: variable roles, dependencies, axis structure, partial grids,
+  irregular/adaptive points, logical step records, per-step parameters,
+  selectable trace collections, fixed-shape traces, and variable-length traces.
+- Excludes: requiring every advanced acquisition to fit a regular grid, or
+  blocking writes only because optional units or labels are absent.
 
 CAP-007: Nonblocking live inspection.
 
 - Promise: Desktop can watch active data without slowing or breaking acquisition
   writes.
-- Includes: live events, line/scatter plot, basic heatmap, selected output
-  channel or log viewing, simple trace inspection, stale/lag indicators, and
-  product support for watching multiple relevant measurement or data views at
-  once.
+- Includes: live events, line/scatter plot, basic heatmap, selected output or
+  trace views, simple trace inspection, stale/lag indicators, and product
+  support for watching multiple relevant measurement or data views at once.
 - Excludes: live consumers as required write acknowledgements, running user
   plotting code, and making full table browsing the primary live monitor
   surface.
@@ -276,7 +274,7 @@ CAP-026: Dataset artifact discovery and direct open.
 - Promise: dataset artifacts remain searchable and directly openable even when
   the Desktop home is measurement-first.
 - Includes: stable artifact IDs, measurement context, search/open entry points,
-  and direct navigation to table or plot views.
+  and direct navigation to selector, plot, or trace views.
 - Excludes: returning to a dataset-first product model.
 
 CAP-027: Passive setup and environment summary.
@@ -292,9 +290,10 @@ CAP-028: Python-native scan plans plus raw schema escape hatch.
 
 - Promise: common scan shapes are easy to declare in ordinary Python while
   uncommon schemas remain possible.
-- Includes: a low-ceremony scan-plan shape for common 1D, 2D, N-D, and trace
-  cases; dict/literal-friendly authoring where useful; optional convenience
-  helpers; and raw schema construction for advanced users.
+- Includes: low-ceremony scan/schema authoring for common 1D, 2D, N-D,
+  irregular step-record, and trace cases; dict/literal-friendly authoring where
+  useful; optional convenience helpers; and raw schema construction for
+  advanced users.
 - Excludes: a fixed framework-specific helper name, a framework-specific
   parameter-object model, treating first-draft helper syntax as accepted
   without usage feedback, a visual sweep builder, or a managed execution plan.
@@ -315,7 +314,7 @@ CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
 - Includes: natural mapping for independent/dependent variables, labels, units,
   legends, old path aliases, numbered legacy titles as metadata, and migration
   guide examples for non-obvious shapes such as N-D sweeps, coarse/fine trace
-  collections, and irregular optimizer logs.
+  collections, and irregular optimizer records.
 - Excludes: a LabRAD compatibility server, LabRAD-dependent helper module,
   built-in Data Vault parser, or old history browser.
 
@@ -327,8 +326,9 @@ CAP-031: Run manifest and failure investigation.
   calibration evidence, generated sidecars, review decisions, and handoff
   state.
 - Boundary: a run manifest is a composite view over available facts, not a
-  duplicate owner of parameter, code, setup, analysis, or artifact records. The
-  first slice supports compare, handoff, export, and anomaly investigation.
+  duplicate owner of parameter, code, setup, analysis, or artifact records.
+  Initial adoption should record facts that later support compare, handoff, and
+  anomaly investigation without accepting a run-manifest model yet.
 
 CAP-032: Routine recipes and reviewed replay.
 

--- a/docs/product/capability-map.md
+++ b/docs/product/capability-map.md
@@ -7,9 +7,10 @@ Draft pending product-analysis revalidation.
 ## Vision Alignment
 
 The capability baseline should be revalidated against one initial adoption
-goal: replace the simple LabRAD Data Vault/Grapher loop for new measurements.
-Capabilities in the first adoption slice should support that loop without
-importing old history, emulating LabRAD, or pulling strategic follow-on
+goal: replace the simple LabRAD Data Vault/Grapher loop for new interactive
+measurements and portable later analysis. Capabilities in the first adoption
+slice should support that loop without importing old history, emulating LabRAD,
+running user plotting code, generating reports, or pulling strategic follow-on
 parameter, code-management, runner, device, or automation systems into the
 first release path.
 
@@ -63,9 +64,10 @@ CAP-003: Python measurement recording.
   measurement with low ceremony and append measurement facts through public
   APIs.
 - Includes: title, start/end lifecycle, optional context links, concurrent local
-  writers, and readable crash outcomes.
-- Excludes: managed runner, task queue, visual sweep builder, and device
-  control.
+  writers, readable crash outcomes, and simple recording-section rewrites for
+  Data Vault-style scripts.
+- Excludes: managed runner, task queue, visual sweep builder, LabRAD
+  compatibility layer, and device control.
 
 CAP-004: Optional, visible, correctable sample/session context.
 
@@ -88,17 +90,23 @@ CAP-006: Dataset scan semantics.
 - Promise: plotted datasets carry explicit scan or trace meaning instead of
   relying on column-position guesses.
 - Includes: variable roles, labels, units, dependencies, axis structure,
-  partial grids, irregular/adaptive points, repeated points, and trace shapes.
-- Excludes: requiring every advanced acquisition to fit a regular grid.
+  partial grids, irregular/adaptive points, logical step records, per-step
+  parameters, selectable log or trace collections, fixed-shape traces, and
+  variable-length traces.
+- Excludes: requiring every advanced acquisition to fit a regular grid or
+  requiring optional units and labels when the schema remains interpretable.
 
 CAP-007: Nonblocking live inspection.
 
 - Promise: Desktop can watch active data without slowing or breaking acquisition
   writes.
-- Includes: live events, table view, line/scatter plot, basic heatmap, simple
-  trace inspection, stale/lag indicators, and product support for watching
-  multiple relevant measurement or data views at once.
-- Excludes: live consumers as required write acknowledgements.
+- Includes: live events, line/scatter plot, basic heatmap, selected output
+  channel or log viewing, simple trace inspection, stale/lag indicators, and
+  product support for watching multiple relevant measurement or data views at
+  once.
+- Excludes: live consumers as required write acknowledgements, running user
+  plotting code, and making full table browsing the primary live monitor
+  surface.
 
 CAP-008: Lifecycle and readable partial recovery.
 
@@ -120,7 +128,8 @@ CAP-010: Python reopen through stable IDs and public APIs.
 - Promise: Python can reopen measurements, dataset artifacts, and exports
   without depending on storage paths.
 - Includes: stable IDs, typed read APIs, schema-aware reads, partial-data
-  semantics, and Desktop-visible snippets.
+  semantics, Desktop-visible snippets, and analysis-friendly reads into common
+  Python objects such as NumPy, pandas, or Polars where appropriate.
 - Excludes: path-based storage contracts and private file layout coupling.
 
 CAP-011: Measurement-centered export.
@@ -129,10 +138,12 @@ CAP-011: Measurement-centered export.
   for offline analysis.
 - Includes: produced datasets, semantic metadata, selected provenance,
   integrity metadata, simple manifest or index preview, direct Python reading,
-  privacy-aware provenance selection, and common analysis-oriented output
-  paths.
-- Excludes: importing old history and a fully polished offline Desktop viewer
-  before the write/reopen loop is proven.
+  privacy-aware provenance selection, and a lightweight Python reader that does
+  not require running the acquisition-time local runtime or Desktop.
+- Excludes: importing old history, first-slice report generation, a fully
+  polished offline Desktop viewer before the write/reopen loop is proven, and
+  promising generic CSV, Parquet, or NumPy exports before real demand is
+  validated.
 
 CAP-012: Backup, restore, and migration checkpoints.
 
@@ -156,9 +167,10 @@ CAP-014: Honest code provenance summary.
 
 - Promise: Fricon records what it can honestly know about unmanaged Python code
   without pretending it owns execution.
-- Includes: unmanaged labels, optional script path, Git summary, dirty-state
-  signal, copied-folder or source-root label, user-supplied summary, and
-  privacy-aware export handling.
+- Includes: unmanaged labels, optional script path, copied-folder or
+  source-root label, user-supplied summary, selected local configuration
+  snapshots, optional Git summary where meaningful, and privacy-aware export
+  handling.
 - Excludes: automatic notebook state capture and managed code snapshots.
 
 CAP-015: Light parameter context summary without a registry UI.
@@ -301,9 +313,11 @@ CAP-030: Migration ergonomics for Data Vault-style new measurement scripts.
 - Promise: users can translate new Data Vault-style scripts to Fricon writers
   without a full experiment-stack rewrite.
 - Includes: natural mapping for independent/dependent variables, labels, units,
-  legends, old path aliases, and numbered legacy titles as metadata.
-- Excludes: a LabRAD compatibility server, built-in Data Vault parser, or old
-  history browser.
+  legends, old path aliases, numbered legacy titles as metadata, and migration
+  guide examples for non-obvious shapes such as N-D sweeps, coarse/fine trace
+  collections, and irregular optimizer logs.
+- Excludes: a LabRAD compatibility server, LabRAD-dependent helper module,
+  built-in Data Vault parser, or old history browser.
 
 CAP-031: Run manifest and failure investigation.
 

--- a/docs/product/epics/EPIC-002-new-measurement-logging.md
+++ b/docs/product/epics/EPIC-002-new-measurement-logging.md
@@ -6,9 +6,9 @@ Draft pending product-analysis revalidation.
 
 ## Product Goal
 
-Replace the simple LabRAD Data Vault/Grapher loop for new measurements:
-declare measured data, append values from Python, watch it live, and reopen it
-later without manual file/folder discipline.
+Replace the simple LabRAD Data Vault/Grapher loop for new interactive
+measurements: declare measured data, append values from Python, watch live
+monitor plots, and reopen it later without manual file/folder discipline.
 
 This is the center of the initial adoption slice. It should stay close to
 ordinary Python measurement scripts instead of becoming a managed automation
@@ -19,13 +19,14 @@ framework.
 - Explicit but low-ceremony Python measurement creation.
 - Measurement-scoped dataset artifact writers.
 - Dataset artifacts remain directly searchable and openable.
-- Python-native scan plans or helpers for common 1D/2D/N-D scans and traces,
-  with raw schema for advanced cases.
+- Python-native scan plans or helpers for common 1D/2D/N-D scans, irregular
+  step records, and traces, with raw schema for advanced cases.
 - Explicit scan semantics for reliable live and historical plots.
 
 ## Not Initial Adoption
 
-- LabRAD compatibility server or built-in Data Vault parser.
+- LabRAD compatibility server, LabRAD-dependent helper module, or built-in
+  Data Vault parser.
 - Visual sweep builder as the primary acquisition model.
 - Full managed runner, device control, or parameter registry.
 

--- a/docs/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs/product/epics/EPIC-003-measurement-console-inspection.md
@@ -14,10 +14,10 @@ actions.
 
 - Measurement-first console.
 - Active and recent measurement list.
-- Live monitor views for line/scatter, basic heatmap, selected output channel
-  or log views, and simple trace inspection.
+- Live monitor views for line/scatter, basic heatmap, selected outputs, and
+  simple trace inspection.
 - Selector or index views for choosing datasets, scan parameters, timestamps,
-  and trace/log records.
+  and trace records.
 - Ability to keep multiple relevant measurement, monitor, plot, or trace views
   visible while acquisition continues.
 - Dataset direct-open entry points.

--- a/docs/product/epics/EPIC-003-measurement-console-inspection.md
+++ b/docs/product/epics/EPIC-003-measurement-console-inspection.md
@@ -14,8 +14,11 @@ actions.
 
 - Measurement-first console.
 - Active and recent measurement list.
-- Live table, line/scatter, basic heatmap, and simple trace inspection.
-- Ability to keep multiple relevant measurement, table, plot, or trace views
+- Live monitor views for line/scatter, basic heatmap, selected output channel
+  or log views, and simple trace inspection.
+- Selector or index views for choosing datasets, scan parameters, timestamps,
+  and trace/log records.
+- Ability to keep multiple relevant measurement, monitor, plot, or trace views
   visible while acquisition continues.
 - Dataset direct-open entry points.
 - Favorites, notes, lifecycle flags, and basic search shortcuts.
@@ -23,6 +26,7 @@ actions.
 ## Not Initial Adoption
 
 - Publication plotting.
+- Running user plotting code inside Fricon.
 - Generic dashboard builder.
 - Rich saved views and comparison workflows beyond the minimal console.
 

--- a/docs/product/epics/EPIC-004-recovery-reopen-export.md
+++ b/docs/product/epics/EPIC-004-recovery-reopen-export.md
@@ -15,8 +15,9 @@ reopen data from Python, and export a measurement for offline analysis.
 - Trash/recover instead of normal hard delete.
 - Python reopen snippets using stable IDs.
 - Measurement-centered read-only export bundles.
-- Direct Python reading of exported bundles without importing into another
-  editable library.
+- Lightweight Python reader for exported bundles without importing into another
+  editable library or running the acquisition-time local runtime.
+- Analysis-friendly reads into common Python objects where appropriate.
 - Human-readable export manifest or index preview.
 - Privacy preview for sensitive provenance in exports.
 
@@ -25,6 +26,8 @@ reopen data from Python, and export a measurement for offline analysis.
 - Resumable managed execution.
 - Full offline viewer polish before the write/reopen loop works.
 - Importing old history as a built-in migration path.
+- First-slice report or presentation generation.
+- Mandatory generic CSV, Parquet, or NumPy exports before demand is validated.
 
 ## Key Stories
 

--- a/docs/product/epics/EPIC-005-migration-future-lab-scaling.md
+++ b/docs/product/epics/EPIC-005-migration-future-lab-scaling.md
@@ -17,9 +17,10 @@ stack.
 - Source aliases and old-system references as metadata, not primary identity.
 - Honest code provenance for interactive unmanaged Python.
 - Light contextual summaries for setup, environment, procedure, and parameters.
-- Run-bound local configuration snapshots or summaries for files and references
-  that old scripts currently leave in copied folders.
+- Run-bound local configuration copies, snapshots, references, or summaries for
+  files and references that old scripts currently leave in copied folders.
 - Optional sample/session context that can be corrected after a run.
+- No built-in LabRAD dependency, compatibility layer, or unit adapter.
 
 ## Strategic Follow-On Scope
 

--- a/docs/product/future-concepts.md
+++ b/docs/product/future-concepts.md
@@ -23,6 +23,11 @@ and reviewed action: explain, compare, hand off, repeat, and safely automate
 work from recorded facts, not imitate legacy acquisition tools or make device
 control, sample visualization, or AI the product center by itself.
 
+The latest first-slice interview did not promote any concept in this file into
+initial adoption. Parameter systems, managed runs, calibration records, report
+artifacts, and Git-heavy provenance remain backlog pressure until the
+Data Vault/Grapher replacement loop is validated.
+
 ## Promotion Rule
 
 A future concept can move into implementation only after it has a clear story,

--- a/docs/product/future-stories-and-requirements.md
+++ b/docs/product/future-stories-and-requirements.md
@@ -24,6 +24,11 @@ ledger and rationale. This backlog expands that ledger into candidate future
 epics, stories, and requirements. Treat both files as backlog context until the
 initial adoption product baseline is revalidated.
 
+The latest first-slice interview kept this backlog out of initial adoption.
+Do not use this file to justify first-slice report generation, managed
+execution, calibration-specific records, Git-dependent reproducibility, generic
+export formats, or code/environment standardization.
+
 Strategic follow-on work should prioritize:
 
 - parameter system first

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -13,8 +13,9 @@ Draft pending terminology revalidation.
   sample.
 - Measurement: data-taking attempt that may produce artifacts and carry
   context, lifecycle, notes, parameters, and code provenance.
-- Dataset Artifact: table-shaped artifact produced or consumed by work; owns
-  dataset-local facts and semantics.
+- Dataset Artifact: structured artifact produced or consumed by work; owns
+  dataset-local facts and semantics such as scan axes, step records, output
+  values, arrays, or traces.
 - Attachment Artifact: small file, image, log, or supporting artifact attached
   to a measurement.
 - Parameter Summary: optional light parameter context recorded for a
@@ -25,9 +26,9 @@ Draft pending terminology revalidation.
   It is not a global parameter profile or device inventory.
 - Code Provenance Summary: initial adoption record of what Fricon can honestly
   know about measurement code, such as unmanaged label, optional
-  script/notebook path, Git summary, dirty-state signal,
-  copied-folder/source-root label, or user-supplied explanation. It is not a
-  managed code snapshot or approval record.
+  script/notebook path, copied-folder/source-root label, optional Git summary
+  where meaningful, or user-supplied explanation. It is not a managed code
+  snapshot or approval record.
 - Setup Summary: optional passive setup, device, driver, environment, clock, or
   method context; describes, does not control.
 - Procedure Summary: optional passive procedure context such as unmanaged
@@ -43,7 +44,7 @@ Draft pending terminology revalidation.
 - Event/Audit Record: timeline record for lifecycle, note, correction, system
   action, or actor-labeled mutation.
 - Export Bundle: read-only portable package for analysis without importing into
-  another data library.
+  another data library or running the acquisition-time local runtime.
 - Export Manifest: read-only package manifest for an export bundle. It records
   package contents, source library identity, export identity, format version,
   stable record IDs, checksums, and integrity metadata.
@@ -151,3 +152,6 @@ Draft pending terminology revalidation.
   primary/baseline data. Not user-facing initial adoption terminology.
 - Experiment: informal scientific wording or possible future grouping/template,
   not the first public acquisition record.
+- Channel or Log: useful comparison terms from other measurement tools, but
+  not accepted Fricon object names until dataset and plotting terminology is
+  revalidated.

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -68,6 +68,22 @@ context or run-bound local configuration. If later workflows review or mutate
 setup or device state, route that decision to an explicit setup/device owner
 rather than to P-002 by default; P-002 owns software-system readiness.
 
+## First Adoption Role Emphasis
+
+The first adoption slice is primarily for P-001 and P-003: an experimenter
+running interactive scripts or notebooks, then reopening or exporting the
+result for later analysis on another machine.
+
+P-005 and P-002 are supporting pressures for initial adoption. Fricon should be
+easy for a method author or AI-assisted migration guide to apply to existing
+recording sections, and it should be installable on constrained lab computers,
+but the first slice should not try to standardize lab-wide code deployment,
+manage Conda environments, or replace waveform and analysis utility stacks.
+
+P-004 remains strategically important, but first adoption treats calibration
+notebooks as ordinary measurement work unless product evidence shows that a
+minimal calibration-specific record removes user code burden.
+
 ## P-001 Measurement Run Operator
 
 The role active when a lab user runs a measurement script or notebook on a lab
@@ -91,6 +107,9 @@ Context and pressure:
   folders, dated backups, and mutable local configuration during migration
 - needs Fricon to make ordinary measurement work safer without forcing managed
   execution first
+- should be able to run multiple independent measurements without accidental
+  global-session interference or one monitor window assuming there is only one
+  active experiment
 
 Common switches:
 
@@ -140,14 +159,18 @@ Common switches:
 
 ## P-003 Experimental Data Analyst
 
-The person who reopens completed measurements for notebooks, reports, or HPC
-analysis. This role often produces secondary artifacts such as fit results,
-plots, `.npy` or `.json` derived data, spreadsheets, and slide decks.
+The person who reopens completed measurements for notebooks, local analysis, or
+HPC analysis. This role often produces secondary artifacts such as fit results,
+plots, `.npy` or `.json` derived data, spreadsheets, and later reports.
 
 Goals:
 
 - reopen completed, interrupted, or exported measurements through stable IDs
   and APIs
+- read portable Fricon packages on another computer through a lightweight
+  Python reader without recreating the acquisition-time local runtime
+- load measurement data into analysis-friendly Python objects such as NumPy,
+  pandas, or Polars where appropriate
 - preserve links from derived artifacts back to source measurements,
   parameters, code/procedure context, and manual judgment
 - keep mapping, readout-classification, shot-group, detector, or observable
@@ -160,6 +183,9 @@ Context and pressure:
   code summaries, environment data, or sample context
 - must distinguish recorded measurement facts from notebook-local analysis
   state and manually edited outputs
+- does not need first-slice report or presentation generation from Fricon;
+  screenshots, exported images, and custom plotting scripts can remain outside
+  the product until real demand requires more
 
 Common switches:
 
@@ -222,6 +248,8 @@ Goals:
   masks, runner identifiers, and procedure summaries from code
 - preserve honest code provenance without claiming Fricon managed execution
   guarantees it does not yet provide
+- help users migrate by rewriting recording sections with small, explicit
+  Fricon calls rather than depending on a built-in LabRAD compatibility layer
 
 Context and pressure:
 

--- a/docs/product/product-analysis-progress.md
+++ b/docs/product/product-analysis-progress.md
@@ -80,6 +80,7 @@ Downstream material not ready for implementation use:
 | Risks and assumptions | Partial | Add an explicit assumption and validation register. |
 | Validation plan | Missing | Define interviews, prototype checks, and migration-script trials. |
 | Product requirements | Not implementation-ready | Derive later from accepted journeys, stories, capabilities, and validation results. |
+| Older backlog review | Partial | Keep strategic follow-on docs as backlog only; revalidate managed run, calibration, Git-heavy provenance, report artifacts, and generic export formats before promoting them. |
 | Domain analysis | Deferred | Start only after the product analysis baseline is stable. |
 | Architecture inputs | Deferred | Start only after product and domain baselines are stable. |
 

--- a/docs/product/product-analysis-progress.md
+++ b/docs/product/product-analysis-progress.md
@@ -66,8 +66,8 @@ Downstream material not ready for implementation use:
 
 | Step | Current State | Next Analysis Action |
 | --- | --- | --- |
-| Problem framing | Strong but should be summarized more sharply | Add a concise problem hypothesis if needed. |
-| User and role analysis | Strong current baseline | Keep refining only when new case evidence appears. |
+| Problem framing | Strong; sharpened around maintained Data Vault/Grapher replacement for new interactive work | Rebuild the initial adoption story backbone from this framing. |
+| User and role analysis | Strong current baseline with first-adoption emphasis on P-001 and P-003 | Keep refining only when new case evidence appears. |
 | Use case discovery | Partial | Reconstruct the initial adoption journey from `vision.md`, `personas.md`, and case evidence. |
 | Alternatives and market analysis | Draft research synthesis exists | Use only for focused pressure, not product authority. |
 | Value proposition | Clear internally | Write a short external-facing value statement later. |
@@ -88,12 +88,11 @@ Downstream material not ready for implementation use:
 Use the current product documents as input evidence, not as the analysis order.
 The next work should proceed from user work to product capabilities:
 
-1. Write or confirm the concise problem hypothesis.
-2. Define the initial adoption journey and story backbone.
-3. Rebuild `product/story-map.md` from that backbone.
-4. Recheck epics and user stories against the rebuilt story map.
-5. Derive `product/capability-map.md` from the accepted stories.
-6. Add success signals, assumptions, and validation tasks.
+1. Define the initial adoption journey and story backbone.
+2. Rebuild `product/story-map.md` from that backbone.
+3. Recheck epics and user stories against the rebuilt story map.
+4. Derive `product/capability-map.md` from the accepted stories.
+5. Add success signals, assumptions, and validation tasks.
 
 Capability review should follow story analysis. A capability without story or
 journey support should be deferred, rewritten as a backlog hypothesis, or

--- a/docs/product/python-sdk-ux.md
+++ b/docs/product/python-sdk-ux.md
@@ -29,12 +29,18 @@ concepts:
 - a lightweight way to bind selected local configuration context to a run
 - Python-native scan-plan authoring for routine scans
 - public reopen/export APIs for later analysis
+- a simple migration path where Data Vault-style scripts rewrite the recording
+  section instead of depending on a LabRAD compatibility layer
 
 The notebook-friendly reusable context/handle style is part of the product
 experience: a user should be able to establish the current local library and
 optional lab context once, inspect it in a notebook, reset it when needed, and
 pass it explicitly to measurement helpers. This does not accept a specific
 entry-point name such as `fricon.library()` or `fc.open()`.
+
+Notebook or process session association may be useful for monitor-window reuse
+and runtime connection behavior, but it should not become a user-facing product
+concept unless later design evidence requires it.
 
 The main ergonomic constraint is low ceremony. Fricon should ask for structure
 only where it changes user understanding: which context is active, whether a
@@ -47,6 +53,11 @@ lab folders are all plausible shapes. The initial adoption slice should record
 honest provenance for those shapes. Managed-run entry points, code snapshots,
 approved code sources, and update flows are strategic follow-on product
 directions, not accepted SDK API mechanics.
+
+Initial migration should be a small explicit rewrite of writer calls. Fricon
+should not depend on LabRAD internals, LabRAD services, or LabRAD's unit system
+for the first slice because local installations may diverge from upstream and
+legacy unit objects may not map cleanly.
 
 For common workflows, Fricon should provide appropriate simplification without
 pretending the right simplification is known before use. The exact API shape
@@ -91,6 +102,8 @@ ceremony should be justified by one of these user-visible benefits:
 - binding selected local configuration context when copied files or sidecars
   explain the run
 - reopening or exporting results through stable public APIs
+- exporting to a portable Fricon package that can be read on another computer
+  with a lightweight Python reader
 
 Boilerplate that exists only for transport, storage layout, local runtime
 startup, local tokens, object graph construction, or future parameter machinery
@@ -168,6 +181,8 @@ Do not settle these in this guideline:
   a raw escape hatch
 - a QCoDeS compatibility layer, fixed borrowed helper name, or
   parameter-object model
+- a LabRAD compatibility layer, LabRAD-dependent helper module, or LabRAD unit
+  adapter
 - scheduler, resource leases, queues, retries, workflow DAGs, or resume
   protocols
 

--- a/docs/product/python-sdk-ux.md
+++ b/docs/product/python-sdk-ux.md
@@ -20,17 +20,19 @@ shapes that would be expensive to change after users build habits around them.
 
 ## Usage Stance
 
-Fricon should feel like ordinary Python with a small number of explicit product
-concepts:
+For initial adoption, Fricon should feel like ordinary Python with a small
+number of explicit product concepts:
 
 - a visible notebook context for the current local library and lab context
 - an interactive unmanaged path for exploratory runs
-- an importable decorated managed-run path for higher provenance
 - a lightweight way to bind selected local configuration context to a run
 - Python-native scan-plan authoring for routine scans
 - public reopen/export APIs for later analysis
 - a simple migration path where Data Vault-style scripts rewrite the recording
   section instead of depending on a LabRAD compatibility layer
+
+Importable managed-run entry points are a strategic follow-on SDK direction,
+not part of the first-slice migration promise.
 
 The notebook-friendly reusable context/handle style is part of the product
 experience: a user should be able to establish the current local library and
@@ -76,10 +78,9 @@ control, and Fricon records measurements, datasets, notes, lifecycle, and
 honest provenance as the script runs. This keeps notebooks, debugging, and
 manual device work natural.
 
-When users want higher provenance, they should be able to move selected code
-into an importable managed-run entry point. The same measurement logic should
-remain normal Python that can be reviewed and tested, but Fricon can run it
-under management when the user opts in.
+Strategic follow-on managed runs should let users move selected code into
+importable entry points while keeping the measurement logic normal Python. That
+later path should not make managed execution mandatory for exploratory scripts.
 
 Routine scans should not force users to build schemas by hand. A Python-native
 scan plan should make common scan shapes concise while still leaving manual
@@ -98,7 +99,8 @@ ceremony should be justified by one of these user-visible benefits:
 - selecting or inspecting the current library and lab context
 - creating a real measurement rather than a loose file or anonymous table
 - declaring scan shape so live and historical plots know what the axes mean
-- choosing unmanaged versus managed execution honestly
+- labeling unmanaged execution honestly, and later choosing managed execution
+  only when that feature exists
 - binding selected local configuration context when copied files or sidecars
   explain the run
 - reopening or exporting results through stable public APIs
@@ -151,7 +153,7 @@ result = fc.run_scan(
 )
 ```
 
-Importable managed-run entry point:
+Strategic follow-on managed-run sketch:
 
 ```python
 import fricon as fc

--- a/docs/product/story-map.md
+++ b/docs/product/story-map.md
@@ -111,9 +111,9 @@ The full initial adoption slice also needs US-009 for export, US-017/US-018 to
 validate the incremental adoption posture, and US-019 to make copied local
 configuration visible. Users should be able to translate new Data Vault-style
 scripts, keep old history in the old system, and bind the run-relevant files or
-summaries that old scripts currently leave in folders and operator memory.
-Translation means a small explicit rewrite of the recording section, not a
-built-in LabRAD compatibility layer.
+summaries that old scripts currently leave in folders and operator memory. This
+means a small explicit rewrite of the recording section, not a built-in LabRAD
+compatibility layer.
 
 Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;

--- a/docs/product/story-map.md
+++ b/docs/product/story-map.md
@@ -28,9 +28,11 @@ Install and set up
 ## Initial Adoption Product Epics
 
 The initial adoption route is the LabRAD Data Vault/Grapher replacement loop
-for new measurements: write from Python, watch live, recover partial data,
-reopen, and export. The epics below divide that route without making legacy
-import or managed automation part of the first adoption slice.
+for new interactive measurements: write from Python, watch live monitor plots,
+recover partial data, reopen, and export for analysis on another machine. The
+epics below divide that route without making legacy import, LabRAD emulation,
+report generation, user plotting code, or managed automation part of the first
+adoption slice.
 
 - EPIC-001: Local setup and data-library adoption.
 - EPIC-002: New measurement logging replacement.
@@ -110,6 +112,8 @@ validate the incremental adoption posture, and US-019 to make copied local
 configuration visible. Users should be able to translate new Data Vault-style
 scripts, keep old history in the old system, and bind the run-relevant files or
 summaries that old scripts currently leave in folders and operator memory.
+Translation means a small explicit rewrite of the recording section, not a
+built-in LabRAD compatibility layer.
 
 Python SDK UX is part of the product story, not only implementation detail.
 The product-level SDK usage guideline lives in `product/python-sdk-ux.md`;
@@ -120,6 +124,8 @@ experiment memory and reviewed action. Those priorities are outside the initial
 adoption story index and live as draft backlog context in
 `product/future-concepts.md`.
 
-Export remains an initial adoption product promise. Detailed
-export/offline-analysis requirements should be derived in a later spec after
-the product, architecture, and ADR boundaries are accepted.
+Export remains an initial adoption product promise. A portable Fricon package
+with a lightweight Python reader is the current baseline; CSV, Parquet, NumPy,
+or other generic export formats should be added when real user demand justifies
+them. Detailed export/offline-analysis requirements should be derived in a
+later spec after the product, architecture, and ADR boundaries are accepted.

--- a/docs/product/user-stories/US-004-produce-dataset-artifacts.md
+++ b/docs/product/user-stories/US-004-produce-dataset-artifacts.md
@@ -11,13 +11,14 @@ EPIC-002: New measurement logging replacement.
 ## Story
 
 As a Measurement Run Operator, I want one measurement to produce one or more
-dataset artifacts so that related tables, scans, or traces stay connected
-without losing direct dataset access.
+dataset artifacts so that related scans, step records, arrays, or traces stay
+connected without losing direct dataset access.
 
 ## Success Criteria
 
 - A measurement can create multiple dataset artifacts with stable IDs.
-- Dataset artifacts carry scan or trace schema where plotting semantics matter.
+- Dataset artifacts carry scan, step-record, array, or trace schema where
+  plotting and slicing semantics matter.
 - Dataset writers share measurement lifecycle by default while remaining
   individually discoverable.
 - Dataset facts are appendable while a writer is active and immutable after the

--- a/docs/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs/product/user-stories/US-005-watch-and-inspect.md
@@ -17,8 +17,8 @@ inspection views so that I can decide whether a measurement is working.
 
 - Desktop starts from a measurement console.
 - Live views are noncritical consumers and cannot block writes.
-- Core live monitor views are line/scatter, basic heatmap, selected output
-  channel or log views, and simple trace inspection.
+- Core live monitor views are line/scatter, basic heatmap, selected outputs,
+  and simple trace inspection.
 - Selector or index views can show scan parameters, timestamps, and dataset or
   trace choices without making raw table browsing the primary monitor
   experience.

--- a/docs/product/user-stories/US-005-watch-and-inspect.md
+++ b/docs/product/user-stories/US-005-watch-and-inspect.md
@@ -10,17 +10,20 @@ EPIC-003: Measurement console and inspection.
 
 ## Story
 
-As a Measurement Run Operator, I want local live and historical table/chart
-views so that I can decide whether a measurement is working.
+As a Measurement Run Operator, I want local live monitor plots and historical
+inspection views so that I can decide whether a measurement is working.
 
 ## Success Criteria
 
 - Desktop starts from a measurement console.
 - Live views are noncritical consumers and cannot block writes.
-- Core views are table, line/scatter, basic heatmap, and simple trace
-  inspection.
-- Users can keep more than one relevant measurement, table, plot, or trace view
-  visible while acquisition continues.
+- Core live monitor views are line/scatter, basic heatmap, selected output
+  channel or log views, and simple trace inspection.
+- Selector or index views can show scan parameters, timestamps, and dataset or
+  trace choices without making raw table browsing the primary monitor
+  experience.
+- Users can keep more than one relevant measurement, monitor, plot, or trace
+  view visible while acquisition continues.
 - Users can open produced datasets directly when needed.
 - Failed, interrupted, or partial runs are visibly different from completed
   runs.
@@ -29,7 +32,8 @@ views so that I can decide whether a measurement is working.
 
 ## Not In Scope
 
-- Publication plotting, generic dashboard building, or rich comparison views.
+- Running user plotting code, publication plotting, generic dashboard building,
+  or rich comparison views.
 
 ## Related Capabilities
 

--- a/docs/product/user-stories/US-008-reopen-measurement-outputs.md
+++ b/docs/product/user-stories/US-008-reopen-measurement-outputs.md
@@ -21,6 +21,8 @@ depend on remembering storage paths.
   by stable IDs.
 - Reopened data preserves scan schema, units, labels, lifecycle state, and
   partial-data semantics.
+- Reopened data can be converted into analysis-friendly Python objects such as
+  NumPy, pandas, or Polars where appropriate for the dataset shape.
 - Path-based access is not the documented normal path.
 
 ## Not In Scope

--- a/docs/product/user-stories/US-009-export-measurement.md
+++ b/docs/product/user-stories/US-009-export-measurement.md
@@ -18,15 +18,15 @@ library or importing the data first.
 
 - Export starts from a measurement by default.
 - Produced datasets and semantic metadata are included.
-- Common analysis files are included where practical, but the Fricon manifest
-  remains the source of meaning.
+- A portable Fricon package with a lightweight Python reader is the baseline;
+  generic analysis files can be added when demand is validated.
 - A simple human-readable manifest or index preview helps users inspect an
   exported bundle before loading it in code.
 - Selected code, setup, procedure, and run-bound configuration summaries can be
   included so the bundle explains the measurement without old local folders.
-- Sensitive provenance is previewed or opt-in, including local paths, dirty
-  code details, environment summaries, source computer labels, setup details,
-  and extended sample metadata.
+- Sensitive provenance is previewed or opt-in, including local paths, code
+  details, environment summaries, source computer labels, setup details, and
+  extended sample metadata.
 - Python can open the bundle directly.
 - A read-only Desktop bundle viewer remains useful product pressure, but full
   viewer polish can follow after the write/reopen/export loop works.
@@ -35,6 +35,7 @@ library or importing the data first.
 
 - Importing the bundle into another editable data library as the default path.
 - Legacy Data Vault, Labber, or HDF5 compatibility layers.
+- First-slice report or presentation generation.
 
 ## Related Capabilities
 

--- a/docs/product/user-stories/US-011-record-code-provenance.md
+++ b/docs/product/user-stories/US-011-record-code-provenance.md
@@ -18,8 +18,8 @@ judge trustworthiness without pretending Fricon managed execution.
 
 - Unmanaged Python is labeled as unmanaged unless Fricon actually controls
   execution.
-- Optional script path, Git revision, dirty-state signal, and user summary can
-  be recorded where available.
+- Optional script path, copied-folder/source label, user summary, and Git
+  revision only where meaningful can be recorded where available.
 - Copied-folder workflows can record a source-root path, folder fingerprint, or
   user-supplied source label without implying managed code history.
 - Code provenance is distinct from passive procedure context and run-bound

--- a/docs/product/user-stories/US-015-declare-common-scan-shapes.md
+++ b/docs/product/user-stories/US-015-declare-common-scan-shapes.md
@@ -16,14 +16,16 @@ plotting semantics without making every script write raw schema by hand.
 
 ## Success Criteria
 
-- Scan-plan authoring covers common 1D, 2D, N-D, fixed-trace, and
-  variable-trace cases.
+- Scan-plan authoring covers common 1D, 2D, N-D, fixed-trace,
+  variable-trace, and irregular step-record cases.
 - Dict/literal-friendly plans are acceptable if they keep axes, setters,
   measured values, labels, and units readable in ordinary Python.
 - The accepted simplification shape is informed by real scripts/notebooks and
   feedback, not only by borrowed framework API names.
 - Schema can represent regular grids, partial grids, irregular/adaptive points,
-  repeated points, and missing expected points where meaningful.
+  per-step parameters, and missing expected points where meaningful. Repeated
+  points should remain representable, but they do not need a special first
+  experience before real demand appears.
 - Variable-length trace scenarios preserve each trace's own coordinate values,
   measured values, and per-trace settings instead of forcing padding,
   resampling, or a fake shared grid at write time.

--- a/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -18,12 +18,15 @@ experiment stack.
 ## Success Criteria
 
 - The migration path uses Fricon SDK writers, not a Data Vault compatibility
-  server.
+  server or LabRAD-dependent helper module.
 - Independent/dependent variable declarations map naturally to Fricon scan
   schema helpers or raw schema.
 - Common writer calls shaped like Data Vault `prepDataset`, `Dataset.add`, or
   independent/dependent variable setup can be translated without rewriting the
   whole hardware runner.
+- Migration documentation covers non-obvious patterns, such as N-D scans,
+  VNA-like coarse/fine trace collections, and minimizer-style irregular logs,
+  rather than many near-duplicate 1D and 2D examples.
 - Labels, units, legends, source aliases, original paths, and old numbered
   titles can be recorded without becoming primary identity.
 - Original Data Vault folder, session, title, numeric ID, and file path can be
@@ -37,7 +40,8 @@ experiment stack.
 
 ## Not In Scope
 
-- Built-in LabRAD Data Vault parser, compatibility server, or legacy browser.
+- Built-in LabRAD Data Vault parser, compatibility server, LabRAD-dependent
+  helper module, or legacy browser.
 - Requiring old data to migrate before new Fricon measurements can start.
 
 ## Related Capabilities

--- a/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
+++ b/docs/product/user-stories/US-017-migrate-data-vault-style-script.md
@@ -25,7 +25,7 @@ experiment stack.
   independent/dependent variable setup can be translated without rewriting the
   whole hardware runner.
 - Migration documentation covers non-obvious patterns, such as N-D scans,
-  VNA-like coarse/fine trace collections, and minimizer-style irregular logs,
+  VNA-like coarse/fine trace collections, and minimizer-style irregular records,
   rather than many near-duplicate 1D and 2D examples.
 - Labels, units, legends, source aliases, original paths, and old numbered
   titles can be recorded without becoming primary identity.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -6,23 +6,20 @@ High-confidence product input; derived scope pending revalidation.
 
 ## Thesis
 
-Fricon is a local lab data library and automation foundation for scientific
-measurement work.
+Fricon is a local lab data library for scientific measurement work.
 
-The near-term product replaces the fragile Data Vault/Grapher-centered loop
-for new interactive measurement work with a maintained local system for
-recording, monitoring, reopening, and exporting experiment data. The long-term
-product should become the lab's local experiment memory and reviewed action
-layer: a system of record for measurement intent, effective parameters, code
-provenance, setup state, analysis attempts, trust decisions, handoff, and
+The first product target is a maintained replacement for the fragile
+Data Vault/Grapher-centered loop around new interactive measurements. The
+long-term product should become the lab's local experiment memory and reviewed
+action layer: a system of record for measurement intent, effective parameters,
+code provenance, setup state, analysis attempts, trust decisions, handoff, and
 reviewed replay.
 
 ## Problem Statement
 
-For the initial adoption slice, Fricon replaces the fragile
-Data Vault/Grapher-centered measurement loop with a maintained local system for
-recording, monitoring, reopening, and exporting new interactive experiment
-data.
+For initial adoption, Fricon helps users record, monitor, reopen, and export
+new interactive experiment data without relying on unmaintained LabRAD
+Data Vault/Grapher behavior or notebook-only reconstruction.
 
 ## Planning Language
 
@@ -50,48 +47,23 @@ decision is recorded.
 Physical measurement work is hard to make reliable when data, parameters,
 measurement code, setup state, notes, and later analysis live in separate tools
 or informal files. Existing frameworks can help users collect data, but they
-often leave the broader experiment record to conventions that are difficult to
-inspect, compare, migrate, or automate. Fricon should replace not only the
-write-to-logger step, but also the informal folder discipline around copied
-measurement code, mutable local JSON configuration, setup sidecars, and later
-analysis handoff.
+often leave the broader experiment record to folder conventions, copied code,
+mutable JSON files, sidecars, notebooks, and operator memory.
 
-The adoption pain is not that notebook-based exploration is inherently wrong.
-Interactive scripts and notebooks can be the comfortable way to try an
-experiment. The failure appears when useful work has to survive beyond one
-person, one lab computer, one copied code folder, one Conda environment, or one
-uninterrupted storage session. Multiple machines may contain similar-looking
-measurement-code folders, waveform helpers, and analysis utilities whose real
-differences are hard to identify. Collaboration then depends on personal
-discipline instead of a maintained product model.
+Notebook-based exploration is not the problem. It is often the most comfortable
+way to try an experiment. The failure appears when useful work has to survive
+beyond one person, one lab computer, one copied code folder, one Conda
+environment, or one uninterrupted storage session.
 
-Fricon should give experimenters one local-first product model for defining,
-running, inspecting, explaining, and reusing measurement work. The long-term
-aim is not only to store results, but to make the relationship between a
-measurement, its datasets, its Python code, its context, and its later
-interpretation explicit enough for humans and future automation to trust.
+Fricon should give experimenters a local-first product model for recording,
+inspecting, explaining, and reusing measurement work. The long-term center is
+trustworthy experiment memory and reviewed reuse, not device control, sample
+visualization, or AI by itself.
 
-The highest-value later lesson from legacy workflows is the code-and-parameter
-management loop: copied code, mutable local configuration, generated sidecars,
-and notebook-local analysis make calibration hard to trust. Fricon should first
-make the recorded facts durable enough to explain, compare, hand off, repeat,
-and then safely automate work.
-
-The long-term center is not device control, sample visualization, or AI by
-itself. Those capabilities matter when they serve trustworthy experiment
-memory, reviewable changes, and safer reuse. Strategic follow-on ordering is a
-draft hypothesis in `product/future-concepts.md`; future terminology lives in
-`product/glossary.md`.
-
-The product should stay close to how experimentalists already work: Python
-scripts and notebooks remain first-class, local lab computers remain useful
-without a server account model, and higher-provenance workflows grow from the
-same core experience instead of becoming a separate system.
-
-Staying close to current practice does not mean freezing current practice as
-the ideal model. Later Fricon slices can introduce higher-provenance workflows,
-but only after the relevant facts, review boundaries, and safety model are
-explicit.
+The product should stay close to current practice: Python scripts and notebooks
+remain first-class, local lab computers remain useful without a server account
+model, and higher-provenance workflows grow from recorded facts and explicit
+review boundaries.
 
 ## Adoption Strategy
 
@@ -108,16 +80,17 @@ canonical product model should stay centered on measurements, dataset
 artifacts, lifecycle, scan schema, provenance, selected configuration context,
 exports, and later reviewed parameter and calibration workflows.
 
-Transition features should point toward the full Fricon workflow:
+Transition features should point toward later Fricon workflows:
 
 - legacy aliases become stable Fricon IDs
-- mutable configuration files become effective snapshots, profiles, and
-  reviewed proposals
-- copied folders become code provenance or configured measurement-code sources
-- unmanaged calibration scripts become calibration evidence and reviewed
-  parameter changes
-- notebooks, spreadsheets, and presentation decks become traceable analysis or
-  handoff artifacts rather than the system of record
+- selected mutable configuration files become run-bound context first, and may
+  later become effective snapshots, profiles, or reviewed proposals
+- copied folders become honest code provenance first, and may later become
+  configured measurement-code sources
+- unmanaged calibration scripts remain ordinary measurements first, and may
+  later become calibration evidence or reviewed parameter changes
+- notebooks, spreadsheets, and reports may become traceable analysis or
+  handoff artifacts later, but they are not first-slice reporting scope
 
 If a legacy need cannot fit one of these bridge forms, it should not become an
 initial adoption concept without explicit product and architecture review.
@@ -153,15 +126,15 @@ Fricon should help a researcher answer:
 - Can I analyze the exported result on another computer without recreating the
   acquisition runtime?
 
-Strategic follow-on slices should also help answer:
+Strategic follow-on slices can later help answer:
 
 - What changed since the previous good run?
 - Why did this run succeed, fail, or become questionable?
 - Which parameter, setup, code, analysis, or calibration facts explain the
   difference?
 - Which code source and parameter snapshot did this calibration depend on?
-- Did each calibration task look healthy, need retry, pause for review, or
-  produce fitted parameters that should update a parameter snapshot/profile?
+- Did calibration evidence look healthy, need retry, pause for review, or
+  justify a proposed parameter update?
 - For a managed routine, what setup or device state was desired, what was
   already current, what did Fricon plan to change, and what actually happened?
 - What did we conclude from this measurement?
@@ -191,11 +164,11 @@ The Python SDK is a primary user experience, not only an implementation API.
 Most experimentalists will define and run measurements through Python scripts
 or notebooks, so SDK ergonomics are product requirements.
 
-At the vision level, the SDK should feel like ordinary Python with low
+For initial adoption, the SDK should feel like ordinary Python with low
 ceremony: a visible notebook context, natural interactive unmanaged runs,
-importable managed-run entry points for higher provenance, Python-native
-scan-plan authoring for routine scans, and public reopen/export APIs for later
-analysis.
+Python-native scan/schema authoring, and public reopen/export APIs for later
+analysis. Importable managed-run entry points are strategic follow-on, not part
+of the first-slice migration promise.
 
 For the first adoption slice, migration from Data Vault-style scripts should
 mean a simple rewrite of the recording section, not emulation of LabRAD or its
@@ -228,9 +201,9 @@ copies or machine-local working trees. Fricon should not claim automatic
 notebook capture, approved code releases, deployment, immutable code snapshots,
 or managed execution.
 
-Strategic follow-on code management should grow toward configured measurement
+Strategic follow-on code management can grow toward configured measurement
 code sources, approved update flows, importable managed-run entry points, and
-code snapshots only after the product facts and review boundaries are clear.
+code snapshots after the product facts and review boundaries are clear.
 
 ## Initial Adoption Scope
 
@@ -245,13 +218,13 @@ To meet the initial adoption goal, the first adoption slice should include:
 - step or record datasets for irregular workflows such as minimizers, adaptive
   scans, and instrument-driven coarse/fine passes where each step may carry
   parameters and one or more scalar, array, or trace results
-- selectable collections of logs or traces so users can compare coarse/fine
+- selectable trace or output collections so users can compare coarse/fine
   passes or variable-length optimizer traces without hard-coding those
   experiment types into the product model
 - low-ceremony scan-plan/schema authoring for common scans and traces, plus a
   raw schema escape hatch for advanced cases
 - nonblocking live monitor views for current 1D line/scatter, 2D heatmap, and
-  selected output channels or logs
+  selected outputs or traces
 - richer historical browsing and selector views that do not need to be live
   auto-refresh surfaces
 - measurement lifecycle, notes, events, favorites/pins, trash/recover, and
@@ -316,8 +289,8 @@ work starts:
 
 ## Strategic Follow-On Direction
 
-At the vision level, strategic follow-on work should extend the facts recorded
-during initial adoption into three user loops:
+Strategic follow-on work should extend the facts recorded during initial
+adoption into three user loops:
 
 - Explain: run manifests, parameter/code/setup provenance, lifecycle evidence,
   analysis attempts, and failure or anomaly investigation.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -9,11 +9,20 @@ High-confidence product input; derived scope pending revalidation.
 Fricon is a local lab data library and automation foundation for scientific
 measurement work.
 
-The near-term product proves a better local measurement write, watch, recover,
-reopen, and export loop. The long-term product should become the lab's local
-experiment memory and reviewed action layer: a system of record for measurement
-intent, effective parameters, code provenance, setup state, analysis attempts,
-trust decisions, handoff, and reviewed replay.
+The near-term product replaces the fragile Data Vault/Grapher-centered loop
+for new interactive measurement work with a maintained local system for
+recording, monitoring, reopening, and exporting experiment data. The long-term
+product should become the lab's local experiment memory and reviewed action
+layer: a system of record for measurement intent, effective parameters, code
+provenance, setup state, analysis attempts, trust decisions, handoff, and
+reviewed replay.
+
+## Problem Statement
+
+For the initial adoption slice, Fricon replaces the fragile
+Data Vault/Grapher-centered measurement loop with a maintained local system for
+recording, monitoring, reopening, and exporting new interactive experiment
+data.
 
 ## Planning Language
 
@@ -46,6 +55,15 @@ inspect, compare, migrate, or automate. Fricon should replace not only the
 write-to-logger step, but also the informal folder discipline around copied
 measurement code, mutable local JSON configuration, setup sidecars, and later
 analysis handoff.
+
+The adoption pain is not that notebook-based exploration is inherently wrong.
+Interactive scripts and notebooks can be the comfortable way to try an
+experiment. The failure appears when useful work has to survive beyond one
+person, one lab computer, one copied code folder, one Conda environment, or one
+uninterrupted storage session. Multiple machines may contain similar-looking
+measurement-code folders, waveform helpers, and analysis utilities whose real
+differences are hard to identify. Collaboration then depends on personal
+discipline instead of a maintained product model.
 
 Fricon should give experimenters one local-first product model for defining,
 running, inspecting, explaining, and reusing measurement work. The long-term
@@ -107,14 +125,18 @@ initial adoption concept without explicit product and architecture review.
 ## Initial Adoption Goal
 
 The initial adoption goal is practical: replace the simple LabRAD Data
-Vault/Grapher loop for new measurements.
+Vault/Grapher loop for new interactive measurements and portable later
+analysis.
 
 Success means a user can start new measurement work in Fricon, write data from
-Python, watch it live, recover partial results, reopen it later, and export it
-without depending on old storage paths or notebook-only reconstruction. The
-initial adoption slice does not need to import old history or emulate LabRAD;
-old LabRAD, QCoDeS, Labber, or folder-based history can remain where it is
-while new work moves to Fricon.
+Python, watch live plots, run multiple independent experiments without
+unnecessary global-session interference, recover partial results, reopen data
+later, and export it to another computer for analysis without depending on old
+storage paths or notebook-only reconstruction. The initial adoption slice does
+not need to import old history, emulate LabRAD, or ship a LabRAD compatibility
+layer; old LabRAD, QCoDeS, Labber, or folder-based history can remain where it
+is while new work moves to Fricon through small explicit recording-code
+rewrites.
 
 ## User Promise
 
@@ -126,7 +148,10 @@ Fricon should help a researcher answer:
 - Was the run finished, interrupted, failed, invalidated, or recovered?
 - What notes, parameters, code provenance, and setup labels explain it?
 - Which selected local configuration files or summaries were bound to it?
+- Can I run another experiment without this one interfering with it?
 - How do I inspect it live, reopen it from Python, export it, or recover it?
+- Can I analyze the exported result on another computer without recreating the
+  acquisition runtime?
 
 Strategic follow-on slices should also help answer:
 
@@ -172,6 +197,12 @@ importable managed-run entry points for higher provenance, Python-native
 scan-plan authoring for routine scans, and public reopen/export APIs for later
 analysis.
 
+For the first adoption slice, migration from Data Vault-style scripts should
+mean a simple rewrite of the recording section, not emulation of LabRAD or its
+unit system. Users should be able to keep experiment logic, instrument calls,
+waveform generation, and analysis utilities outside Fricon while replacing the
+writer and live-inspection path.
+
 Common workflows should have appropriate simplifications, but exact helper
 shapes are not part of the product vision until real usage feedback supports
 them.
@@ -189,10 +220,13 @@ translated scripts, and copied lab working folders. Fricon should record honest
 context for these forms without pretending it owns their execution.
 
 The initial adoption code promise is provenance, not code management. Fricon
-may record an unmanaged label, optional script or notebook path, Git summary,
-dirty-state signal, copied-folder/source-root label, user summary, and export
-privacy choice. It should not claim automatic notebook capture, approved code
-releases, deployment, immutable code snapshots, or managed execution.
+may record an unmanaged label, optional script or notebook path, copied-folder
+or source-root label, user summary, selected local configuration snapshots, and
+export privacy choice. Git state can be recorded when it is meaningful, but it
+is not a first-slice success requirement because many lab folders are old
+copies or machine-local working trees. Fricon should not claim automatic
+notebook capture, approved code releases, deployment, immutable code snapshots,
+or managed execution.
 
 Strategic follow-on code management should grow toward configured measurement
 code sources, approved update flows, importable managed-run entry points, and
@@ -207,26 +241,38 @@ To meet the initial adoption goal, the first adoption slice should include:
 - optional sample and sample-session context
 - dataset artifacts that remain directly searchable and openable, even though
   the Desktop home is measurement-first
-- table-shaped scan and trace data with explicit scan schema for plotted data
-- scan modes for regular grids, partial grids, irregular or adaptive points,
-  repeated points, and fixed-shape or variable-length traces
-- low-ceremony scan-plan/schema authoring for common 1D/2D/N-D scans and
-  traces, plus a raw schema escape hatch for advanced cases
-- nonblocking live table and chart inspection
+- declared scan datasets for common 1D, 2D, and N-D sweeps
+- step or record datasets for irregular workflows such as minimizers, adaptive
+  scans, and instrument-driven coarse/fine passes where each step may carry
+  parameters and one or more scalar, array, or trace results
+- selectable collections of logs or traces so users can compare coarse/fine
+  passes or variable-length optimizer traces without hard-coding those
+  experiment types into the product model
+- low-ceremony scan-plan/schema authoring for common scans and traces, plus a
+  raw schema escape hatch for advanced cases
+- nonblocking live monitor views for current 1D line/scatter, 2D heatmap, and
+  selected output channels or logs
+- richer historical browsing and selector views that do not need to be live
+  auto-refresh surfaces
 - measurement lifecycle, notes, events, favorites/pins, trash/recover, and
   readable partial data semantics
 - light attachments
 - light contextual summaries for parameters, code provenance, setup,
   environment, and unmanaged procedure context
-- selected run-bound local configuration snapshots or summaries, such as
-  parameter files, registry files, wiring references, line/chip info, or
-  demod/readout settings, without turning initial adoption into a full
-  parameter registry
+- selected run-bound local configuration copies, snapshots, references, or
+  summaries, such as parameter files, registry files, wiring references,
+  line/chip info, or demod/readout settings, without turning initial adoption
+  into a full parameter registry
 - Python reopen snippets through public APIs
-- a near-term measurement export spec for portable bundles and common analysis
-  formats
+- a portable Fricon package readable by a lightweight Python reader without
+  running the acquisition-time local runtime or Desktop
+- analysis-friendly reads into common Python objects such as NumPy, pandas, or
+  Polars where appropriate
 - backup/restore and migration checkpoints
 - coherent install/update compatibility and guided setup diagnostics
+- migration documentation for non-obvious script shapes, including N-D sweeps,
+  VNA-like coarse/fine trace collections, minimizer-style irregular traces, and
+  a realistic Data Vault-style recording rewrite
 
 ## Product Pressure Checks
 
@@ -247,13 +293,23 @@ work starts:
 - Dataset artifact semantics should be checked against real measurement shapes,
   including adaptive or instrument-tuned traces where each trace may have its
   own coordinate values, settings, and length.
+- Required metadata should stay limited to facts needed for later
+  interpretation, slicing, and plotting. Labels, units, notes, sample/session
+  context, operator labels, and free-form JSON are valuable examples and
+  optional records, not reasons to block ordinary writes when absent.
 - Live inspection should support repeated lab monitoring behavior without
   becoming part of the write acknowledgement path. Users may need to watch
-  multiple measurements or views at once while acquisition keeps running.
+  multiple independent measurements or views at once while acquisition keeps
+  running. The Desktop should remain measurement-first; live monitors can be
+  opened from measurement, dataset, or session context rather than assuming one
+  global active experiment.
 - Measurement-code and run-configuration ideas should stay focused on the user
   pain of copied folders, mutable local files, setup sidecars, scan helpers,
   plot presets, and export recipes. Initial adoption records honest context;
   approved code update and managed execution remain strategic follow-on.
+- Fricon should not run user plotting code in the first slice. Users can reopen
+  data from Python and build custom plots themselves; built-in live plotting
+  should focus on common measurement monitor views.
 - Mutating actions should be attributable enough for local lab history, but the
   first adoption slice must not turn this into accounts, roles, permissions, or
   remote collaboration.
@@ -298,8 +354,11 @@ device apply remains ADR-gated.
 - distributed database semantics
 - direct shared-folder access to one editable data library
 - LabRAD Data Vault/Grapher compatibility server
+- built-in LabRAD-dependent helper module or unit-system adapter
 - built-in legacy Data Vault import or browser
 - requiring full old-history migration before adopting Fricon for new data
+- first-slice report or presentation generation
+- running user plotting code inside Fricon
 - broad device-driver framework
 - generic workflow DAG engine
 - visual sweep builder as the primary acquisition model


### PR DESCRIPTION
## Summary
- Refines the product vision around a maintained Data Vault/Grapher replacement for new interactive measurements.
- Tightens the first-adoption scope to prioritize P-001/P-003 workflows, simple script migration, portable reopen/export, and live monitor inspection.
- Aligns capability, story, persona, glossary, SDK, epic, and user-story docs so managed run, calibration automation, report generation, and LabRAD compatibility remain backlog pressure rather than first-slice scope.
- Updates agent context and analysis tracking so future AI sessions inherit the narrower, interview-backed framing.

## Testing
- Not run (docs-only change).