### PR TITLE
docs: tighten first-slice product framing

### DIFF
--- a/docs/product/capability-map.md
+++ b/docs/product/capability-map.md
@@ -74,7 +74,8 @@ CAP-004: Optional, visible, correctable sample/session context.
 - Promise: sample and sample-session context can explain a measurement when it
   matters, without blocking quick exploratory work.
 - Includes: optional active context, visible context on creation, and correction
-  after a run.
+  after a run. The first-slice role is mainly grouping and display, replacing
+  folder-path habits for sample, cooldown, mount, or campaign context.
 - Excludes: requiring a complete sample registry before recording data.
 
 CAP-005: Dataset artifact recording.
@@ -137,7 +138,9 @@ CAP-011: Measurement-centered export.
 - Includes: produced datasets, semantic metadata, selected provenance,
   integrity metadata, simple manifest or index preview, direct Python reading,
   privacy-aware provenance selection, and a lightweight Python reader that does
-  not require running the acquisition-time local runtime or Desktop.
+  not require running the acquisition-time local runtime or Desktop. Reader
+  APIs should load data into NumPy, pandas, Polars, or similar analysis
+  objects where the dataset shape supports it.
 - Excludes: importing old history, first-slice report generation, a fully
   polished offline Desktop viewer before the write/reopen loop is proven, and
   promising generic CSV, Parquet, or NumPy exports before real demand is
@@ -343,12 +346,14 @@ CAP-032: Routine recipes and reviewed replay.
 
 CAP-033: Run-bound local configuration snapshot.
 
-- Promise: a measurement can bind selected local configuration files,
-  references, hashes, or summaries so later analysis can identify the effective
-  lab-local state without reading copied folders by hand.
+- Promise: a measurement can bind selected local configuration files so later
+  analysis can identify the effective lab-local state without reading copied
+  folders by hand.
 - Includes: user-selected parameter files, registry files, wiring references,
   line/chip information, demod/readout settings, runner labels, source aliases,
-  privacy-aware export selection, and correction history.
-- Excludes: automatic tracing of every file read, global parameter profiles,
-  calibration promotion, device control, or claiming unmanaged execution was
-  fully reproducible.
+  privacy-aware export selection, correction history, original-file access,
+  simple text preview where practical, and a way to open files in an external
+  editor.
+- Excludes: automatic tracing of every file read, parsing or normalizing
+  arbitrary parameter files, global parameter profiles, calibration promotion,
+  device control, or claiming unmanaged execution was fully reproducible.

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -84,6 +84,10 @@ P-004 remains strategically important, but first adoption treats calibration
 notebooks as ordinary measurement work unless product evidence shows that a
 minimal calibration-specific record removes user code burden.
 
+Route-level planning should carry these first-slice boundaries. Individual
+persona definitions remain broader responsibility archetypes so they can guide
+later product analysis without repeating every first-slice non-goal.
+
 ## P-001 Measurement Run Operator
 
 The role active when a lab user runs a measurement script or notebook on a lab

--- a/docs/product/story-map.md
+++ b/docs/product/story-map.md
@@ -15,7 +15,7 @@ acceptance details.
 ```text
 Install and set up
   -> create/open data library
-  -> select optional sample/session context
+  -> optionally set sample/session context
   -> run Python measurement
   -> record dataset artifacts
   -> inspect live
@@ -125,7 +125,9 @@ adoption story index and live as draft backlog context in
 `product/future-concepts.md`.
 
 Export remains an initial adoption product promise. A portable Fricon package
-with a lightweight Python reader is the current baseline; CSV, Parquet, NumPy,
-or other generic export formats should be added when real user demand justifies
-them. Detailed export/offline-analysis requirements should be derived in a
-later spec after the product, architecture, and ADR boundaries are accepted.
+with a lightweight Python reader is the current baseline; reader APIs should
+load data into NumPy, pandas, Polars, or similar analysis objects where the
+dataset shape supports it. CSV, Parquet, or other generic file exports should
+be added when real user demand justifies them. Detailed export/offline-analysis
+requirements should be derived in a later spec after the product, architecture,
+and ADR boundaries are accepted.

--- a/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
+++ b/docs/product/user-stories/US-019-capture-run-bound-local-configuration.md
@@ -10,20 +10,24 @@ EPIC-005: Migration ergonomics and future lab scaling.
 
 ## Story
 
-As an Effective Configuration Steward, I want to bind selected local
-configuration files, references, hashes, or summaries to a measurement so that
-later analysis can explain which lab-local state was active without reading
-copied folders by hand.
+As a Measurement Run Operator, I want to bind selected local configuration
+files to a measurement so that later analysis can inspect the lab-local state
+without reading copied folders by hand.
 
 ## Success Criteria
 
-- A measurement can attach a run-bound configuration summary at creation time
-  or during the run.
-- The summary can reference or snapshot selected files such as
-  `parameters.json`, `registry.json`, wiring sheets, line/chip info, demod
-  settings, readout settings, or external runner configuration.
-- Fricon records enough source identity to distinguish a copied file reference,
-  a copied file snapshot, a content hash, and a user-entered summary.
+- A measurement can attach run-bound configuration files at creation time or
+  during the run.
+- Attached files can include `parameters.json`, `registry.json`, wiring sheets,
+  line/chip info, demod settings, readout settings, or external runner
+  configuration.
+- Fricon preserves and returns attached files in their original user-supplied
+  form.
+- Fricon records enough source identity to distinguish a copied file, a source
+  path reference, a content hash, and a user-entered summary.
+- Fricon can provide simple text preview or a way to open files in an external
+  editor where practical, without parsing the file into Fricon-owned parameter
+  semantics.
 - Corrections to configuration context are visible as events.
 - Export previews sensitive local paths, machine names, IP addresses, and other
   local setup details before including them.
@@ -31,6 +35,7 @@ copied folders by hand.
 ## Not In Scope
 
 - Automatic tracing of every file a script reads.
+- Parsing or normalizing arbitrary user parameter files.
 - Global parameter profiles, proposal workflows, or calibration promotion.
 - Device control, hardware inventory, or claiming unmanaged execution is fully
   reproducible.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -6,7 +6,7 @@ High-confidence product input; derived scope pending revalidation.
 
 ## Thesis
 
-Fricon is a local lab data library for scientific measurement work.
+Fricon is a local measurement data system for scientific experiment work.
 
 The first product target is a maintained replacement for the fragile
 Data Vault/Grapher-centered loop around new interactive measurements. The

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -143,11 +143,15 @@ Strategic follow-on slices can later help answer:
 ## Primary Mental Model
 
 ```text
-I selected an active sample/session when it mattered.
 I ran a measurement from Python.
 It produced datasets.
-Fricon helps me inspect, annotate, recover, reopen, and export them.
+Fricon helps me monitor, inspect, recover, reopen, and export them.
 ```
+
+Optional sample or session context can replace folder-path habits for grouping
+data by sample, cooldown, mount, or campaign. It should be settable once near
+the start of a notebook and useful in plots and browsing, but it is not the
+center of the first-slice workflow.
 
 Strategic follow-on slices should extend that model:
 
@@ -211,7 +215,7 @@ To meet the initial adoption goal, the first adoption slice should include:
 
 - one local data library per normal lab computer
 - explicit measurements
-- optional sample and sample-session context
+- optional sample and sample-session context for grouping and display
 - dataset artifacts that remain directly searchable and openable, even though
   the Desktop home is measurement-first
 - declared scan datasets for common 1D, 2D, and N-D sweeps
@@ -232,10 +236,12 @@ To meet the initial adoption goal, the first adoption slice should include:
 - light attachments
 - light contextual summaries for parameters, code provenance, setup,
   environment, and unmanaged procedure context
-- selected run-bound local configuration copies, snapshots, references, or
-  summaries, such as parameter files, registry files, wiring references,
-  line/chip info, or demod/readout settings, without turning initial adoption
-  into a full parameter registry
+- selected run-bound local configuration copies, such as parameter files,
+  registry files, wiring references, line/chip info, or demod/readout settings.
+  Fricon should preserve and return these files in their original user-supplied
+  form, with simple text preview or a way to open them in an external editor
+  where practical, without turning initial adoption into a parameter parser or
+  registry
 - Python reopen snippets through public APIs
 - a portable Fricon package readable by a lightweight Python reader without
   running the acquisition-time local runtime or Desktop
@@ -263,6 +269,9 @@ work starts:
   open a measurement bundle directly from Python, inspect a simple manifest or
   index preview, and choose whether sensitive paths, code, environment, setup,
   or sample details are included.
+- Generic export formats should be demand-driven. The first export promise is a
+  Fricon package plus reader APIs that load data into NumPy, pandas, Polars, or
+  similar analysis objects.
 - Dataset artifact semantics should be checked against real measurement shapes,
   including adaptive or instrument-tuned traces where each trace may have its
   own coordinate values, settings, and length.


### PR DESCRIPTION
## Summary
- Sharpen the initial-adoption framing around a maintained Data Vault/Grapher replacement for interactive measurements.
- Clarify that sample/session context is optional and mainly for grouping and display, not a core first-slice workflow.
- Reframe run-bound local configuration as raw user-supplied files with preview/open support, without parsing or normalizing them.
- Make export reader-first: Fricon package plus Python reader APIs that load into NumPy, pandas, or Polars; generic formats stay demand-driven.
- Keep personas broader, with first-slice boundaries stated at the route level instead of repeated throughout each role.